### PR TITLE
Refactor series plan management to support display order

### DIFF
--- a/pecha_api/plans/series/series_repository.py
+++ b/pecha_api/plans/series/series_repository.py
@@ -47,16 +47,20 @@ def save_series_with_plans(
     db: Session,
     series: Series,
     metadata_entries: List,
-    plan_ids: Optional[List[UUID]] = None,
+    plans_to_attach: Optional[List[Tuple[UUID, int]]] = None,
 ) -> Series:
     db.add(series)
     db.flush()
     _persist_metadata_entries(db, series.id, metadata_entries)
-    if plan_ids:
-        db.query(Plan).filter(Plan.id.in_(plan_ids)).update(
-            {Plan.series_id: series.id},
-            synchronize_session=False,
-        )
+    if plans_to_attach:
+        for plan_id, display_order in plans_to_attach:
+            db.query(Plan).filter(Plan.id == plan_id).update(
+                {
+                    Plan.series_id: series.id,
+                    Plan.display_order: display_order,
+                },
+                synchronize_session=False,
+            )
     db.commit()
     db.refresh(series)
     return series
@@ -79,7 +83,7 @@ def update_series_with_plans(
     image: Optional[str],
     featured: bool,
     updated_by: Optional[str],
-    plan_ids_to_attach: List[UUID],
+    plans_to_attach: List[Tuple[UUID, int]],
     plan_ids_to_detach: List[UUID],
     updated_at,
     metadata_entries: Optional[List] = None,
@@ -94,14 +98,21 @@ def update_series_with_plans(
 
     if plan_ids_to_detach:
         db.query(Plan).filter(Plan.id.in_(plan_ids_to_detach)).update(
-            {Plan.series_id: None},
+            {
+                Plan.series_id: None,
+                Plan.display_order: None,
+            },
             synchronize_session=False,
         )
-    if plan_ids_to_attach:
-        db.query(Plan).filter(Plan.id.in_(plan_ids_to_attach)).update(
-            {Plan.series_id: series.id},
-            synchronize_session=False,
-        )
+    if plans_to_attach:
+        for plan_id, display_order in plans_to_attach:
+            db.query(Plan).filter(Plan.id == plan_id).update(
+                {
+                    Plan.series_id: series.id,
+                    Plan.display_order: display_order,
+                },
+                synchronize_session=False,
+            )
 
     db.commit()
     db.refresh(series)

--- a/pecha_api/plans/series/series_service.py
+++ b/pecha_api/plans/series/series_service.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 from uuid import UUID
 
 from fastapi import HTTPException
@@ -67,17 +67,22 @@ def _metadata_to_dtos(entries) -> List[SeriesMetadataDTO]:
     )
 
 
-def _flatten_plans_by_language(plans_by_language: Optional[Dict[str, List[UUID]]]) -> List[UUID]:
+def _build_plan_order_pairs(
+    plans_by_language: Optional[Dict[str, List[UUID]]],
+) -> List[Tuple[UUID, int]]:
     if not plans_by_language:
         return []
     seen: set = set()
-    flat: List[UUID] = []
+    pairs: List[Tuple[UUID, int]] = []
     for ids in plans_by_language.values():
+        order = 0
         for pid in ids or []:
-            if pid not in seen:
-                seen.add(pid)
-                flat.append(pid)
-    return flat
+            if pid in seen:
+                continue
+            seen.add(pid)
+            pairs.append((pid, order))
+            order += 1
+    return pairs
 
 
 def _plan_to_dto(plan) -> SeriesPlanDTO:
@@ -286,7 +291,8 @@ def update_existing_series(
                 )
 
             if update_series_request.plans is not None:
-                new_plan_ids = _flatten_plans_by_language(update_series_request.plans)
+                plan_order_pairs = _build_plan_order_pairs(update_series_request.plans)
+                new_plan_ids = [pid for pid, _ in plan_order_pairs]
                 current_attached = {p.id for p in (series.plans or []) if p.deleted_at is None}
 
                 if new_plan_ids:
@@ -300,10 +306,12 @@ def update_existing_series(
 
                 new_set = set(new_plan_ids)
                 to_detach = list(current_attached - new_set)
-                to_attach = list(new_set - current_attached)
+                # Every plan in the request gets its display_order (re)written,
+                # including ones already attached, since order may have changed.
+                plans_to_attach = plan_order_pairs
             else:
                 to_detach = []
-                to_attach = []
+                plans_to_attach = []
 
             _apply_series_field_updates(series, update_series_request)
 
@@ -313,7 +321,7 @@ def update_existing_series(
                 image=series.image,
                 featured=series.featured,
                 updated_by=current_author.email,
-                plan_ids_to_attach=to_attach,
+                plans_to_attach=plans_to_attach,
                 plan_ids_to_detach=to_detach,
                 updated_at=datetime.now(timezone.utc),
                 metadata_entries=update_series_request.metadata,
@@ -339,14 +347,15 @@ def create_new_series(token: str, create_series_request: CreateSeriesRequest) ->
         status=PlanStatus.DRAFT,
     )
 
-    flat_plan_ids = _flatten_plans_by_language(create_series_request.plans)
+    plan_order_pairs = _build_plan_order_pairs(create_series_request.plans)
+    plan_ids = [pid for pid, _ in plan_order_pairs]
 
     try:
         with SessionLocal() as db_session:
-            if flat_plan_ids:
+            if plan_ids:
                 _validate_plan_ids(
                     db=db_session,
-                    plan_ids=flat_plan_ids,
+                    plan_ids=plan_ids,
                     current_author_id=current_author.id,
                     is_admin=bool(current_author.is_admin),
                 )
@@ -355,12 +364,12 @@ def create_new_series(token: str, create_series_request: CreateSeriesRequest) ->
                 db=db_session,
                 series=new_series,
                 metadata_entries=create_series_request.metadata,
-                plan_ids=flat_plan_ids,
+                plans_to_attach=plan_order_pairs,
             )
 
             saved = get_series_by_id(db=db_session, series_id=saved.id)
 
-        return _series_to_dto(saved, include_plans=bool(flat_plan_ids))
+        return _series_to_dto(saved, include_plans=bool(plan_ids))
     except IntegrityError as exc:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/tests/plans/series/test_series_repository.py
+++ b/tests/plans/series/test_series_repository.py
@@ -6,7 +6,13 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from pecha_api.plans.series.series_model import Series
-from pecha_api.plans.series.series_repository import get_series_by_id, get_series_paginated, save_series_with_plans
+from pecha_api.plans.plans_models import Plan
+from pecha_api.plans.series.series_repository import (
+    get_series_by_id,
+    get_series_paginated,
+    save_series_with_plans,
+    update_series_with_plans,
+)
 
 
 def _make_session_mock() -> Session:
@@ -29,7 +35,7 @@ def test_save_series_success_commits_and_returns_series():
     db = _make_session_mock()
     series = MagicMock(name="SeriesInstance")
 
-    result = save_series_with_plans(db=db, series=series, metadata_entries=[], plan_ids=None)
+    result = save_series_with_plans(db=db, series=series, metadata_entries=[], plans_to_attach=None)
 
     assert result is series
     db.add.assert_called_once_with(series)
@@ -44,7 +50,7 @@ def test_save_series_integrity_error_propagates():
     db.commit.side_effect = IntegrityError("statement", {}, orig)
 
     with pytest.raises(IntegrityError):
-        save_series_with_plans(db=db, series=series, metadata_entries=[], plan_ids=None)
+        save_series_with_plans(db=db, series=series, metadata_entries=[], plans_to_attach=None)
 
 
 def test_get_series_paginated_no_search_returns_rows_and_total():
@@ -165,3 +171,149 @@ def test_get_series_by_id_returns_none_when_missing():
     result = get_series_by_id(db=db, series_id=series_id)
 
     assert result is None
+
+
+# ---------------------------------------------------------------------------
+# display_order persistence: save_series_with_plans (POST path)
+# ---------------------------------------------------------------------------
+
+def _capture_plan_updates(db):
+    """Collect the dict passed to every Plan .update() call on the mock session.
+
+    Each .update() is reached via db.query(Plan).filter(...).update({...}).
+    Returns the list of update-value dicts in call order.
+    """
+    return [
+        call.args[0]
+        for call in db.query.return_value.filter.return_value.update.call_args_list
+    ]
+
+
+def test_save_series_with_plans_writes_series_id_and_display_order_per_plan():
+    db = _make_session_mock()
+    series = MagicMock(name="SeriesInstance")
+    series.id = uuid.uuid4()
+
+    plan_a = uuid.uuid4()
+    plan_b = uuid.uuid4()
+    plan_c = uuid.uuid4()
+    plans_to_attach = [(plan_a, 0), (plan_b, 1), (plan_c, 2)]
+
+    save_series_with_plans(
+        db=db,
+        series=series,
+        metadata_entries=[],
+        plans_to_attach=plans_to_attach,
+    )
+
+    updates = _capture_plan_updates(db)
+    # One update issued per plan.
+    assert len(updates) == 3
+    # Every update sets both series_id and display_order.
+    display_orders = [u[Plan.display_order] for u in updates]
+    assert display_orders == [0, 1, 2]
+    for u in updates:
+        assert u[Plan.series_id] == series.id
+    db.commit.assert_called_once()
+
+
+def test_save_series_with_plans_no_plans_issues_no_plan_updates():
+    db = _make_session_mock()
+    series = MagicMock(name="SeriesInstance")
+    series.id = uuid.uuid4()
+
+    save_series_with_plans(
+        db=db,
+        series=series,
+        metadata_entries=[],
+        plans_to_attach=None,
+    )
+
+    assert _capture_plan_updates(db) == []
+    db.commit.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# display_order persistence: update_series_with_plans (PUT path)
+# ---------------------------------------------------------------------------
+
+def test_update_series_with_plans_attaches_with_display_order():
+    db = _make_session_mock()
+    series = MagicMock(name="SeriesInstance")
+    series.id = uuid.uuid4()
+
+    plan_a = uuid.uuid4()
+    plan_b = uuid.uuid4()
+    plans_to_attach = [(plan_a, 0), (plan_b, 1)]
+
+    update_series_with_plans(
+        db=db,
+        series=series,
+        image=None,
+        featured=False,
+        updated_by="tester@example.com",
+        plans_to_attach=plans_to_attach,
+        plan_ids_to_detach=[],
+        updated_at=None,
+    )
+
+    updates = _capture_plan_updates(db)
+    assert len(updates) == 2
+    assert [u[Plan.display_order] for u in updates] == [0, 1]
+    for u in updates:
+        assert u[Plan.series_id] == series.id
+    db.commit.assert_called_once()
+
+
+def test_update_series_with_plans_detach_resets_series_id_and_display_order():
+    db = _make_session_mock()
+    series = MagicMock(name="SeriesInstance")
+    series.id = uuid.uuid4()
+
+    detach_a = uuid.uuid4()
+    detach_b = uuid.uuid4()
+
+    update_series_with_plans(
+        db=db,
+        series=series,
+        image=None,
+        featured=False,
+        updated_by="tester@example.com",
+        plans_to_attach=[],
+        plan_ids_to_detach=[detach_a, detach_b],
+        updated_at=None,
+    )
+
+    updates = _capture_plan_updates(db)
+    assert len(updates) == 1
+    detach_values = updates[0]
+    assert detach_values[Plan.series_id] is None
+    assert detach_values[Plan.display_order] is None
+    db.commit.assert_called_once()
+
+
+def test_update_series_with_plans_attach_and_detach_together():
+    db = _make_session_mock()
+    series = MagicMock(name="SeriesInstance")
+    series.id = uuid.uuid4()
+
+    keep_a = uuid.uuid4()
+    new_b = uuid.uuid4()
+    detach_c = uuid.uuid4()
+
+    update_series_with_plans(
+        db=db,
+        series=series,
+        image=None,
+        featured=False,
+        updated_by="tester@example.com",
+        plans_to_attach=[(keep_a, 0), (new_b, 1)],
+        plan_ids_to_detach=[detach_c],
+        updated_at=None,
+    )
+
+    updates = _capture_plan_updates(db)
+    assert len(updates) == 3
+    detach_updates = [u for u in updates if u.get(Plan.series_id) is None]
+    assert len(detach_updates) == 1
+    assert detach_updates[0][Plan.display_order] is None

--- a/tests/plans/series/test_series_service.py
+++ b/tests/plans/series/test_series_service.py
@@ -11,6 +11,7 @@ from pecha_api.plans.plans_enums import DifficultyLevel, LanguageCode, PlanStatu
 from pecha_api.plans.series.series_model import Series
 from pecha_api.plans.series.series_service import (
     _validate_plan_ids,
+    _build_plan_order_pairs,
     create_new_series,
     get_filtered_series,
     get_series_detail,
@@ -588,7 +589,7 @@ def test_update_existing_series_plans_omitted_leaves_attachments_untouched():
 
     mock_validate.assert_not_called()
     call_kwargs = mock_update.call_args.kwargs
-    assert call_kwargs["plan_ids_to_attach"] == []
+    assert call_kwargs["plans_to_attach"] == []
     assert call_kwargs["plan_ids_to_detach"] == []
 
 
@@ -621,7 +622,7 @@ def test_update_existing_series_plans_empty_dict_detaches_all():
         update_existing_series(token="dummy", series_id=series_id, update_series_request=request)
 
     call_kwargs = mock_update.call_args.kwargs
-    assert call_kwargs["plan_ids_to_attach"] == []
+    assert call_kwargs["plans_to_attach"] == []
     assert set(call_kwargs["plan_ids_to_detach"]) == {plan_a_id, plan_b_id}
 
 
@@ -668,7 +669,8 @@ def test_update_existing_series_full_replacement_with_diff():
         update_existing_series(token="dummy", series_id=series_id, update_series_request=request)
 
     call_kwargs = mock_update.call_args.kwargs
-    assert set(call_kwargs["plan_ids_to_attach"]) == {plan_c_id}
+    plans_to_attach = call_kwargs["plans_to_attach"]
+    assert plans_to_attach == [(plan_a_id, 0), (plan_c_id, 1)]
     assert set(call_kwargs["plan_ids_to_detach"]) == {plan_b_id}
 
 
@@ -1098,7 +1100,7 @@ def test_create_new_series_with_plans_attaches_and_returns_dto():
         dto = create_new_series(token="dummy", create_series_request=request)
 
     mock_save.assert_called_once()
-    assert mock_save.call_args.kwargs["plan_ids"] == [plan_id]
+    assert mock_save.call_args.kwargs["plans_to_attach"] == [(plan_id, 0)]
     assert dto.id == series_id
 
 
@@ -1492,3 +1494,166 @@ def test_validate_plan_ids_noop_when_empty():
             is_admin=False,
         )
     mock_get_plans.assert_not_called()
+
+# ---------------------------------------------------------------------------
+# _build_plan_order_pairs: per-language display_order computation
+# ---------------------------------------------------------------------------
+
+def test_build_plan_order_pairs_none_returns_empty():
+    assert _build_plan_order_pairs(None) == []
+
+
+def test_build_plan_order_pairs_empty_dict_returns_empty():
+    assert _build_plan_order_pairs({}) == []
+
+
+def test_build_plan_order_pairs_single_language_indexes_from_zero():
+    a, b, c = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+
+    pairs = _build_plan_order_pairs({"EN": [a, b, c]})
+
+    assert pairs == [(a, 0), (b, 1), (c, 2)]
+
+
+def test_build_plan_order_pairs_each_language_numbered_independently():
+    a, b, x, y = uuid.uuid4(), uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+
+    pairs = _build_plan_order_pairs({"EN": [a, b], "BO": [x, y]})
+
+    assert pairs == [(a, 0), (b, 1), (x, 0), (y, 1)]
+
+
+def test_build_plan_order_pairs_preserves_request_order_not_sorted():
+    c, a, b = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+
+    pairs = _build_plan_order_pairs({"EN": [c, a, b]})
+
+    assert pairs == [(c, 0), (a, 1), (b, 2)]
+
+
+def test_build_plan_order_pairs_dedupes_keeping_first_occurrence():
+    a, b = uuid.uuid4(), uuid.uuid4()
+
+    pairs = _build_plan_order_pairs({"EN": [a, a, b]})
+
+    assert pairs == [(a, 0), (b, 1)]
+
+
+def test_build_plan_order_pairs_handles_more_than_ten_plans():
+    ids = [uuid.uuid4() for _ in range(15)]
+
+    pairs = _build_plan_order_pairs({"EN": ids})
+
+    # display_order is a plain counter; it scales past single digits.
+    assert pairs == [(pid, idx) for idx, pid in enumerate(ids)]
+    assert pairs[-1][1] == 14
+
+
+def test_build_plan_order_pairs_skips_empty_language_list():
+    a = uuid.uuid4()
+
+    pairs = _build_plan_order_pairs({"EN": [a], "BO": []})
+
+    assert pairs == [(a, 0)]
+
+
+# ---------------------------------------------------------------------------
+# PUT: pure reorder of already-attached plans (no add/remove)
+# ---------------------------------------------------------------------------
+
+def test_update_existing_series_pure_reorder_sends_all_plans_with_new_order():
+    """Reordering already-attached plans (no additions, no removals) must still
+    send every plan to the repository so their display_order is rewritten."""
+    series_id = uuid.uuid4()
+    author_id = uuid.uuid4()
+
+    plan_a_id = uuid.uuid4()
+    plan_b_id = uuid.uuid4()
+    plan_c_id = uuid.uuid4()
+
+    existing_a = MagicMock()
+    existing_a.id = plan_a_id
+    existing_a.deleted_at = None
+    existing_b = MagicMock()
+    existing_b.id = plan_b_id
+    existing_b.deleted_at = None
+    existing_c = MagicMock()
+    existing_c.id = plan_c_id
+    existing_c.deleted_at = None
+
+    existing = _make_existing_series(
+        series_id, author_id, plans=[existing_a, existing_b, existing_c]
+    )
+    refreshed = _make_refreshed_series(series_id, author_id)
+    mock_author = _make_mock_author(author_id)
+
+    fetched_a = MagicMock()
+    fetched_a.id = plan_a_id
+    fetched_a.deleted_at = None
+    fetched_a.series_id = series_id
+    fetched_a.author_id = author_id
+    fetched_b = MagicMock()
+    fetched_b.id = plan_b_id
+    fetched_b.deleted_at = None
+    fetched_b.series_id = series_id
+    fetched_b.author_id = author_id
+    fetched_c = MagicMock()
+    fetched_c.id = plan_c_id
+    fetched_c.deleted_at = None
+    fetched_c.series_id = series_id
+    fetched_c.author_id = author_id
+
+    # Same three plans, reordered to C, A, B.
+    request = UpdateSeriesRequest(plans={"EN": [plan_c_id, plan_a_id, plan_b_id]})
+
+    with patch("pecha_api.plans.series.series_service.SessionLocal") as mock_session_local, \
+         patch("pecha_api.plans.series.series_service.validate_and_extract_author_details", return_value=mock_author), \
+         patch("pecha_api.plans.series.series_service.get_series_by_id", side_effect=[existing, refreshed]), \
+         patch("pecha_api.plans.series.series_service.get_plans_by_ids", return_value=[fetched_a, fetched_b, fetched_c]), \
+         patch("pecha_api.plans.series.series_service.update_series_with_plans") as mock_update:
+        _session_local_context(mock_session_local)
+        update_existing_series(token="dummy", series_id=series_id, update_series_request=request)
+
+    call_kwargs = mock_update.call_args.kwargs
+    assert call_kwargs["plans_to_attach"] == [
+        (plan_c_id, 0),
+        (plan_a_id, 1),
+        (plan_b_id, 2),
+    ]
+    assert call_kwargs["plan_ids_to_detach"] == []
+
+
+def test_update_existing_series_multi_language_independent_ordering():
+    """Each language list is numbered independently from zero."""
+    series_id = uuid.uuid4()
+    author_id = uuid.uuid4()
+
+    en_1, en_2 = uuid.uuid4(), uuid.uuid4()
+    bo_1, bo_2 = uuid.uuid4(), uuid.uuid4()
+
+    existing = _make_existing_series(series_id, author_id, plans=[])
+    refreshed = _make_refreshed_series(series_id, author_id)
+    mock_author = _make_mock_author(author_id)
+
+    def _fetched(pid):
+        m = MagicMock()
+        m.id = pid
+        m.deleted_at = None
+        m.series_id = None
+        m.author_id = author_id
+        return m
+
+    request = UpdateSeriesRequest(
+        plans={"EN": [en_1, en_2], "BO": [bo_1, bo_2]}
+    )
+
+    with patch("pecha_api.plans.series.series_service.SessionLocal") as mock_session_local, \
+         patch("pecha_api.plans.series.series_service.validate_and_extract_author_details", return_value=mock_author), \
+         patch("pecha_api.plans.series.series_service.get_series_by_id", side_effect=[existing, refreshed]), \
+         patch("pecha_api.plans.series.series_service.get_plans_by_ids", return_value=[_fetched(en_1), _fetched(en_2), _fetched(bo_1), _fetched(bo_2)]), \
+         patch("pecha_api.plans.series.series_service.update_series_with_plans") as mock_update:
+        _session_local_context(mock_session_local)
+        update_existing_series(token="dummy", series_id=series_id, update_series_request=request)
+
+    plans_to_attach = mock_update.call_args.kwargs["plans_to_attach"]
+    assert plans_to_attach == [(en_1, 0), (en_2, 1), (bo_1, 0), (bo_2, 1)]

--- a/tests/plans/series/test_series_views.py
+++ b/tests/plans/series/test_series_views.py
@@ -353,6 +353,33 @@ def test_update_series_rejects_invalid_language_key_in_plans():
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
 
+def test_update_series_accepts_multi_language_plans_payload():
+    series_id = uuid.uuid4()
+    payload = {
+        "plans": {
+            "EN": [str(uuid.uuid4()), str(uuid.uuid4())],
+            "BO": [str(uuid.uuid4())],
+        }
+    }
+
+    with patch(
+        "pecha_api.plans.series.series_view.update_existing_series",
+        return_value=sample_series_dto_factory(),
+    ) as mock_update:
+        response = client.put(
+            f"/cms/series/{series_id}",
+            json=payload,
+            headers={"Authorization": "Bearer dummy"},
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    mock_update.assert_called_once()
+    request = mock_update.call_args.kwargs["update_series_request"]
+    assert set(request.plans.keys()) == {"EN", "BO"}
+    assert len(request.plans["EN"]) == 2
+    assert len(request.plans["BO"]) == 1
+
+
 def test_create_series_rejects_invalid_language_key_in_plans():
     payload = {
         "metadata": [{"title": "Test", "language": "EN"}],


### PR DESCRIPTION
- Removed the old flattening helper that merged all the language lists into one and lost the ordering. Now we keep each language separate and number the plans by their position in their own language list (starting from 0).
- POST and PUT now save the display order for each plan, not just the series ID. On PUT we send every plan in the request, not just the new ones, so reordering existing plans works too.
- When a plan is detached from a series, its display order resets to null along with the series ID, so it doesn't hold on to an old order value.