### PR TITLE
Delete api

### DIFF
--- a/pecha_api/plans/series/series_repository.py
+++ b/pecha_api/plans/series/series_repository.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 from typing import List, Optional, Tuple
 from uuid import UUID
 
@@ -117,6 +118,23 @@ def update_series_with_plans(
     db.commit()
     db.refresh(series)
     return series
+
+
+def soft_delete_series_with_plan_detach(
+    db: Session,
+    series: Series,
+    deleted_by: Optional[str],
+) -> None:
+    db.query(Plan).filter(Plan.series_id == series.id).update(
+        {
+            Plan.series_id: None,
+            Plan.display_order: None,
+        },
+        synchronize_session=False,
+    )
+    series.deleted_at = datetime.now(timezone.utc)
+    series.deleted_by = deleted_by
+    db.commit()
 
 
 def get_series_paginated(

--- a/pecha_api/plans/series/series_service.py
+++ b/pecha_api/plans/series/series_service.py
@@ -15,6 +15,7 @@ from pecha_api.plans.series.series_repository import (
     get_plans_by_ids,
     save_series_with_plans,
     update_series_with_plans,
+    soft_delete_series_with_plan_detach,
 )
 from pecha_api.plans.series.series_response_models import (
     CreateSeriesRequest,
@@ -370,6 +371,36 @@ def create_new_series(token: str, create_series_request: CreateSeriesRequest) ->
             saved = get_series_by_id(db=db_session, series_id=saved.id)
 
         return _series_to_dto(saved, include_plans=bool(plan_ids))
+    except IntegrityError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Database integrity error: {exc.orig}",
+        ) from exc
+
+
+def delete_existing_series(token: str, series_id: UUID) -> None:
+    current_author = validate_and_extract_author_details(token=token)
+
+    try:
+        with SessionLocal() as db_session:
+            series = get_series_by_id(db=db_session, series_id=series_id)
+            if not series:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail=f"Series with id '{series_id}' not found",
+                )
+            if not current_author.is_admin and series.author_id != current_author.id:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="You do not have permission to delete this series",
+                )
+
+            soft_delete_series_with_plan_detach(
+                db=db_session,
+                series=series,
+                deleted_by=current_author.email,
+            )
+        return
     except IntegrityError as exc:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/pecha_api/plans/series/series_view.py
+++ b/pecha_api/plans/series/series_view.py
@@ -6,7 +6,7 @@ from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from starlette import status
 
 from pecha_api.plans.series.series_response_models import CreateSeriesRequest, UpdateSeriesRequest, SeriesDTO, SeriesListResponse
-from pecha_api.plans.series.series_service import create_new_series, update_existing_series, get_cms_filtered_series, get_cms_series_detail
+from pecha_api.plans.series.series_service import create_new_series, update_existing_series, get_cms_filtered_series, get_cms_series_detail, delete_existing_series
 
 oauth2_scheme = HTTPBearer()
 
@@ -40,6 +40,20 @@ async def update_series(
         token=authentication_credential.credentials,
         series_id=series_id,
         update_series_request=update_series_request,
+    )
+
+
+@cms_series_router.delete(
+    "/{series_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def delete_series(
+    series_id: UUID,
+    authentication_credential: Annotated[HTTPAuthorizationCredentials, Depends(oauth2_scheme)],
+):
+    return delete_existing_series(
+        token=authentication_credential.credentials,
+        series_id=series_id,
     )
 
 

--- a/tests/plans/series/test_series_repository.py
+++ b/tests/plans/series/test_series_repository.py
@@ -12,6 +12,7 @@ from pecha_api.plans.series.series_repository import (
     get_series_paginated,
     save_series_with_plans,
     update_series_with_plans,
+    soft_delete_series_with_plan_detach,
 )
 
 
@@ -317,3 +318,55 @@ def test_update_series_with_plans_attach_and_detach_together():
     detach_updates = [u for u in updates if u.get(Plan.series_id) is None]
     assert len(detach_updates) == 1
     assert detach_updates[0][Plan.display_order] is None
+
+
+# ---------------------------------------------------------------------------
+# soft delete: soft_delete_series_with_plan_detach (DELETE path)
+# ---------------------------------------------------------------------------
+
+def test_soft_delete_series_sets_deleted_fields_and_commits():
+    db = _make_session_mock()
+    series = MagicMock(name="SeriesInstance")
+    series.id = uuid.uuid4()
+
+    soft_delete_series_with_plan_detach(
+        db=db,
+        series=series,
+        deleted_by="tester@example.com",
+    )
+
+    assert series.deleted_at is not None
+    assert series.deleted_by == "tester@example.com"
+    db.commit.assert_called_once()
+
+
+def test_soft_delete_series_detaches_all_attached_plans():
+    db = _make_session_mock()
+    series = MagicMock(name="SeriesInstance")
+    series.id = uuid.uuid4()
+
+    soft_delete_series_with_plan_detach(
+        db=db,
+        series=series,
+        deleted_by="tester@example.com",
+    )
+
+    updates = _capture_plan_updates(db)
+    assert len(updates) == 1
+    detach_values = updates[0]
+    assert detach_values[Plan.series_id] is None
+    assert detach_values[Plan.display_order] is None
+
+
+def test_soft_delete_series_returns_none():
+    db = _make_session_mock()
+    series = MagicMock(name="SeriesInstance")
+    series.id = uuid.uuid4()
+
+    result = soft_delete_series_with_plan_detach(
+        db=db,
+        series=series,
+        deleted_by="tester@example.com",
+    )
+
+    assert result is None

--- a/tests/plans/series/test_series_service.py
+++ b/tests/plans/series/test_series_service.py
@@ -18,6 +18,7 @@ from pecha_api.plans.series.series_service import (
     update_existing_series,
     get_cms_filtered_series,
     get_cms_series_detail,
+    delete_existing_series,
 )
 from pecha_api.plans.series.series_response_models import (
     CreateSeriesRequest,
@@ -487,8 +488,8 @@ def test_get_series_detail_handles_plan_without_items_attribute():
     series_id = uuid.uuid4()
     author_id = uuid.uuid4()
 
-    plan_no_items = MagicMock(spec=["deleted_at", "display_order", "id", "title", "description", 
-                                     "language", "difficulty_level", "image_url", "tags", 
+    plan_no_items = MagicMock(spec=["deleted_at", "display_order", "id", "title", "description",
+                                     "language", "difficulty_level", "image_url", "tags",
                                      "status", "featured", "start_date"])
     plan_no_items.deleted_at = None
     plan_no_items.display_order = 1
@@ -1657,3 +1658,111 @@ def test_update_existing_series_multi_language_independent_ordering():
 
     plans_to_attach = mock_update.call_args.kwargs["plans_to_attach"]
     assert plans_to_attach == [(en_1, 0), (en_2, 1), (bo_1, 0), (bo_2, 1)]
+
+
+# ---------------------------------------------------------------------------
+# DELETE: delete_existing_series
+# ---------------------------------------------------------------------------
+
+def test_delete_existing_series_soft_deletes_when_owner():
+    series_id = uuid.uuid4()
+    author_id = uuid.uuid4()
+
+    existing = _make_existing_series(series_id, author_id)
+    mock_author = _make_mock_author(author_id, email="owner@pecha.org", is_admin=False)
+
+    with patch("pecha_api.plans.series.series_service.SessionLocal") as mock_session_local, \
+         patch("pecha_api.plans.series.series_service.validate_and_extract_author_details", return_value=mock_author), \
+         patch("pecha_api.plans.series.series_service.get_series_by_id", return_value=existing), \
+         patch("pecha_api.plans.series.series_service.soft_delete_series_with_plan_detach") as mock_soft_delete:
+        _session_local_context(mock_session_local)
+
+        result = delete_existing_series(token="dummy", series_id=series_id)
+
+    assert result is None
+    mock_soft_delete.assert_called_once()
+    call_kwargs = mock_soft_delete.call_args.kwargs
+    assert call_kwargs["series"] is existing
+    assert call_kwargs["deleted_by"] == "owner@pecha.org"
+
+
+def test_delete_existing_series_returns_404_when_series_not_found():
+    series_id = uuid.uuid4()
+    author_id = uuid.uuid4()
+    mock_author = _make_mock_author(author_id)
+
+    with patch("pecha_api.plans.series.series_service.SessionLocal") as mock_session_local, \
+         patch("pecha_api.plans.series.series_service.validate_and_extract_author_details", return_value=mock_author), \
+         patch("pecha_api.plans.series.series_service.get_series_by_id", return_value=None), \
+         patch("pecha_api.plans.series.series_service.soft_delete_series_with_plan_detach") as mock_soft_delete:
+        _session_local_context(mock_session_local)
+
+        with pytest.raises(HTTPException) as exc:
+            delete_existing_series(token="dummy", series_id=series_id)
+
+    assert exc.value.status_code == status.HTTP_404_NOT_FOUND
+    assert str(series_id) in exc.value.detail
+    mock_soft_delete.assert_not_called()
+
+
+def test_delete_existing_series_returns_403_when_non_admin_other_author():
+    series_id = uuid.uuid4()
+    author_id = uuid.uuid4()
+    other_author_id = uuid.uuid4()
+
+    existing = _make_existing_series(series_id, other_author_id)
+    mock_author = _make_mock_author(author_id, is_admin=False)
+
+    with patch("pecha_api.plans.series.series_service.SessionLocal") as mock_session_local, \
+         patch("pecha_api.plans.series.series_service.validate_and_extract_author_details", return_value=mock_author), \
+         patch("pecha_api.plans.series.series_service.get_series_by_id", return_value=existing), \
+         patch("pecha_api.plans.series.series_service.soft_delete_series_with_plan_detach") as mock_soft_delete:
+        _session_local_context(mock_session_local)
+
+        with pytest.raises(HTTPException) as exc:
+            delete_existing_series(token="dummy", series_id=series_id)
+
+    assert exc.value.status_code == status.HTTP_403_FORBIDDEN
+    mock_soft_delete.assert_not_called()
+
+
+def test_delete_existing_series_admin_can_delete_other_author_series():
+    series_id = uuid.uuid4()
+    admin_id = uuid.uuid4()
+    other_author_id = uuid.uuid4()
+
+    existing = _make_existing_series(series_id, other_author_id)
+    mock_admin = _make_mock_author(admin_id, is_admin=True)
+
+    with patch("pecha_api.plans.series.series_service.SessionLocal") as mock_session_local, \
+         patch("pecha_api.plans.series.series_service.validate_and_extract_author_details", return_value=mock_admin), \
+         patch("pecha_api.plans.series.series_service.get_series_by_id", return_value=existing), \
+         patch("pecha_api.plans.series.series_service.soft_delete_series_with_plan_detach") as mock_soft_delete:
+        _session_local_context(mock_session_local)
+
+        result = delete_existing_series(token="dummy", series_id=series_id)
+
+    assert result is None
+    mock_soft_delete.assert_called_once()
+
+
+def test_delete_existing_series_integrity_error_raises_400():
+    series_id = uuid.uuid4()
+    author_id = uuid.uuid4()
+    orig = Exception("foreign key violation")
+
+    existing = _make_existing_series(series_id, author_id)
+    mock_author = _make_mock_author(author_id)
+
+    with patch("pecha_api.plans.series.series_service.SessionLocal") as mock_session_local, \
+         patch("pecha_api.plans.series.series_service.validate_and_extract_author_details", return_value=mock_author), \
+         patch("pecha_api.plans.series.series_service.get_series_by_id", return_value=existing), \
+         patch("pecha_api.plans.series.series_service.soft_delete_series_with_plan_detach",
+               side_effect=IntegrityError("statement", {}, orig)):
+        _session_local_context(mock_session_local)
+
+        with pytest.raises(HTTPException) as exc:
+            delete_existing_series(token="dummy", series_id=series_id)
+
+    assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
+    assert "Database integrity error" in exc.value.detail

--- a/tests/plans/series/test_series_views.py
+++ b/tests/plans/series/test_series_views.py
@@ -484,3 +484,53 @@ def test_get_cms_series_by_id_forbidden():
         )
 
     assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_delete_series_success():
+    series_id = uuid.uuid4()
+    with patch(
+        "pecha_api.plans.series.series_view.delete_existing_series",
+        return_value=None,
+    ) as mock_delete:
+        response = client.delete(
+            f"/cms/series/{series_id}",
+            headers={"Authorization": "Bearer dummy"},
+        )
+
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    assert response.content == b""
+    mock_delete.assert_called_once_with(token="dummy", series_id=series_id)
+
+
+def test_delete_series_not_found():
+    series_id = uuid.uuid4()
+    with patch(
+        "pecha_api.plans.series.series_view.delete_existing_series",
+        side_effect=HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Series with id '{series_id}' not found",
+        ),
+    ):
+        response = client.delete(
+            f"/cms/series/{series_id}",
+            headers={"Authorization": "Bearer dummy"},
+        )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_delete_series_forbidden():
+    series_id = uuid.uuid4()
+    with patch(
+        "pecha_api.plans.series.series_view.delete_existing_series",
+        side_effect=HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You do not have permission to delete this series",
+        ),
+    ):
+        response = client.delete(
+            f"/cms/series/{series_id}",
+            headers={"Authorization": "Bearer dummy"},
+        )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN


### PR DESCRIPTION
https://github.com/OpenPecha/WeBuddhist-Backend/issues/594

- Soft-deletes the series (sets deleted_at and deleted_by).
- Detaches all plans currently attached to the series (plans themselves are not deleted).
- Non-admin authors can only delete series they own.
- Updated tests