### PR TITLE
feat: add cascade delete for user task completions and update relatio…

### DIFF
--- a/pecha_api/plans/tasks/plan_tasks_models.py
+++ b/pecha_api/plans/tasks/plan_tasks_models.py
@@ -28,6 +28,7 @@ class PlanTask(Base):
 
     plan_item = relationship("PlanItem", backref="tasks")
     sub_tasks = relationship("PlanSubTask", back_populates="task", cascade="all, delete-orphan")
+    user_task_completions = relationship("UserTaskCompletion", back_populates="task", cascade="all, delete-orphan", passive_deletes=True)
 
     __table_args__ = (
         Index("idx_tasks_plan_item_order", "plan_item_id", "display_order"),

--- a/pecha_api/plans/users/plan_users_models.py
+++ b/pecha_api/plans/users/plan_users_models.py
@@ -48,7 +48,7 @@ class UserTaskCompletion(Base):
     created_at = Column(DateTime(timezone=True), default=datetime.now(_datetime.timezone.utc),nullable=False)
 
     user = relationship("Users", backref="completed_tasks")
-    task = relationship("PlanTask", backref="user_task_completions")
+    task = relationship("PlanTask", back_populates="user_task_completions")
 
     __table_args__ = (
         UniqueConstraint("user_id", "task_id", name="uq_user_task_completion"),


### PR DESCRIPTION
This is same issue as the one face before for deleting the subtask when a task is deleted. 
```ForeignKey('users.id', ondelete='CASCADE')``` does work on db level, The applied changes is needed for deletion on SQLAlchemy's ORM layer