### PR TITLE
Patch apis

### DIFF
--- a/pecha_api/plans/series/series_repository.py
+++ b/pecha_api/plans/series/series_repository.py
@@ -121,6 +121,38 @@ def update_series_with_plans(
     return series
 
 
+def update_series_status(
+    db: Session,
+    series: Series,
+    status,
+    updated_by: Optional[str],
+    updated_at,
+) -> Series:
+    series.status = status
+    series.updated_at = updated_at
+    series.updated_by = updated_by
+
+    db.commit()
+    db.refresh(series)
+    return series
+
+
+def update_series_featured(
+    db: Session,
+    series: Series,
+    featured: bool,
+    updated_by: Optional[str],
+    updated_at,
+) -> Series:
+    series.featured = featured
+    series.updated_at = updated_at
+    series.updated_by = updated_by
+
+    db.commit()
+    db.refresh(series)
+    return series
+
+
 def soft_delete_series_with_plan_detach(
     db: Session,
     series: Series,

--- a/pecha_api/plans/series/series_response_models.py
+++ b/pecha_api/plans/series/series_response_models.py
@@ -58,6 +58,10 @@ class UpdateSeriesRequest(BaseModel):
         return _validate_plan_language_keys(v)
 
 
+class UpdateSeriesStatusRequest(BaseModel):
+    status: PlanStatus
+
+
 class SeriesPlanDTO(BaseModel):
     id: UUID
     title: str

--- a/pecha_api/plans/series/series_service.py
+++ b/pecha_api/plans/series/series_service.py
@@ -34,6 +34,9 @@ from pecha_api.uploads.S3_utils import generate_presigned_access_url
 from starlette import status
 
 
+_SERIES_UPDATE_PERMISSION_ERROR = "You do not have permission to update this series"
+
+
 def _generate_image_url(image_key: Optional[str]) -> Optional[str]:
     if not image_key:
         return None
@@ -292,7 +295,7 @@ def update_existing_series(
             if not current_author.is_admin and series.author_id != current_author.id:
                 raise HTTPException(
                     status_code=status.HTTP_403_FORBIDDEN,
-                    detail="You do not have permission to update this series",
+                    detail=_SERIES_UPDATE_PERMISSION_ERROR,
                 )
 
             if update_series_request.plans is not None:
@@ -360,7 +363,7 @@ def update_existing_series_status(
             if not current_author.is_admin and series.author_id != current_author.id:
                 raise HTTPException(
                     status_code=status.HTTP_403_FORBIDDEN,
-                    detail="You do not have permission to update this series",
+                    detail=_SERIES_UPDATE_PERMISSION_ERROR,
                 )
 
             update_series_status(
@@ -398,7 +401,7 @@ def update_existing_series_featured(
             if not current_author.is_admin and series.author_id != current_author.id:
                 raise HTTPException(
                     status_code=status.HTTP_403_FORBIDDEN,
-                    detail="You do not have permission to update this series",
+                    detail=_SERIES_UPDATE_PERMISSION_ERROR,
                 )
 
             update_series_featured(

--- a/pecha_api/plans/series/series_service.py
+++ b/pecha_api/plans/series/series_service.py
@@ -15,11 +15,14 @@ from pecha_api.plans.series.series_repository import (
     get_plans_by_ids,
     save_series_with_plans,
     update_series_with_plans,
+    update_series_status,
+    update_series_featured,
     soft_delete_series_with_plan_detach,
 )
 from pecha_api.plans.series.series_response_models import (
     CreateSeriesRequest,
     UpdateSeriesRequest,
+    UpdateSeriesStatusRequest,
     SeriesDTO,
     SeriesMetadataDTO,
     SeriesPlanDTO,
@@ -332,6 +335,80 @@ def update_existing_series(
             refreshed = get_series_by_id(db=db_session, series_id=series_id)
 
         return _series_to_dto(refreshed, include_plans=True)
+    except IntegrityError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Database integrity error: {exc.orig}",
+        ) from exc
+
+
+def update_existing_series_status(
+    token: str,
+    series_id: UUID,
+    update_series_status_request: UpdateSeriesStatusRequest,
+) -> SeriesDTO:
+    current_author = validate_and_extract_author_details(token=token)
+
+    try:
+        with SessionLocal() as db_session:
+            series = get_series_by_id(db=db_session, series_id=series_id)
+            if not series:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail=f"Series with id '{series_id}' not found",
+                )
+            if not current_author.is_admin and series.author_id != current_author.id:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="You do not have permission to update this series",
+                )
+
+            update_series_status(
+                db=db_session,
+                series=series,
+                status=update_series_status_request.status,
+                updated_by=current_author.email,
+                updated_at=datetime.now(timezone.utc),
+            )
+
+            refreshed = get_series_by_id(db=db_session, series_id=series_id)
+
+        return _series_to_dto(refreshed, include_plans=True)
+    except IntegrityError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Database integrity error: {exc.orig}",
+        ) from exc
+
+
+def update_existing_series_featured(
+    token: str,
+    series_id: UUID,
+) -> None:
+    current_author = validate_and_extract_author_details(token=token)
+
+    try:
+        with SessionLocal() as db_session:
+            series = get_series_by_id(db=db_session, series_id=series_id)
+            if not series:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail=f"Series with id '{series_id}' not found",
+                )
+            if not current_author.is_admin and series.author_id != current_author.id:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="You do not have permission to update this series",
+                )
+
+            update_series_featured(
+                db=db_session,
+                series=series,
+                featured=not series.featured,
+                updated_by=current_author.email,
+                updated_at=datetime.now(timezone.utc),
+            )
+        return
     except IntegrityError as exc:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/pecha_api/plans/series/series_view.py
+++ b/pecha_api/plans/series/series_view.py
@@ -5,8 +5,8 @@ from fastapi import APIRouter, Depends, Query
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from starlette import status
 
-from pecha_api.plans.series.series_response_models import CreateSeriesRequest, UpdateSeriesRequest, SeriesDTO, SeriesListResponse
-from pecha_api.plans.series.series_service import create_new_series, update_existing_series, get_cms_filtered_series, get_cms_series_detail, delete_existing_series
+from pecha_api.plans.series.series_response_models import CreateSeriesRequest, UpdateSeriesRequest, UpdateSeriesStatusRequest, SeriesDTO, SeriesListResponse
+from pecha_api.plans.series.series_service import create_new_series, update_existing_series, update_existing_series_status, update_existing_series_featured, get_cms_filtered_series, get_cms_series_detail, delete_existing_series
 
 oauth2_scheme = HTTPBearer()
 
@@ -40,6 +40,37 @@ async def update_series(
         token=authentication_credential.credentials,
         series_id=series_id,
         update_series_request=update_series_request,
+    )
+
+
+@cms_series_router.patch(
+    "/{series_id}/status",
+    status_code=status.HTTP_200_OK,
+    response_model=SeriesDTO,
+)
+async def update_series_status(
+    series_id: UUID,
+    authentication_credential: Annotated[HTTPAuthorizationCredentials, Depends(oauth2_scheme)],
+    update_series_status_request: UpdateSeriesStatusRequest,
+):
+    return update_existing_series_status(
+        token=authentication_credential.credentials,
+        series_id=series_id,
+        update_series_status_request=update_series_status_request,
+    )
+
+
+@cms_series_router.patch(
+    "/{series_id}/featured",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def update_series_featured(
+    series_id: UUID,
+    authentication_credential: Annotated[HTTPAuthorizationCredentials, Depends(oauth2_scheme)],
+):
+    return update_existing_series_featured(
+        token=authentication_credential.credentials,
+        series_id=series_id,
     )
 
 

--- a/tests/plans/series/test_series_repository.py
+++ b/tests/plans/series/test_series_repository.py
@@ -12,6 +12,8 @@ from pecha_api.plans.series.series_repository import (
     get_series_paginated,
     save_series_with_plans,
     update_series_with_plans,
+    update_series_status,
+    update_series_featured,
     soft_delete_series_with_plan_detach,
 )
 
@@ -370,3 +372,105 @@ def test_soft_delete_series_returns_none():
     )
 
     assert result is None
+
+# ---------------------------------------------------------------------------
+# status update: update_series_status (PATCH /status path)
+# ---------------------------------------------------------------------------
+
+def test_update_series_status_sets_status_updated_fields_and_commits():
+    db = _make_session_mock()
+    series = MagicMock(name="SeriesInstance")
+    series.id = uuid.uuid4()
+    updated_at = MagicMock(name="UpdatedAt")
+
+    result = update_series_status(
+        db=db,
+        series=series,
+        status="PUBLISHED",
+        updated_by="tester@example.com",
+        updated_at=updated_at,
+    )
+
+    assert result is series
+    assert series.status == "PUBLISHED"
+    assert series.updated_at is updated_at
+    assert series.updated_by == "tester@example.com"
+    db.commit.assert_called_once()
+    db.refresh.assert_called_once_with(series)
+
+
+def test_update_series_status_integrity_error_propagates():
+    db = _make_session_mock()
+    series = MagicMock(name="SeriesInstance")
+    series.id = uuid.uuid4()
+    orig = Exception("constraint violation")
+    db.commit.side_effect = IntegrityError("statement", {}, orig)
+
+    with pytest.raises(IntegrityError):
+        update_series_status(
+            db=db,
+            series=series,
+            status="PUBLISHED",
+            updated_by="tester@example.com",
+            updated_at=MagicMock(),
+        )
+
+
+# ---------------------------------------------------------------------------
+# featured update: update_series_featured (PATCH /featured path)
+# ---------------------------------------------------------------------------
+
+def test_update_series_featured_sets_featured_updated_fields_and_commits():
+    db = _make_session_mock()
+    series = MagicMock(name="SeriesInstance")
+    series.id = uuid.uuid4()
+    updated_at = MagicMock(name="UpdatedAt")
+
+    result = update_series_featured(
+        db=db,
+        series=series,
+        featured=True,
+        updated_by="tester@example.com",
+        updated_at=updated_at,
+    )
+
+    assert result is series
+    assert series.featured is True
+    assert series.updated_at is updated_at
+    assert series.updated_by == "tester@example.com"
+    db.commit.assert_called_once()
+    db.refresh.assert_called_once_with(series)
+
+
+def test_update_series_featured_writes_false_value():
+    db = _make_session_mock()
+    series = MagicMock(name="SeriesInstance")
+    series.id = uuid.uuid4()
+
+    update_series_featured(
+        db=db,
+        series=series,
+        featured=False,
+        updated_by="tester@example.com",
+        updated_at=MagicMock(),
+    )
+
+    assert series.featured is False
+    db.commit.assert_called_once()
+
+
+def test_update_series_featured_integrity_error_propagates():
+    db = _make_session_mock()
+    series = MagicMock(name="SeriesInstance")
+    series.id = uuid.uuid4()
+    orig = Exception("constraint violation")
+    db.commit.side_effect = IntegrityError("statement", {}, orig)
+
+    with pytest.raises(IntegrityError):
+        update_series_featured(
+            db=db,
+            series=series,
+            featured=True,
+            updated_by="tester@example.com",
+            updated_at=MagicMock(),
+        )

--- a/tests/plans/series/test_series_service.py
+++ b/tests/plans/series/test_series_service.py
@@ -16,6 +16,8 @@ from pecha_api.plans.series.series_service import (
     get_filtered_series,
     get_series_detail,
     update_existing_series,
+    update_existing_series_status,
+    update_existing_series_featured,
     get_cms_filtered_series,
     get_cms_series_detail,
     delete_existing_series,
@@ -23,6 +25,7 @@ from pecha_api.plans.series.series_service import (
 from pecha_api.plans.series.series_response_models import (
     CreateSeriesRequest,
     UpdateSeriesRequest,
+    UpdateSeriesStatusRequest,
     SeriesListResponse,
     SeriesMetadataInput,
 )
@@ -1763,6 +1766,263 @@ def test_delete_existing_series_integrity_error_raises_400():
 
         with pytest.raises(HTTPException) as exc:
             delete_existing_series(token="dummy", series_id=series_id)
+
+    assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
+    assert "Database integrity error" in exc.value.detail
+
+# ===========================================================================
+# PATCH /status — update_existing_series_status
+# ===========================================================================
+
+def test_update_existing_series_status_updates_status_when_owner():
+    series_id = uuid.uuid4()
+    author_id = uuid.uuid4()
+
+    existing = _make_existing_series(series_id, author_id)
+    refreshed = _make_refreshed_series(series_id, author_id)
+    mock_author = _make_mock_author(author_id, email="owner@pecha.org")
+
+    request = UpdateSeriesStatusRequest(status=PlanStatus.PUBLISHED)
+
+    with patch("pecha_api.plans.series.series_service.SessionLocal") as mock_session_local, \
+         patch("pecha_api.plans.series.series_service.validate_and_extract_author_details", return_value=mock_author), \
+         patch("pecha_api.plans.series.series_service.get_series_by_id", side_effect=[existing, refreshed]), \
+         patch("pecha_api.plans.series.series_service.update_series_status") as mock_update:
+        _session_local_context(mock_session_local)
+        dto = update_existing_series_status(
+            token="dummy", series_id=series_id, update_series_status_request=request
+        )
+
+    mock_update.assert_called_once()
+    call_kwargs = mock_update.call_args.kwargs
+    assert call_kwargs["series"] is existing
+    assert call_kwargs["status"] == PlanStatus.PUBLISHED
+    assert call_kwargs["updated_by"] == "owner@pecha.org"
+    assert isinstance(call_kwargs["updated_at"], datetime)
+    assert call_kwargs["updated_at"].tzinfo is not None
+    assert dto.id == series_id
+
+
+def test_update_existing_series_status_returns_404_when_not_found():
+    series_id = uuid.uuid4()
+    author_id = uuid.uuid4()
+    mock_author = _make_mock_author(author_id)
+
+    request = UpdateSeriesStatusRequest(status=PlanStatus.PUBLISHED)
+
+    with patch("pecha_api.plans.series.series_service.SessionLocal") as mock_session_local, \
+         patch("pecha_api.plans.series.series_service.validate_and_extract_author_details", return_value=mock_author), \
+         patch("pecha_api.plans.series.series_service.get_series_by_id", return_value=None), \
+         patch("pecha_api.plans.series.series_service.update_series_status") as mock_update:
+        _session_local_context(mock_session_local)
+
+        with pytest.raises(HTTPException) as exc:
+            update_existing_series_status(
+                token="dummy", series_id=series_id, update_series_status_request=request
+            )
+
+    assert exc.value.status_code == status.HTTP_404_NOT_FOUND
+    assert str(series_id) in exc.value.detail
+    mock_update.assert_not_called()
+
+
+def test_update_existing_series_status_returns_403_when_non_admin_other_author():
+    series_id = uuid.uuid4()
+    author_id = uuid.uuid4()
+    other_author_id = uuid.uuid4()
+
+    existing = _make_existing_series(series_id, other_author_id)
+    mock_author = _make_mock_author(author_id, is_admin=False)
+
+    request = UpdateSeriesStatusRequest(status=PlanStatus.PUBLISHED)
+
+    with patch("pecha_api.plans.series.series_service.SessionLocal") as mock_session_local, \
+         patch("pecha_api.plans.series.series_service.validate_and_extract_author_details", return_value=mock_author), \
+         patch("pecha_api.plans.series.series_service.get_series_by_id", return_value=existing), \
+         patch("pecha_api.plans.series.series_service.update_series_status") as mock_update:
+        _session_local_context(mock_session_local)
+
+        with pytest.raises(HTTPException) as exc:
+            update_existing_series_status(
+                token="dummy", series_id=series_id, update_series_status_request=request
+            )
+
+    assert exc.value.status_code == status.HTTP_403_FORBIDDEN
+    mock_update.assert_not_called()
+
+
+def test_update_existing_series_status_admin_can_update_other_author_series():
+    series_id = uuid.uuid4()
+    admin_id = uuid.uuid4()
+    other_author_id = uuid.uuid4()
+
+    existing = _make_existing_series(series_id, other_author_id)
+    refreshed = _make_refreshed_series(series_id, other_author_id)
+    mock_admin = _make_mock_author(admin_id, is_admin=True)
+
+    request = UpdateSeriesStatusRequest(status=PlanStatus.PUBLISHED)
+
+    with patch("pecha_api.plans.series.series_service.SessionLocal") as mock_session_local, \
+         patch("pecha_api.plans.series.series_service.validate_and_extract_author_details", return_value=mock_admin), \
+         patch("pecha_api.plans.series.series_service.get_series_by_id", side_effect=[existing, refreshed]), \
+         patch("pecha_api.plans.series.series_service.update_series_status") as mock_update:
+        _session_local_context(mock_session_local)
+        update_existing_series_status(
+            token="dummy", series_id=series_id, update_series_status_request=request
+        )
+
+    mock_update.assert_called_once()
+
+
+def test_update_existing_series_status_integrity_error_raises_400():
+    series_id = uuid.uuid4()
+    author_id = uuid.uuid4()
+    orig = Exception("constraint violation")
+
+    existing = _make_existing_series(series_id, author_id)
+    mock_author = _make_mock_author(author_id)
+
+    request = UpdateSeriesStatusRequest(status=PlanStatus.PUBLISHED)
+
+    with patch("pecha_api.plans.series.series_service.SessionLocal") as mock_session_local, \
+         patch("pecha_api.plans.series.series_service.validate_and_extract_author_details", return_value=mock_author), \
+         patch("pecha_api.plans.series.series_service.get_series_by_id", return_value=existing), \
+         patch("pecha_api.plans.series.series_service.update_series_status",
+               side_effect=IntegrityError("statement", {}, orig)):
+        _session_local_context(mock_session_local)
+
+        with pytest.raises(HTTPException) as exc:
+            update_existing_series_status(
+                token="dummy", series_id=series_id, update_series_status_request=request
+            )
+
+    assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
+    assert "Database integrity error" in exc.value.detail
+
+
+# ===========================================================================
+# PATCH /featured — update_existing_series_featured
+# ===========================================================================
+
+def test_update_existing_series_featured_toggles_false_to_true():
+    series_id = uuid.uuid4()
+    author_id = uuid.uuid4()
+
+    existing = _make_existing_series(series_id, author_id)
+    existing.featured = False
+    mock_author = _make_mock_author(author_id, email="owner@pecha.org")
+
+    with patch("pecha_api.plans.series.series_service.SessionLocal") as mock_session_local, \
+         patch("pecha_api.plans.series.series_service.validate_and_extract_author_details", return_value=mock_author), \
+         patch("pecha_api.plans.series.series_service.get_series_by_id", return_value=existing), \
+         patch("pecha_api.plans.series.series_service.update_series_featured") as mock_update:
+        _session_local_context(mock_session_local)
+        result = update_existing_series_featured(token="dummy", series_id=series_id)
+
+    assert result is None
+    mock_update.assert_called_once()
+    call_kwargs = mock_update.call_args.kwargs
+    assert call_kwargs["series"] is existing
+    assert call_kwargs["featured"] is True
+    assert call_kwargs["updated_by"] == "owner@pecha.org"
+    assert isinstance(call_kwargs["updated_at"], datetime)
+    assert call_kwargs["updated_at"].tzinfo is not None
+
+
+def test_update_existing_series_featured_toggles_true_to_false():
+    series_id = uuid.uuid4()
+    author_id = uuid.uuid4()
+
+    existing = _make_existing_series(series_id, author_id)
+    existing.featured = True
+    mock_author = _make_mock_author(author_id)
+
+    with patch("pecha_api.plans.series.series_service.SessionLocal") as mock_session_local, \
+         patch("pecha_api.plans.series.series_service.validate_and_extract_author_details", return_value=mock_author), \
+         patch("pecha_api.plans.series.series_service.get_series_by_id", return_value=existing), \
+         patch("pecha_api.plans.series.series_service.update_series_featured") as mock_update:
+        _session_local_context(mock_session_local)
+        update_existing_series_featured(token="dummy", series_id=series_id)
+
+    assert mock_update.call_args.kwargs["featured"] is False
+
+
+def test_update_existing_series_featured_returns_404_when_not_found():
+    series_id = uuid.uuid4()
+    author_id = uuid.uuid4()
+    mock_author = _make_mock_author(author_id)
+
+    with patch("pecha_api.plans.series.series_service.SessionLocal") as mock_session_local, \
+         patch("pecha_api.plans.series.series_service.validate_and_extract_author_details", return_value=mock_author), \
+         patch("pecha_api.plans.series.series_service.get_series_by_id", return_value=None), \
+         patch("pecha_api.plans.series.series_service.update_series_featured") as mock_update:
+        _session_local_context(mock_session_local)
+
+        with pytest.raises(HTTPException) as exc:
+            update_existing_series_featured(token="dummy", series_id=series_id)
+
+    assert exc.value.status_code == status.HTTP_404_NOT_FOUND
+    assert str(series_id) in exc.value.detail
+    mock_update.assert_not_called()
+
+
+def test_update_existing_series_featured_returns_403_when_non_admin_other_author():
+    series_id = uuid.uuid4()
+    author_id = uuid.uuid4()
+    other_author_id = uuid.uuid4()
+
+    existing = _make_existing_series(series_id, other_author_id)
+    mock_author = _make_mock_author(author_id, is_admin=False)
+
+    with patch("pecha_api.plans.series.series_service.SessionLocal") as mock_session_local, \
+         patch("pecha_api.plans.series.series_service.validate_and_extract_author_details", return_value=mock_author), \
+         patch("pecha_api.plans.series.series_service.get_series_by_id", return_value=existing), \
+         patch("pecha_api.plans.series.series_service.update_series_featured") as mock_update:
+        _session_local_context(mock_session_local)
+
+        with pytest.raises(HTTPException) as exc:
+            update_existing_series_featured(token="dummy", series_id=series_id)
+
+    assert exc.value.status_code == status.HTTP_403_FORBIDDEN
+    mock_update.assert_not_called()
+
+
+def test_update_existing_series_featured_admin_can_update_other_author_series():
+    series_id = uuid.uuid4()
+    admin_id = uuid.uuid4()
+    other_author_id = uuid.uuid4()
+
+    existing = _make_existing_series(series_id, other_author_id)
+    existing.featured = False
+    mock_admin = _make_mock_author(admin_id, is_admin=True)
+
+    with patch("pecha_api.plans.series.series_service.SessionLocal") as mock_session_local, \
+         patch("pecha_api.plans.series.series_service.validate_and_extract_author_details", return_value=mock_admin), \
+         patch("pecha_api.plans.series.series_service.get_series_by_id", return_value=existing), \
+         patch("pecha_api.plans.series.series_service.update_series_featured") as mock_update:
+        _session_local_context(mock_session_local)
+        update_existing_series_featured(token="dummy", series_id=series_id)
+
+    mock_update.assert_called_once()
+
+
+def test_update_existing_series_featured_integrity_error_raises_400():
+    series_id = uuid.uuid4()
+    author_id = uuid.uuid4()
+    orig = Exception("constraint violation")
+
+    existing = _make_existing_series(series_id, author_id)
+    mock_author = _make_mock_author(author_id)
+
+    with patch("pecha_api.plans.series.series_service.SessionLocal") as mock_session_local, \
+         patch("pecha_api.plans.series.series_service.validate_and_extract_author_details", return_value=mock_author), \
+         patch("pecha_api.plans.series.series_service.get_series_by_id", return_value=existing), \
+         patch("pecha_api.plans.series.series_service.update_series_featured",
+               side_effect=IntegrityError("statement", {}, orig)):
+        _session_local_context(mock_session_local)
+
+        with pytest.raises(HTTPException) as exc:
+            update_existing_series_featured(token="dummy", series_id=series_id)
 
     assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
     assert "Database integrity error" in exc.value.detail

--- a/tests/plans/series/test_series_views.py
+++ b/tests/plans/series/test_series_views.py
@@ -534,3 +534,142 @@ def test_delete_series_forbidden():
         )
 
     assert response.status_code == status.HTTP_403_FORBIDDEN
+
+# ===========================================================================
+# PATCH /cms/series/{series_id}/status
+# ===========================================================================
+
+def test_update_series_status_success(sample_series_dto):
+    series_id = uuid.uuid4()
+    payload = {"status": "PUBLISHED"}
+
+    with patch(
+        "pecha_api.plans.series.series_view.update_existing_series_status",
+        return_value=sample_series_dto,
+    ) as mock_update:
+        response = client.patch(
+            f"/cms/series/{series_id}/status",
+            json=payload,
+            headers={"Authorization": "Bearer dummy"},
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    mock_update.assert_called_once()
+    call_kwargs = mock_update.call_args.kwargs
+    assert call_kwargs["token"] == "dummy"
+    assert call_kwargs["series_id"] == series_id
+    assert call_kwargs["update_series_status_request"].status == PlanStatus.PUBLISHED
+
+    data = response.json()
+    assert data["id"] == str(sample_series_dto.id)
+
+
+def test_update_series_status_rejects_invalid_status_value():
+    series_id = uuid.uuid4()
+    response = client.patch(
+        f"/cms/series/{series_id}/status",
+        json={"status": "NOT_A_REAL_STATUS"},
+        headers={"Authorization": "Bearer dummy"},
+    )
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+def test_update_series_status_rejects_missing_status_field():
+    series_id = uuid.uuid4()
+    response = client.patch(
+        f"/cms/series/{series_id}/status",
+        json={},
+        headers={"Authorization": "Bearer dummy"},
+    )
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+def test_update_series_status_not_found():
+    series_id = uuid.uuid4()
+    with patch(
+        "pecha_api.plans.series.series_view.update_existing_series_status",
+        side_effect=HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Series with id '{series_id}' not found",
+        ),
+    ):
+        response = client.patch(
+            f"/cms/series/{series_id}/status",
+            json={"status": "PUBLISHED"},
+            headers={"Authorization": "Bearer dummy"},
+        )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_update_series_status_forbidden():
+    series_id = uuid.uuid4()
+    with patch(
+        "pecha_api.plans.series.series_view.update_existing_series_status",
+        side_effect=HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You do not have permission to update this series",
+        ),
+    ):
+        response = client.patch(
+            f"/cms/series/{series_id}/status",
+            json={"status": "PUBLISHED"},
+            headers={"Authorization": "Bearer dummy"},
+        )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+# ===========================================================================
+# PATCH /cms/series/{series_id}/featured
+# ===========================================================================
+
+def test_update_series_featured_success():
+    series_id = uuid.uuid4()
+
+    with patch(
+        "pecha_api.plans.series.series_view.update_existing_series_featured",
+        return_value=None,
+    ) as mock_update:
+        response = client.patch(
+            f"/cms/series/{series_id}/featured",
+            headers={"Authorization": "Bearer dummy"},
+        )
+
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    assert response.content == b""
+    mock_update.assert_called_once_with(token="dummy", series_id=series_id)
+
+
+def test_update_series_featured_not_found():
+    series_id = uuid.uuid4()
+    with patch(
+        "pecha_api.plans.series.series_view.update_existing_series_featured",
+        side_effect=HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Series with id '{series_id}' not found",
+        ),
+    ):
+        response = client.patch(
+            f"/cms/series/{series_id}/featured",
+            headers={"Authorization": "Bearer dummy"},
+        )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_update_series_featured_forbidden():
+    series_id = uuid.uuid4()
+    with patch(
+        "pecha_api.plans.series.series_view.update_existing_series_featured",
+        side_effect=HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You do not have permission to update this series",
+        ),
+    ):
+        response = client.patch(
+            f"/cms/series/{series_id}/featured",
+            headers={"Authorization": "Bearer dummy"},
+        )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN


### PR DESCRIPTION
https://github.com/OpenPecha/WeBuddhist-Backend/issues/592
- Added PATCH /cms/series/{series_id}/status to update a series' status, and PATCH /cms/series/{series_id}/featured to toggle whether a series is featured.
- Both endpoints check admin-or-owner permission and bump updated_at so the change registers in "Recently Modified."
- Added test coverage for both endpoints across the repository, service, and view layers.

PS- will update the logic in separate branch for GETs