### PR TITLE
Enhance series management with language filtering and plan count

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ env/
 .venv/
 env.bak/
 venv.bak/
+sync_database
 
 # FastAPI
 *.log

--- a/pecha_api/plans/series/public_series_view.py
+++ b/pecha_api/plans/series/public_series_view.py
@@ -17,10 +17,14 @@ async def get_series_list(
     search: Annotated[
         Optional[str], Query(description="Search within serialized name JSON")
     ] = None,
+    language: Annotated[
+        Optional[str],
+        Query(description="Filter by series metadata language (e.g. 'en', 'bo', 'zh')"),
+    ] = None,
     skip: Annotated[int, Query()] = 0,
     limit: Annotated[int, Query()] = 10,
 ):
-    return get_filtered_series(search=search, skip=skip, limit=limit)
+    return get_filtered_series(search=search, skip=skip, limit=limit, language=language)
 
 
 @public_series_router.get(

--- a/pecha_api/plans/series/series_repository.py
+++ b/pecha_api/plans/series/series_repository.py
@@ -1,12 +1,22 @@
 from typing import List, Optional, Tuple
 from uuid import UUID
 
-from sqlalchemy import String, cast, desc, asc, or_, exists, select
+from sqlalchemy import String, cast, desc, asc, or_, exists, select, func
 from sqlalchemy.orm import Session, selectinload
 
+from pecha_api.plans.plans_enums import PlanStatus
 from pecha_api.plans.series.series_model import Series
 from pecha_api.plans.series.series_metadata_model import SeriesMetadata
 from pecha_api.plans.plans_models import Plan
+
+
+def _series_active_plans_count_subquery():
+    return (
+        select(func.count(Plan.id))
+        .where(Plan.series_id == Series.id, Plan.deleted_at.is_(None))
+        .correlate(Series)
+        .scalar_subquery()
+    )
 
 
 def get_series_by_id(db: Session, series_id) -> Optional[Series]:
@@ -129,7 +139,10 @@ def get_series_paginated(
     order_by_field=None,
     order_desc: bool = True,
     author_id: Optional[UUID] = None,
-) -> Tuple[List[Series], int]:
+    language: Optional[str] = None,
+    status: Optional[PlanStatus] = None,
+    featured: Optional[bool] = None,
+) -> Tuple[List[Tuple[Series, int]], int]:
 
     filters = []
     if not include_deleted:
@@ -148,8 +161,23 @@ def get_series_paginated(
         )
     if author_id is not None:
         filters.append(Series.author_id == author_id)
+    if status is not None:
+        filters.append(Series.status == status)
+    if featured is not None:
+        filters.append(Series.featured == featured)
+    if language:
+        language_upper = language.upper()
+        filters.append(
+            exists(
+                select(1).where(
+                    SeriesMetadata.series_id == Series.id,
+                    SeriesMetadata.language == language_upper,
+                )
+            )
+        )
 
-    query = db.query(Series).options(selectinload(Series.metadata_entries))
+    plan_count = _series_active_plans_count_subquery().label("plan_count")
+    query = db.query(Series, plan_count).options(selectinload(Series.metadata_entries))
     if filters:
         query = query.filter(*filters)
 
@@ -163,5 +191,8 @@ def get_series_paginated(
     else:
         query = query.order_by(asc(order_by_field), Series.id)
 
-    rows = query.offset(skip).limit(limit).all()
+    rows = [
+        (series, int(count or 0))
+        for series, count in query.offset(skip).limit(limit).all()
+    ]
     return rows, total

--- a/pecha_api/plans/series/series_response_models.py
+++ b/pecha_api/plans/series/series_response_models.py
@@ -74,6 +74,18 @@ class SeriesPlanDTO(BaseModel):
     total_days: int = 0
 
 
+class SeriesListItemDTO(BaseModel):
+    id: UUID
+    metadata: List[SeriesMetadataDTO] = []
+    image: Optional[str] = None
+    image_key: Optional[str] = None
+    author_id: UUID
+    featured: bool
+    status: PlanStatus
+    plan_count: int = 0
+    total_days: int = 0
+
+
 class SeriesDTO(BaseModel):
     id: UUID
     metadata: List[SeriesMetadataDTO] = []
@@ -87,7 +99,7 @@ class SeriesDTO(BaseModel):
 
 
 class SeriesListResponse(BaseModel):
-    series: list[SeriesDTO]
+    series: list[SeriesListItemDTO]
     skip: int
     limit: int
     total: int

--- a/pecha_api/plans/series/series_service.py
+++ b/pecha_api/plans/series/series_service.py
@@ -20,6 +20,7 @@ from pecha_api.plans.series.series_response_models import (
     CreateSeriesRequest,
     UpdateSeriesRequest,
     SeriesDTO,
+    SeriesListItemDTO,
     SeriesMetadataDTO,
     SeriesPlanDTO,
     SeriesListResponse,
@@ -115,6 +116,20 @@ def _get_sorted_active_plans(plans) -> List:
     )
 
 
+def _series_to_list_item_dto(row: Series, plan_count: int = 0) -> SeriesListItemDTO:
+    return SeriesListItemDTO(
+        id=row.id,
+        metadata=_metadata_to_dtos(row.metadata_entries),
+        image=_generate_image_url(row.image),
+        image_key=row.image,
+        author_id=row.author_id,
+        featured=bool(row.featured),
+        status=_to_plan_status(row.status),
+        plan_count=plan_count,
+        total_days=0,
+    )
+
+
 def _series_to_dto(row: Series, include_plans: bool = False) -> SeriesDTO:
     plans_dtos = []
     series_total_days = 0
@@ -143,6 +158,7 @@ def get_filtered_series(
     search: Optional[str],
     skip: int,
     limit: int,
+    language: Optional[str] = None,
 ) -> SeriesListResponse:
     with SessionLocal() as db_session:
         rows, total = get_series_paginated(
@@ -153,9 +169,14 @@ def get_filtered_series(
             include_deleted=False,
             order_by_field=Series.created_at,
             order_desc=True,
+            language=language,
+            status=PlanStatus.PUBLISHED,
         )
 
-    series_dtos: List[SeriesDTO] = [_series_to_dto(row) for row in rows]
+    series_dtos: List[SeriesListItemDTO] = [
+        _series_to_list_item_dto(row, plan_count=plan_count)
+        for row, plan_count in rows
+    ]
     return SeriesListResponse(
         series=series_dtos,
         skip=skip,
@@ -167,7 +188,7 @@ def get_filtered_series(
 def get_series_detail(series_id: UUID) -> SeriesDTO:
     with SessionLocal() as db_session:
         row = get_series_by_id(db=db_session, series_id=series_id)
-    if not row:
+    if not row or _to_plan_status(row.status) != PlanStatus.PUBLISHED:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Series with id '{series_id}' not found",
@@ -179,9 +200,21 @@ def get_cms_filtered_series(
     search: Optional[str],
     skip: int,
     limit: int,
+    language: Optional[str] = None,
+    plan_status: Optional[PlanStatus] = None,
+    featured: Optional[bool] = None,
+    filter_author_id: Optional[UUID] = None,
 ) -> SeriesListResponse:
     current_author = validate_and_extract_author_details(token=token)
-    author_id = None if current_author.is_admin else current_author.id
+    if current_author.is_admin:
+        author_id = filter_author_id
+    else:
+        if filter_author_id is not None and filter_author_id != current_author.id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="You do not have permission to filter by another author's series",
+            )
+        author_id = current_author.id
 
     with SessionLocal() as db_session:
         rows, total = get_series_paginated(
@@ -193,9 +226,15 @@ def get_cms_filtered_series(
             order_by_field=Series.created_at,
             order_desc=True,
             author_id=author_id,
+            language=language,
+            status=plan_status,
+            featured=featured,
         )
 
-    series_dtos: List[SeriesDTO] = [_series_to_dto(row) for row in rows]
+    series_dtos: List[SeriesListItemDTO] = [
+        _series_to_list_item_dto(row, plan_count=plan_count)
+        for row, plan_count in rows
+    ]
     return SeriesListResponse(
         series=series_dtos,
         skip=skip,

--- a/pecha_api/plans/series/series_view.py
+++ b/pecha_api/plans/series/series_view.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, Depends, Query
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from starlette import status
 
+from pecha_api.plans.plans_enums import PlanStatus
 from pecha_api.plans.series.series_response_models import CreateSeriesRequest, UpdateSeriesRequest, SeriesDTO, SeriesListResponse
 from pecha_api.plans.series.series_service import create_new_series, update_existing_series, get_cms_filtered_series, get_cms_series_detail
 
@@ -53,6 +54,16 @@ async def get_cms_series_list(
     search: Annotated[
         Optional[str], Query(description="Search within serialized name JSON")
     ] = None,
+    language: Annotated[
+        Optional[str],
+        Query(description="Filter by series metadata language (e.g. 'en', 'bo', 'zh')"),
+    ] = None,
+    status: Annotated[Optional[PlanStatus], Query()] = None,
+    featured: Annotated[Optional[bool], Query()] = None,
+    author_id: Annotated[
+        Optional[UUID],
+        Query(description="Filter by author ID (admins only; non-admins are scoped to their own series)"),
+    ] = None,
     skip: Annotated[int, Query()] = 0,
     limit: Annotated[int, Query()] = 10,
 ):
@@ -61,6 +72,10 @@ async def get_cms_series_list(
         search=search,
         skip=skip,
         limit=limit,
+        language=language,
+        plan_status=status,
+        featured=featured,
+        filter_author_id=author_id,
     )
 
 

--- a/tests/plans/series/test_series_repository.py
+++ b/tests/plans/series/test_series_repository.py
@@ -5,6 +5,7 @@ import pytest
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from pecha_api.plans.plans_enums import PlanStatus
 from pecha_api.plans.series.series_model import Series
 from pecha_api.plans.plans_models import Plan
 from pecha_api.plans.series.series_repository import (
@@ -19,13 +20,16 @@ def _make_session_mock() -> Session:
     return MagicMock(spec=Session)
 
 
-def _paginated_query_chain(rows, total, *, with_filter=True):
+def _paginated_query_chain(rows, total, *, with_filter=True, plan_counts=None):
+    if plan_counts is None:
+        plan_counts = [0] * len(rows)
+    query_rows = list(zip(rows, plan_counts))
     query_mock = MagicMock()
     options_mock = MagicMock()
     target = options_mock.filter.return_value if with_filter else options_mock
     target.count.return_value = total
     ordered = MagicMock()
-    ordered.offset.return_value.limit.return_value.all.return_value = rows
+    ordered.offset.return_value.limit.return_value.all.return_value = query_rows
     target.order_by.return_value = ordered
     query_mock.options.return_value = options_mock
     return query_mock
@@ -63,8 +67,9 @@ def test_get_series_paginated_no_search_returns_rows_and_total():
     rows, total = get_series_paginated(db=db, search=None, skip=0, limit=10)
 
     assert total == 2
-    assert rows == [row1, row2]
-    db.query.assert_called_once_with(Series)
+    assert rows == [(row1, 0), (row2, 0)]
+    db.query.assert_called_once()
+    assert db.query.call_args.args[0] is Series
     db.query.return_value.options.return_value.filter.return_value.count.assert_called_once()
     db.query.return_value.options.return_value.filter.return_value.order_by.assert_called_once()
 
@@ -80,7 +85,7 @@ def test_get_series_paginated_with_include_deleted():
     )
 
     assert total == 1
-    assert rows == [row]
+    assert rows == [(row, 0)]
     db.query.return_value.options.return_value.filter.assert_not_called()
 
 
@@ -100,7 +105,7 @@ def test_get_series_paginated_with_custom_ordering():
     )
 
     assert total == 1
-    assert rows == [row]
+    assert rows == [(row, 0)]
     db.query.return_value.options.return_value.filter.return_value.order_by.assert_called_once()
 
 
@@ -133,12 +138,61 @@ def test_get_series_paginated_with_author_id_applies_filter():
         db=db, search=None, skip=0, limit=10, author_id=author_id
     )
 
-    assert rows == [row]
+    assert rows == [(row, 0)]
     assert total == 1
     filtered = db.query.return_value.options.return_value.filter
     assert filtered.call_count == 1
     filter_args = filtered.call_args[0]
     assert len(filter_args) == 2
+
+
+def test_get_series_paginated_with_language_applies_metadata_filter():
+    db = _make_session_mock()
+
+    db.query.return_value = _paginated_query_chain([], 0)
+
+    rows, total = get_series_paginated(db=db, search=None, skip=0, limit=10, language="bo")
+
+    assert rows == []
+    assert total == 0
+    filtered = db.query.return_value.options.return_value.filter
+    assert filtered.call_count == 1
+    filter_args = filtered.call_args[0]
+    assert len(filter_args) == 2
+
+
+def test_get_series_paginated_returns_series_with_plan_count():
+    db = _make_session_mock()
+    row = MagicMock(spec=Series)
+
+    db.query.return_value = _paginated_query_chain([row], 1, plan_counts=[5])
+
+    rows, total = get_series_paginated(db=db, search=None, skip=0, limit=10)
+
+    assert total == 1
+    assert rows == [(row, 5)]
+
+
+def test_get_series_paginated_with_status_and_featured_applies_filters():
+    db = _make_session_mock()
+
+    db.query.return_value = _paginated_query_chain([], 0)
+
+    rows, total = get_series_paginated(
+        db=db,
+        search=None,
+        skip=0,
+        limit=10,
+        status=PlanStatus.PUBLISHED,
+        featured=True,
+    )
+
+    assert rows == []
+    assert total == 0
+    filtered = db.query.return_value.options.return_value.filter
+    assert filtered.call_count == 1
+    filter_args = filtered.call_args[0]
+    assert len(filter_args) == 3
 
 
 def test_get_series_by_id_returns_series_when_found():

--- a/tests/plans/series/test_series_service.py
+++ b/tests/plans/series/test_series_service.py
@@ -22,6 +22,7 @@ from pecha_api.plans.series.series_service import (
 from pecha_api.plans.series.series_response_models import (
     CreateSeriesRequest,
     UpdateSeriesRequest,
+    SeriesListItemDTO,
     SeriesListResponse,
     SeriesMetadataInput,
 )
@@ -60,7 +61,7 @@ def test_get_filtered_series_maps_rows_to_response():
 
     with patch("pecha_api.plans.series.series_service.SessionLocal") as mock_session_local, patch(
         "pecha_api.plans.series.series_service.get_series_paginated",
-        return_value=([row], 1),
+        return_value=([(row, 3)], 1),
     ) as mock_repo:
         _session_local_context(mock_session_local)
 
@@ -74,6 +75,7 @@ def test_get_filtered_series_maps_rows_to_response():
     assert call_kwargs["include_deleted"] is False
     assert call_kwargs["order_by_field"] == Series.created_at
     assert call_kwargs["order_desc"] is True
+    assert call_kwargs["status"] == PlanStatus.PUBLISHED
 
     assert isinstance(result, SeriesListResponse)
     assert result.skip == 2
@@ -90,6 +92,9 @@ def test_get_filtered_series_maps_rows_to_response():
     assert dto.author_id == author_id
     assert dto.featured is True
     assert dto.status == PlanStatus.DRAFT
+    assert dto.plan_count == 3
+    assert isinstance(dto, SeriesListItemDTO)
+    assert "plans" not in SeriesListItemDTO.model_fields
 
 
 def test_get_filtered_series_presigns_image_when_key_present():
@@ -104,7 +109,7 @@ def test_get_filtered_series_presigns_image_when_key_present():
 
     with patch("pecha_api.plans.series.series_service.SessionLocal") as mock_session_local, patch(
         "pecha_api.plans.series.series_service.get_series_paginated",
-        return_value=([row], 1),
+        return_value=([(row, 0)], 1),
     ), patch("pecha_api.plans.series.series_service.get", return_value="test-bucket"), patch(
         "pecha_api.plans.series.series_service.generate_presigned_access_url",
         return_value="https://signed.example/x.jpg",
@@ -256,6 +261,24 @@ def test_get_series_detail_raises_404_when_not_found():
     assert str(series_id) in exc.value.detail
 
 
+def test_get_series_detail_raises_404_when_not_published():
+    series_id = uuid.uuid4()
+    row = MagicMock()
+    row.id = series_id
+    row.status = PlanStatus.DRAFT
+
+    with patch("pecha_api.plans.series.series_service.SessionLocal") as mock_session_local, patch(
+        "pecha_api.plans.series.series_service.get_series_by_id",
+        return_value=row,
+    ):
+        _session_local_context(mock_session_local)
+
+        with pytest.raises(HTTPException) as exc:
+            get_series_detail(series_id=series_id)
+
+    assert exc.value.status_code == status.HTTP_404_NOT_FOUND
+
+
 def test_get_series_detail_returns_dto_without_plans():
     series_id = uuid.uuid4()
     row = MagicMock()
@@ -264,7 +287,7 @@ def test_get_series_detail_returns_dto_without_plans():
     row.image = None
     row.author_id = uuid.uuid4()
     row.featured = False
-    row.status = PlanStatus.DRAFT
+    row.status = PlanStatus.PUBLISHED
     row.plans = []
 
     with patch("pecha_api.plans.series.series_service.SessionLocal") as mock_session_local, patch(
@@ -400,7 +423,7 @@ def test_get_series_detail_includes_total_days_for_each_plan():
     row.image = None
     row.author_id = author_id
     row.featured = False
-    row.status = PlanStatus.DRAFT
+    row.status = PlanStatus.PUBLISHED
     row.plans = [plan_a, plan_b]
 
     with patch("pecha_api.plans.series.series_service.SessionLocal") as mock_session_local, patch(
@@ -442,7 +465,7 @@ def test_get_series_detail_total_days_zero_when_no_items():
     row.image = None
     row.author_id = author_id
     row.featured = False
-    row.status = PlanStatus.DRAFT
+    row.status = PlanStatus.PUBLISHED
     row.plans = [plan_empty]
 
     with patch("pecha_api.plans.series.series_service.SessionLocal") as mock_session_local, patch(
@@ -468,7 +491,7 @@ def test_get_series_detail_total_days_zero_when_no_plans():
     row.image = None
     row.author_id = author_id
     row.featured = False
-    row.status = PlanStatus.DRAFT
+    row.status = PlanStatus.PUBLISHED
     row.plans = []
 
     with patch("pecha_api.plans.series.series_service.SessionLocal") as mock_session_local, patch(
@@ -509,7 +532,7 @@ def test_get_series_detail_handles_plan_without_items_attribute():
     row.image = None
     row.author_id = author_id
     row.featured = False
-    row.status = PlanStatus.DRAFT
+    row.status = PlanStatus.PUBLISHED
     row.plans = [plan_no_items]
 
     with patch("pecha_api.plans.series.series_service.SessionLocal") as mock_session_local, patch(
@@ -1277,7 +1300,7 @@ def test_get_cms_filtered_series_scopes_to_current_author_when_not_admin():
     with patch("pecha_api.plans.series.series_service.SessionLocal") as mock_session_local, \
          patch("pecha_api.plans.series.series_service.validate_and_extract_author_details", return_value=mock_author), \
          patch("pecha_api.plans.series.series_service.get_series_paginated",
-               return_value=([row], 1)) as mock_repo:
+               return_value=([(row, 2)], 1)) as mock_repo:
         _session_local_context(mock_session_local)
 
         result = get_cms_filtered_series(token="dummy", search=None, skip=0, limit=10)
@@ -1293,6 +1316,7 @@ def test_get_cms_filtered_series_scopes_to_current_author_when_not_admin():
     assert isinstance(result, SeriesListResponse)
     assert result.total == 1
     assert len(result.series) == 1
+    assert result.series[0].plan_count == 2
 
 
 def test_get_cms_filtered_series_admin_sees_all_authors():
@@ -1311,7 +1335,7 @@ def test_get_cms_filtered_series_admin_sees_all_authors():
     with patch("pecha_api.plans.series.series_service.SessionLocal") as mock_session_local, \
          patch("pecha_api.plans.series.series_service.validate_and_extract_author_details", return_value=mock_admin), \
          patch("pecha_api.plans.series.series_service.get_series_paginated",
-               return_value=([row], 1)) as mock_repo:
+               return_value=([(row, 0)], 1)) as mock_repo:
         _session_local_context(mock_session_local)
 
         get_cms_filtered_series(token="dummy", search=None, skip=0, limit=10)
@@ -1337,6 +1361,79 @@ def test_get_cms_filtered_series_passes_search_and_pagination():
     assert call_kwargs["skip"] == 5
     assert call_kwargs["limit"] == 20
     assert call_kwargs["author_id"] == author_id
+
+
+def test_get_filtered_series_passes_language_to_repository():
+    with patch("pecha_api.plans.series.series_service.SessionLocal") as mock_session_local, \
+         patch("pecha_api.plans.series.series_service.get_series_paginated",
+               return_value=([], 0)) as mock_repo:
+        _session_local_context(mock_session_local)
+
+        get_filtered_series(search=None, skip=0, limit=10, language="zh")
+
+    call_kwargs = mock_repo.call_args.kwargs
+    assert call_kwargs["language"] == "zh"
+    assert call_kwargs["status"] == PlanStatus.PUBLISHED
+
+
+def test_get_cms_filtered_series_passes_language_to_repository():
+    author_id = uuid.uuid4()
+    mock_author = _make_mock_author(author_id, is_admin=False)
+
+    with patch("pecha_api.plans.series.series_service.SessionLocal") as mock_session_local, \
+         patch("pecha_api.plans.series.series_service.validate_and_extract_author_details", return_value=mock_author), \
+         patch("pecha_api.plans.series.series_service.get_series_paginated",
+               return_value=([], 0)) as mock_repo:
+        _session_local_context(mock_session_local)
+
+        get_cms_filtered_series(token="dummy", search=None, skip=0, limit=10, language="en")
+
+    assert mock_repo.call_args.kwargs["language"] == "en"
+
+
+def test_get_cms_filtered_series_admin_passes_status_featured_and_author_filters():
+    admin_id = uuid.uuid4()
+    filter_author_id = uuid.uuid4()
+    mock_admin = _make_mock_author(admin_id, is_admin=True)
+
+    with patch("pecha_api.plans.series.series_service.SessionLocal") as mock_session_local, \
+         patch("pecha_api.plans.series.series_service.validate_and_extract_author_details", return_value=mock_admin), \
+         patch("pecha_api.plans.series.series_service.get_series_paginated",
+               return_value=([], 0)) as mock_repo:
+        _session_local_context(mock_session_local)
+
+        get_cms_filtered_series(
+            token="dummy",
+            search=None,
+            skip=0,
+            limit=10,
+            plan_status=PlanStatus.DRAFT,
+            featured=False,
+            filter_author_id=filter_author_id,
+        )
+
+    call_kwargs = mock_repo.call_args.kwargs
+    assert call_kwargs["author_id"] == filter_author_id
+    assert call_kwargs["status"] == PlanStatus.DRAFT
+    assert call_kwargs["featured"] is False
+
+
+def test_get_cms_filtered_series_non_admin_cannot_filter_by_other_author():
+    author_id = uuid.uuid4()
+    other_author_id = uuid.uuid4()
+    mock_author = _make_mock_author(author_id, is_admin=False)
+
+    with patch("pecha_api.plans.series.series_service.validate_and_extract_author_details", return_value=mock_author):
+        with pytest.raises(HTTPException) as exc_info:
+            get_cms_filtered_series(
+                token="dummy",
+                search=None,
+                skip=0,
+                limit=10,
+                filter_author_id=other_author_id,
+            )
+
+    assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN
 
 
 # ---------------------------------------------------------------------------
@@ -1447,7 +1544,7 @@ def test_get_filtered_series_handles_plain_string_status_and_language():
 
     with patch("pecha_api.plans.series.series_service.SessionLocal") as mock_session_local, patch(
         "pecha_api.plans.series.series_service.get_series_paginated",
-        return_value=([row], 1),
+        return_value=([(row, 0)], 1),
     ):
         _session_local_context(mock_session_local)
 
@@ -1476,7 +1573,7 @@ def test_get_filtered_series_metadata_uses_string_language():
 
     with patch("pecha_api.plans.series.series_service.SessionLocal") as mock_session_local, patch(
         "pecha_api.plans.series.series_service.get_series_paginated",
-        return_value=([row], 1),
+        return_value=([(row, 0)], 1),
     ):
         _session_local_context(mock_session_local)
 

--- a/tests/plans/series/test_series_views.py
+++ b/tests/plans/series/test_series_views.py
@@ -10,6 +10,7 @@ from pecha_api.app import api
 from pecha_api.plans.plans_enums import PlanStatus, LanguageCode, DifficultyLevel
 from pecha_api.plans.series.series_response_models import (
     SeriesDTO,
+    SeriesListItemDTO,
     SeriesListResponse,
     SeriesPlanDTO,
     SeriesMetadataDTO,
@@ -60,8 +61,19 @@ def sample_series_dto():
 
 @pytest.fixture
 def sample_series_list_response(sample_series_dto):
+    list_item = SeriesListItemDTO(
+        id=sample_series_dto.id,
+        metadata=sample_series_dto.metadata,
+        image=sample_series_dto.image,
+        image_key=sample_series_dto.image_key,
+        author_id=sample_series_dto.author_id,
+        featured=sample_series_dto.featured,
+        status=sample_series_dto.status,
+        plan_count=2,
+        total_days=0,
+    )
     return SeriesListResponse(
-        series=[sample_series_dto],
+        series=[list_item],
         skip=0,
         limit=10,
         total=1,
@@ -78,7 +90,7 @@ def test_get_series_list_success(sample_series_list_response):
         assert response.status_code == status.HTTP_200_OK
         data = response.json()
 
-        mock_service.assert_called_once_with(search=None, skip=0, limit=10)
+        mock_service.assert_called_once_with(search=None, skip=0, limit=10, language=None)
 
         assert "series" in data
         assert data["skip"] == 0
@@ -108,7 +120,7 @@ def test_get_series_list_with_search_pagination(sample_series_dto):
         assert response.status_code == status.HTTP_200_OK
         data = response.json()
 
-        mock_service.assert_called_once_with(search="meditation", skip=2, limit=5)
+        mock_service.assert_called_once_with(search="meditation", skip=2, limit=5, language=None)
 
         assert data["series"] == []
         assert data["skip"] == 2
@@ -291,9 +303,9 @@ def test_get_series_by_id_includes_total_days_in_response():
         assert data["plans"][1]["total_days"] == 3
 
 
-def test_get_series_list_includes_total_days_zero():
+def test_get_series_list_returns_plan_count_not_plans():
     series_id = uuid.uuid4()
-    series_dto = SeriesDTO(
+    list_item = SeriesListItemDTO(
         id=series_id,
         metadata=[_metadata("Series without plans")],
         image=None,
@@ -301,12 +313,12 @@ def test_get_series_list_includes_total_days_zero():
         author_id=uuid.uuid4(),
         featured=False,
         status=PlanStatus.DRAFT,
-        plans=[],
+        plan_count=0,
         total_days=0,
     )
 
     series_list_response = SeriesListResponse(
-        series=[series_dto],
+        series=[list_item],
         skip=0,
         limit=10,
         total=1,
@@ -322,7 +334,9 @@ def test_get_series_list_includes_total_days_zero():
         data = response.json()
 
         assert len(data["series"]) == 1
+        assert data["series"][0]["plan_count"] == 0
         assert data["series"][0]["total_days"] == 0
+        assert "plans" not in data["series"][0]
 
 
 def test_update_series_accepts_empty_body():
@@ -407,7 +421,14 @@ def test_get_cms_series_list_success(sample_series_list_response):
         data = response.json()
 
         mock_service.assert_called_once_with(
-            token="dummy", search=None, skip=0, limit=10
+            token="dummy",
+            search=None,
+            skip=0,
+            limit=10,
+            language=None,
+            plan_status=None,
+            featured=None,
+            filter_author_id=None,
         )
 
         assert data["total"] == 1
@@ -428,7 +449,14 @@ def test_get_cms_series_list_passes_query_params(sample_series_dto):
 
         assert response.status_code == status.HTTP_200_OK
         mock_service.assert_called_once_with(
-            token="dummy", search="meditation", skip=2, limit=5
+            token="dummy",
+            search="meditation",
+            skip=2,
+            limit=5,
+            language=None,
+            plan_status=None,
+            featured=None,
+            filter_author_id=None,
         )
 
 


### PR DESCRIPTION
- Added language filtering to the series retrieval endpoints, allowing users to filter series by metadata language.
- Introduced a plan count in the series response models to provide better insights into the number of active plans associated with each series.
- Updated relevant services and repository methods to support the new filtering and response structure.
- Enhanced tests to cover the new functionality, ensuring proper behavior of the series retrieval with language and plan count features.