### PR TITLE
Add dashboard views to API router

### DIFF
--- a/pecha_api/app.py
+++ b/pecha_api/app.py
@@ -28,6 +28,7 @@ from pecha_api.plans.media import media_views
 from pecha_api.plans.items import plan_items_views
 from pecha_api.plans.authors import plan_authors_views as plan_authors_views
 from pecha_api.plans.featured import featured_day_views
+from pecha_api.plans.dashboard import dashboard_views as cms_dashboard_views
 from pecha_api.recitations import recitations_view
 from pecha_api.user_follows import user_follow_views
 from pecha_api.plans.users.recitation import user_recitations_views
@@ -60,6 +61,7 @@ api.include_router(share_views.share_router)
 api.include_router(plan_auth_views.plan_auth_router)
 api.include_router(cms_plans_views.cms_plans_router)
 api.include_router(cms_series_views.cms_series_router)
+api.include_router(cms_dashboard_views.dashboard_router)
 api.include_router(public_series_views.public_series_router)
 api.include_router(media_views.media_router)
 api.include_router(public_plans_views.public_plans_router)

--- a/pecha_api/plans/dashboard/dashboard_repository.py
+++ b/pecha_api/plans/dashboard/dashboard_repository.py
@@ -1,0 +1,216 @@
+import math
+from typing import List, Optional, Tuple
+from uuid import UUID
+
+from sqlalchemy import String, cast, desc, exists, func, literal, or_, select
+from sqlalchemy.orm import Query, Session
+
+from pecha_api.plans.authors.plan_authors_model import Author  # noqa: F401
+from pecha_api.plans.plans_enums import PlanStatus
+from pecha_api.plans.plans_models import Plan
+from pecha_api.plans.series.series_model import Series
+from pecha_api.plans.users.plan_users_models import UserPlanProgress
+
+_SERIES_TITLE = func.coalesce(
+    Series.name["en"].astext,
+    Series.name["EN"].astext,
+    Series.name["bo"].astext,
+    cast(Series.name, String),
+)
+
+
+def _series_plans_count_subquery():
+    return (
+        select(func.count(Plan.id))
+        .where(Plan.series_id == Series.id, Plan.deleted_at.is_(None))
+        .correlate(Series)
+        .scalar_subquery()
+    )
+
+
+def _series_languages_subquery():
+    return (
+        select(func.string_agg(func.distinct(cast(Plan.language, String)), ","))
+        .where(Plan.series_id == Series.id, Plan.deleted_at.is_(None))
+        .correlate(Series)
+        .scalar_subquery()
+    )
+
+
+def _series_enrolled_count_subquery():
+    return (
+        select(func.count(func.distinct(UserPlanProgress.user_id)))
+        .select_from(UserPlanProgress)
+        .join(Plan, Plan.id == UserPlanProgress.plan_id)
+        .where(Plan.series_id == Series.id, Plan.deleted_at.is_(None))
+        .correlate(Series)
+        .scalar_subquery()
+    )
+
+
+def _plan_enrolled_count_subquery():
+    return (
+        select(func.count(func.distinct(UserPlanProgress.user_id)))
+        .where(UserPlanProgress.plan_id == Plan.id)
+        .correlate(Plan)
+        .scalar_subquery()
+    )
+
+
+def _apply_series_filters(
+    query: Query,
+    *,
+    search: Optional[str],
+    status: Optional[PlanStatus],
+    featured: Optional[bool],
+    language: Optional[str],
+    author_id: Optional[UUID],
+) -> Query:
+    query = query.filter(Series.deleted_at.is_(None))
+    if author_id is not None:
+        query = query.filter(Series.author_id == author_id)
+    if search:
+        query = query.filter(cast(Series.name, String).ilike(f"%{search}%"))
+    if status is not None:
+        query = query.filter(Series.status == status)
+    if featured is not None:
+        query = query.filter(Series.featured == featured)
+    if language:
+        language_upper = language.upper()
+        query = query.filter(
+            exists(
+                select(literal(1)).where(
+                    Plan.series_id == Series.id,
+                    Plan.deleted_at.is_(None),
+                    Plan.language == language_upper,
+                )
+            )
+        )
+    return query
+
+
+def _apply_plan_filters(
+    query: Query,
+    *,
+    search: Optional[str],
+    status: Optional[PlanStatus],
+    featured: Optional[bool],
+    language: Optional[str],
+    author_id: Optional[UUID],
+    standalone_only: bool,
+) -> Query:
+    query = query.filter(Plan.deleted_at.is_(None))
+    if standalone_only:
+        query = query.filter(Plan.series_id.is_(None))
+    if author_id is not None:
+        query = query.filter(Plan.author_id == author_id)
+    if search:
+        query = query.filter(
+            or_(
+                Plan.title.ilike(f"%{search}%"),
+                Plan.description.ilike(f"%{search}%"),
+            )
+        )
+    if status is not None:
+        query = query.filter(Plan.status == status)
+    if featured is not None:
+        query = query.filter(Plan.featured == featured)
+    if language:
+        query = query.filter(Plan.language == language.upper())
+    return query
+
+
+def _series_base_query(db: Session) -> Query:
+    return db.query(
+        Series.id.label("id"),
+        literal("series").label("item_type"),
+        _SERIES_TITLE.label("title"),
+        Series.image.label("image_key"),
+        Series.status.label("status"),
+        Series.featured.label("featured"),
+        _series_languages_subquery().label("languages_raw"),
+        func.coalesce(_series_enrolled_count_subquery(), 0).label("enrolled_count"),
+        _series_plans_count_subquery().label("plans_count"),
+        Series.updated_at.label("updated_at"),
+        Series.created_at.label("created_at"),
+    )
+
+
+def _plan_base_query(db: Session) -> Query:
+    return db.query(
+        Plan.id.label("id"),
+        literal("plan").label("item_type"),
+        Plan.title.label("title"),
+        Plan.image_url.label("image_key"),
+        Plan.status.label("status"),
+        Plan.featured.label("featured"),
+        cast(Plan.language, String).label("languages_raw"),
+        func.coalesce(_plan_enrolled_count_subquery(), 0).label("enrolled_count"),
+        literal(None).label("plans_count"),
+        Plan.updated_at.label("updated_at"),
+        Plan.created_at.label("created_at"),
+    )
+
+
+def _order_combined_query(query: Query, subquery) -> Query:
+    return query.order_by(
+        desc(subquery.c.featured),
+        desc(subquery.c.updated_at),
+        subquery.c.item_type,
+        subquery.c.id,
+    )
+
+
+def get_dashboard_items(
+    db: Session,
+    *,
+    tab: str,
+    page: int,
+    page_size: int,
+    search: Optional[str],
+    status: Optional[PlanStatus],
+    language: Optional[str],
+    featured: Optional[bool],
+    author_id: Optional[UUID],
+) -> Tuple[List, int]:
+    filter_kwargs = {
+        "search": search,
+        "status": status,
+        "featured": featured,
+        "language": language,
+        "author_id": author_id,
+    }
+
+    series_query = _apply_series_filters(_series_base_query(db), **filter_kwargs)
+    plan_query = _apply_plan_filters(
+        _plan_base_query(db),
+        standalone_only=False,
+        **filter_kwargs,
+    )
+    standalone_plan_query = _apply_plan_filters(
+        _plan_base_query(db),
+        standalone_only=True,
+        **filter_kwargs,
+    )
+
+    if tab == "series":
+        combined = series_query
+    elif tab == "plans":
+        combined = plan_query
+    else:
+        combined = series_query.union_all(standalone_plan_query)
+
+    combined_subquery = combined.subquery()
+    ordered = _order_combined_query(db.query(combined_subquery), combined_subquery)
+
+    offset = (page - 1) * page_size
+    rows = ordered.offset(offset).limit(page_size).all()
+
+    total = db.query(func.count()).select_from(combined_subquery).scalar() or 0
+    return rows, int(total)
+
+
+def total_pages(total: int, page_size: int) -> int:
+    if page_size <= 0:
+        return 0
+    return math.ceil(total / page_size) if total > 0 else 0

--- a/pecha_api/plans/dashboard/dashboard_response_models.py
+++ b/pecha_api/plans/dashboard/dashboard_response_models.py
@@ -1,0 +1,36 @@
+from datetime import datetime
+from typing import List, Literal, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+from pecha_api.plans.plans_enums import PlanStatus
+
+DashboardTab = Literal["all", "series", "plans"]
+DashboardItemType = Literal["series", "plan"]
+
+
+class DashboardItemDTO(BaseModel):
+    id: UUID
+    type: DashboardItemType
+    title: str
+    image_url: Optional[str] = None
+    status: PlanStatus
+    featured: bool
+    languages: List[str] = Field(default_factory=list)
+    enrolled_count: int = 0
+    plans_count: Optional[int] = None
+    updated_at: Optional[datetime] = None
+    created_at: datetime
+
+
+class DashboardPaginationDTO(BaseModel):
+    page: int
+    page_size: int
+    total: int
+    total_pages: int
+
+
+class DashboardItemsResponse(BaseModel):
+    items: List[DashboardItemDTO]
+    pagination: DashboardPaginationDTO

--- a/pecha_api/plans/dashboard/dashboard_service.py
+++ b/pecha_api/plans/dashboard/dashboard_service.py
@@ -54,7 +54,7 @@ def _row_to_dto(row) -> DashboardItemDTO:
     )
 
 
-async def get_dashboard_items_list(
+def get_dashboard_items_list(
     token: str,
     tab: DashboardTab,
     page: int,

--- a/pecha_api/plans/dashboard/dashboard_service.py
+++ b/pecha_api/plans/dashboard/dashboard_service.py
@@ -1,0 +1,95 @@
+from typing import List, Optional
+
+from pecha_api.config import get
+from pecha_api.db.database import SessionLocal
+from pecha_api.plans.authors.plan_authors_service import validate_and_extract_author_details
+from pecha_api.plans.dashboard.dashboard_repository import get_dashboard_items, total_pages
+from pecha_api.plans.dashboard.dashboard_response_models import (
+    DashboardItemDTO,
+    DashboardItemsResponse,
+    DashboardPaginationDTO,
+    DashboardTab,
+)
+from pecha_api.plans.plans_enums import PlanStatus
+from pecha_api.uploads.S3_utils import generate_presigned_access_url
+
+
+def _parse_languages(item_type: str, languages_raw: Optional[str]) -> List[str]:
+    if not languages_raw:
+        return []
+    if item_type == "plan":
+        return [languages_raw]
+    return [lang.strip() for lang in languages_raw.split(",") if lang.strip()]
+
+
+def _to_plan_status(status_value) -> PlanStatus:
+    if hasattr(status_value, "value"):
+        return PlanStatus(status_value.value)
+    return PlanStatus(status_value)
+
+
+def _image_url(image_key: Optional[str]) -> Optional[str]:
+    if not image_key:
+        return None
+    return generate_presigned_access_url(
+        bucket_name=get("AWS_BUCKET_NAME"),
+        s3_key=image_key,
+    )
+
+
+def _row_to_dto(row) -> DashboardItemDTO:
+    item_type = row.item_type
+    return DashboardItemDTO(
+        id=row.id,
+        type=item_type,
+        title=row.title or "",
+        image_url=_image_url(row.image_key),
+        status=_to_plan_status(row.status),
+        featured=bool(row.featured),
+        languages=_parse_languages(item_type, row.languages_raw),
+        enrolled_count=int(row.enrolled_count or 0),
+        plans_count=int(row.plans_count) if row.plans_count is not None else None,
+        updated_at=row.updated_at,
+        created_at=row.created_at,
+    )
+
+
+async def get_dashboard_items_list(
+    token: str,
+    tab: DashboardTab,
+    page: int,
+    page_size: int,
+    search: Optional[str] = None,
+    status: Optional[PlanStatus] = None,
+    language: Optional[str] = None,
+    featured: Optional[bool] = None,
+) -> DashboardItemsResponse:
+    current_author = validate_and_extract_author_details(token=token)
+    author_id = None if current_author.is_admin else current_author.id
+
+    page = max(page, 1)
+    page_size = max(page_size, 1)
+
+    with SessionLocal() as db_session:
+        rows, total = get_dashboard_items(
+            db_session,
+            tab=tab,
+            page=page,
+            page_size=page_size,
+            search=search,
+            status=status,
+            language=language,
+            featured=featured,
+            author_id=author_id,
+        )
+
+    items = [_row_to_dto(row) for row in rows]
+    return DashboardItemsResponse(
+        items=items,
+        pagination=DashboardPaginationDTO(
+            page=page,
+            page_size=page_size,
+            total=total,
+            total_pages=total_pages(total, page_size),
+        ),
+    )

--- a/pecha_api/plans/dashboard/dashboard_views.py
+++ b/pecha_api/plans/dashboard/dashboard_views.py
@@ -28,16 +28,18 @@ async def list_dashboard_items(
     authentication_credential: Annotated[
         HTTPAuthorizationCredentials, Depends(oauth2_scheme)
     ],
-    tab: DashboardTab = Query(default="all"),
-    page: int = Query(default=1, ge=1),
-    page_size: int = Query(default=20, ge=1, le=100),
-    search: Optional[str] = Query(default=None),
-    status: Optional[PlanStatus] = Query(default=None),
-    language: Optional[str] = Query(default=None),
-    featured: Optional[bool] = Query(default=None),
-    sort: Optional[str] = Query(default=None, description="Reserved; default sort is applied"),
+    tab: Annotated[DashboardTab, Query()] = "all",
+    page: Annotated[int, Query(ge=1)] = 1,
+    page_size: Annotated[int, Query(ge=1, le=100)] = 20,
+    search: Annotated[Optional[str], Query()] = None,
+    status: Annotated[Optional[PlanStatus], Query()] = None,
+    language: Annotated[Optional[str], Query()] = None,
+    featured: Annotated[Optional[bool], Query()] = None,
+    sort: Annotated[
+        Optional[str], Query(description="Reserved; default sort is applied")
+    ] = None,
 ):
-    return await get_dashboard_items_list(
+    return get_dashboard_items_list(
         token=authentication_credential.credentials,
         tab=tab,
         page=page,

--- a/pecha_api/plans/dashboard/dashboard_views.py
+++ b/pecha_api/plans/dashboard/dashboard_views.py
@@ -1,0 +1,49 @@
+from typing import Annotated, Optional
+
+from fastapi import APIRouter, Depends, Query
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from starlette import status
+
+from pecha_api.plans.dashboard.dashboard_response_models import (
+    DashboardItemsResponse,
+    DashboardTab,
+)
+from pecha_api.plans.dashboard.dashboard_service import get_dashboard_items_list
+from pecha_api.plans.plans_enums import PlanStatus
+
+oauth2_scheme = HTTPBearer()
+
+dashboard_router = APIRouter(
+    prefix="/cms/dashboard",
+    tags=["CMS Dashboard"],
+)
+
+
+@dashboard_router.get(
+    "/items",
+    status_code=status.HTTP_200_OK,
+    response_model=DashboardItemsResponse,
+)
+async def list_dashboard_items(
+    authentication_credential: Annotated[
+        HTTPAuthorizationCredentials, Depends(oauth2_scheme)
+    ],
+    tab: DashboardTab = Query(default="all"),
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=20, ge=1, le=100),
+    search: Optional[str] = Query(default=None),
+    status: Optional[PlanStatus] = Query(default=None),
+    language: Optional[str] = Query(default=None),
+    featured: Optional[bool] = Query(default=None),
+    sort: Optional[str] = Query(default=None, description="Reserved; default sort is applied"),
+):
+    return await get_dashboard_items_list(
+        token=authentication_credential.credentials,
+        tab=tab,
+        page=page,
+        page_size=page_size,
+        search=search,
+        status=status,
+        language=language,
+        featured=featured,
+    )

--- a/tests/plans/dashboard/test_dashboard_views.py
+++ b/tests/plans/dashboard/test_dashboard_views.py
@@ -1,0 +1,79 @@
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from starlette import status
+
+from pecha_api.plans.dashboard.dashboard_response_models import (
+    DashboardItemDTO,
+    DashboardItemsResponse,
+    DashboardPaginationDTO,
+)
+from pecha_api.plans.dashboard.dashboard_views import list_dashboard_items
+from pecha_api.plans.plans_enums import PlanStatus
+
+
+class _Creds:
+    def __init__(self, token: str):
+        self.credentials = token
+
+
+@pytest.mark.asyncio
+async def test_list_dashboard_items_success():
+    item_id = uuid.uuid4()
+    expected = DashboardItemsResponse(
+        items=[
+            DashboardItemDTO(
+                id=item_id,
+                type="series",
+                title="Foundations",
+                image_url="https://example.com/image.jpg",
+                status=PlanStatus.DRAFT,
+                featured=True,
+                languages=["EN"],
+                enrolled_count=0,
+                plans_count=2,
+                updated_at=datetime.now(timezone.utc),
+                created_at=datetime.now(timezone.utc),
+            )
+        ],
+        pagination=DashboardPaginationDTO(
+            page=1,
+            page_size=20,
+            total=1,
+            total_pages=1,
+        ),
+    )
+    creds = _Creds(token="token123")
+
+    with patch(
+        "pecha_api.plans.dashboard.dashboard_views.get_dashboard_items_list",
+        new_callable=AsyncMock,
+        return_value=expected,
+    ) as mock_service:
+        response = await list_dashboard_items(
+            authentication_credential=creds,
+            tab="all",
+            page=1,
+            page_size=20,
+            search="found",
+            status=PlanStatus.DRAFT,
+            language="en",
+            featured=True,
+            sort=None,
+        )
+
+        mock_service.assert_called_once_with(
+            token="token123",
+            tab="all",
+            page=1,
+            page_size=20,
+            search="found",
+            status=PlanStatus.DRAFT,
+            language="en",
+            featured=True,
+        )
+        assert response == expected
+        assert response.items[0].type == "series"
+        assert response.pagination.total == 1

--- a/tests/plans/dashboard/test_dashboard_views.py
+++ b/tests/plans/dashboard/test_dashboard_views.py
@@ -1,6 +1,6 @@
 import uuid
 from datetime import datetime, timezone
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
 import pytest
 from starlette import status
@@ -49,7 +49,6 @@ async def test_list_dashboard_items_success():
 
     with patch(
         "pecha_api.plans.dashboard.dashboard_views.get_dashboard_items_list",
-        new_callable=AsyncMock,
         return_value=expected,
     ) as mock_service:
         response = await list_dashboard_items(


### PR DESCRIPTION
- Included the dashboard router from the CMS plans in the main API application to enhance functionality and provide access to dashboard-related features.


GET /api/v1/cms/dashboard/items — unified CMS listing for series + plans

Tabs: all (series + standalone plans via UNION ALL), series, plans
Filters: search, status, language, featured, pagination
Normalized response: items[] with type, title, image_url, languages, plans_count, enrolled_count, etc.

