### PR TITLE
feat: add language filtering to series plans and update related endpo…

### DIFF
--- a/pecha_api/plans/series/series_service.py
+++ b/pecha_api/plans/series/series_service.py
@@ -113,7 +113,11 @@ def _plan_to_dto(plan) -> SeriesPlanDTO:
     )
 
 
-def _get_sorted_active_plans(plans, published_only: bool = False) -> List:
+def _get_sorted_active_plans(
+    plans,
+    published_only: bool = False,
+    language: Optional[str] = None,
+) -> List:
     if not plans:
         return []
     active_plans = [plan for plan in plans if plan.deleted_at is None]
@@ -121,6 +125,12 @@ def _get_sorted_active_plans(plans, published_only: bool = False) -> List:
         active_plans = [
             plan for plan in active_plans
             if _to_plan_status(plan.status) == PlanStatus.PUBLISHED
+        ]
+    if language:
+        language_upper = language.upper()
+        active_plans = [
+            plan for plan in active_plans
+            if _language_value(plan.language).upper() == language_upper
         ]
     return sorted(
         active_plans,
@@ -142,12 +152,21 @@ def _series_to_list_item_dto(row: Series, plan_count: int = 0) -> SeriesListItem
     )
 
 
-def _series_to_dto(row: Series, include_plans: bool = False, published_only: bool = False) -> SeriesDTO:
+def _series_to_dto(
+    row: Series,
+    include_plans: bool = False,
+    published_only: bool = False,
+    plan_language: Optional[str] = None,
+) -> SeriesDTO:
     plans_dtos = []
     series_total_days = 0
 
     if include_plans:
-        sorted_plans = _get_sorted_active_plans(row.plans, published_only=published_only)
+        sorted_plans = _get_sorted_active_plans(
+            row.plans,
+            published_only=published_only,
+            language=plan_language,
+        )
         for plan in sorted_plans:
             plan_dto = _plan_to_dto(plan)
             plans_dtos.append(plan_dto)
@@ -256,7 +275,11 @@ def get_cms_filtered_series(
     )
 
 
-def get_cms_series_detail(token: str, series_id: UUID) -> SeriesDTO:
+def get_cms_series_detail(
+    token: str,
+    series_id: UUID,
+    language: Optional[str] = None,
+) -> SeriesDTO:
     current_author = validate_and_extract_author_details(token=token)
 
     with SessionLocal() as db_session:
@@ -273,7 +296,7 @@ def get_cms_series_detail(token: str, series_id: UUID) -> SeriesDTO:
             detail="You do not have permission to view this series",
         )
 
-    return _series_to_dto(row, include_plans=True)
+    return _series_to_dto(row, include_plans=True, plan_language=language)
 
 def _validate_plan_ids(
     db,

--- a/pecha_api/plans/series/series_view.py
+++ b/pecha_api/plans/series/series_view.py
@@ -132,8 +132,13 @@ async def get_cms_series_list(
 async def get_cms_series(
     series_id: UUID,
     authentication_credential: Annotated[HTTPAuthorizationCredentials, Depends(oauth2_scheme)],
+    language: Annotated[
+        Optional[str],
+        Query(description="Filter plans by language (e.g. 'en', 'bo', 'zh')"),
+    ] = None,
 ):
     return get_cms_series_detail(
         token=authentication_credential.credentials,
         series_id=series_id,
+        language=language,
     )

--- a/tests/plans/series/test_series_service.py
+++ b/tests/plans/series/test_series_service.py
@@ -1589,6 +1589,63 @@ def test_get_cms_series_detail_admin_can_view_other_author_series():
     assert dto.author_id == other_author_id
 
 
+def test_get_cms_series_detail_filters_plans_by_language():
+    series_id = uuid.uuid4()
+    author_id = uuid.uuid4()
+
+    plan_en = MagicMock()
+    plan_en.deleted_at = None
+    plan_en.display_order = 0
+    plan_en.id = uuid.uuid4()
+    plan_en.title = "English plan"
+    plan_en.description = None
+    plan_en.language = LanguageCode.EN
+    plan_en.difficulty_level = None
+    plan_en.image_url = None
+    plan_en.tag_list = []
+    plan_en.status = PlanStatus.DRAFT
+    plan_en.featured = False
+    plan_en.start_date = None
+    plan_en.items = []
+
+    plan_bo = MagicMock()
+    plan_bo.deleted_at = None
+    plan_bo.display_order = 1
+    plan_bo.id = uuid.uuid4()
+    plan_bo.title = "Tibetan plan"
+    plan_bo.description = None
+    plan_bo.language = LanguageCode.BO
+    plan_bo.difficulty_level = None
+    plan_bo.image_url = None
+    plan_bo.tag_list = []
+    plan_bo.status = PlanStatus.DRAFT
+    plan_bo.featured = False
+    plan_bo.start_date = None
+    plan_bo.items = []
+
+    row = MagicMock()
+    row.id = series_id
+    row.metadata_entries = []
+    row.image = None
+    row.author_id = author_id
+    row.featured = False
+    row.status = PlanStatus.DRAFT
+    row.plans = [plan_en, plan_bo]
+
+    mock_author = _make_mock_author(author_id, is_admin=False)
+
+    with patch("pecha_api.plans.series.series_service.SessionLocal") as mock_session_local, \
+         patch("pecha_api.plans.series.series_service.validate_and_extract_author_details", return_value=mock_author), \
+         patch("pecha_api.plans.series.series_service.get_series_by_id", return_value=row):
+        _session_local_context(mock_session_local)
+
+        dto = get_cms_series_detail(token="dummy", series_id=series_id, language="bo")
+
+    assert len(dto.plans) == 1
+    assert dto.plans[0].id == plan_bo.id
+    assert dto.plans[0].language == "BO"
+
+
 def test_get_filtered_series_handles_plain_string_status_and_language():
     row = MagicMock()
     row.id = uuid.uuid4()

--- a/tests/plans/series/test_series_views.py
+++ b/tests/plans/series/test_series_views.py
@@ -473,7 +473,7 @@ def test_get_cms_series_by_id_success(sample_series_dto):
 
         assert response.status_code == status.HTTP_200_OK
         mock_detail.assert_called_once_with(
-            token="dummy", series_id=series_id
+            token="dummy", series_id=series_id, language=None
         )
 
         data = response.json()
@@ -512,6 +512,24 @@ def test_get_cms_series_by_id_forbidden():
         )
 
     assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_get_cms_series_by_id_passes_language_param(sample_series_dto):
+    series_id = sample_series_dto.id
+    with patch(
+        "pecha_api.plans.series.series_view.get_cms_series_detail",
+        return_value=sample_series_dto,
+    ) as mock_detail:
+        response = client.get(
+            f"/cms/series/{series_id}",
+            params={"language": "bo"},
+            headers={"Authorization": "Bearer dummy"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        mock_detail.assert_called_once_with(
+            token="dummy", series_id=series_id, language="bo"
+        )
 
 
 def test_delete_series_success():


### PR DESCRIPTION
…ints

- Enhanced `_get_sorted_active_plans` to support filtering plans by language.
- Updated `_series_to_dto` to pass the language parameter for plan filtering.
- Modified `get_cms_series_detail` to accept a language parameter.
- Adjusted `get_cms_series` view to include language in the request.
- Added tests to verify language filtering functionality in series detail retrieval.