### PR TITLE
feat: enhance plan creation and update with series attachment support

### DIFF
--- a/pecha_api/plans/cms/cms_plans_service.py
+++ b/pecha_api/plans/cms/cms_plans_service.py
@@ -5,6 +5,7 @@ from pecha_api.plans.plans_models import Plan
 from pecha_api.plans.items.plan_items_models import PlanItem
 from pecha_api.plans.users.plan_users_models import UserPlanProgress
 from pecha_api.plans.cms.cms_plans_repository import save_plan, get_plan_by_id, get_plans_by_author_id, update_plan
+from pecha_api.plans.series.series_repository import get_series_by_id
 from pecha_api.plans.tags.tag_helpers import tags_to_summary_dtos
 from pecha_api.plans.tags.tag_repository import set_plan_tags
 from pecha_api.plans.tags.tag_service import validate_tag_ids
@@ -148,6 +149,79 @@ async def get_filtered_plans(token: str, search: Optional[str], sort_by: str, so
     return PlansResponse(plans=plans, skip=skip, limit=limit, total=plan_repository_response.total)
 
 
+def _get_next_display_order_in_series(db: Session, series_id: UUID) -> int:
+    result = db.query(func.max(Plan.display_order)).filter(
+        Plan.series_id == series_id,
+        Plan.deleted_at.is_(None),
+    ).scalar()
+    return 0 if result is None else result + 1
+
+
+def _validate_series_for_plan_attachment(
+    db: Session,
+    series_id: UUID,
+    author_id: UUID,
+    is_admin: bool,
+) -> None:
+    series = get_series_by_id(db=db, series_id=series_id)
+    if not series:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Series with id '{series_id}' not found",
+        )
+    if not is_admin and series.author_id != author_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You do not have permission to attach plans to this series",
+        )
+
+
+def _apply_series_attachment_to_plan(
+    db: Session,
+    plan: Plan,
+    series_id: UUID,
+    author_id: UUID,
+    is_admin: bool,
+    display_order: Optional[int] = None,
+) -> None:
+    if plan.series_id is not None and plan.series_id != series_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Plan is already attached to another series",
+        )
+    _validate_series_for_plan_attachment(db, series_id, author_id, is_admin)
+    plan.series_id = series_id
+    plan.display_order = (
+        display_order
+        if display_order is not None
+        else _get_next_display_order_in_series(db, series_id)
+    )
+
+
+def _detach_plan_from_series(plan: Plan) -> None:
+    plan.series_id = None
+    plan.display_order = None
+
+
+def _apply_create_plan_series_fields(
+    db: Session,
+    plan: Plan,
+    create_plan_request: CreatePlanRequest,
+    author_id: UUID,
+    is_admin: bool,
+) -> None:
+    if not create_plan_request.series_id:
+        return
+    _apply_series_attachment_to_plan(
+        db=db,
+        plan=plan,
+        series_id=create_plan_request.series_id,
+        author_id=author_id,
+        is_admin=is_admin,
+        display_order=create_plan_request.display_order,
+    )
+
+
 def create_new_plan(token: str, create_plan_request: CreatePlanRequest) -> PlanDTO:
 
     current_author = validate_and_extract_author_details(token=token)
@@ -171,6 +245,13 @@ def create_new_plan(token: str, create_plan_request: CreatePlanRequest) -> PlanD
     with SessionLocal() as db_session:
         if create_plan_request.tag_ids:
             validate_tag_ids(db=db_session, tag_ids=create_plan_request.tag_ids)
+        _apply_create_plan_series_fields(
+            db=db_session,
+            plan=new_plan_model,
+            create_plan_request=create_plan_request,
+            author_id=current_author.id,
+            is_admin=bool(current_author.is_admin),
+        )
         saved_plan = save_plan(db=db_session, plan=new_plan_model)
         if create_plan_request.tag_ids:
             set_plan_tags(db=db_session, plan=saved_plan, tag_ids=create_plan_request.tag_ids)
@@ -337,6 +418,25 @@ async def update_plan_details(token: str, plan_id: UUID, update_plan_request: Up
         if update_plan_request.tag_ids is not None:
             validate_tag_ids(db=db, tag_ids=update_plan_request.tag_ids)
             set_plan_tags(db=db, plan=plan, tag_ids=update_plan_request.tag_ids)
+
+        if "series_id" in update_plan_request.model_fields_set:
+            if update_plan_request.series_id is None:
+                _detach_plan_from_series(plan)
+            else:
+                _apply_series_attachment_to_plan(
+                    db=db,
+                    plan=plan,
+                    series_id=update_plan_request.series_id,
+                    author_id=author_details.id,
+                    is_admin=bool(author_details.is_admin),
+                    display_order=update_plan_request.display_order,
+                )
+        elif (
+            "display_order" in update_plan_request.model_fields_set
+            and update_plan_request.display_order is not None
+            and plan.series_id is not None
+        ):
+            plan.display_order = update_plan_request.display_order
         
         plan.updated_at = datetime.now(timezone.utc)
         plan.updated_by = author_details.email

--- a/pecha_api/plans/plans_response_models.py
+++ b/pecha_api/plans/plans_response_models.py
@@ -16,6 +16,8 @@ class CreatePlanRequest(BaseModel):
     image_url: Optional[str] = None
     tag_ids: Optional[List[UUID]] = []
     start_date: Optional[datetime] = None
+    series_id: Optional[UUID] = None
+    display_order: Optional[int] = None
 
 class UpdatePlanRequest(BaseModel):
     title: Optional[str] = None
@@ -26,6 +28,8 @@ class UpdatePlanRequest(BaseModel):
     image_url: Optional[str] = None
     tag_ids: Optional[List[UUID]] = None
     start_date: Optional[datetime] = None
+    series_id: Optional[UUID] = None
+    display_order: Optional[int] = None
 
 class PlanStatusUpdate(BaseModel):
     status: PlanStatus

--- a/tests/plans/cms/test_plan_service.py
+++ b/tests/plans/cms/test_plan_service.py
@@ -253,6 +253,138 @@ def test_create_new_plan_success():
         assert response.start_date == request.start_date
 
 
+def test_create_new_plan_with_series_id():
+    series_id = uuid.uuid4()
+    request = CreatePlanRequest(
+        title="Series Plan",
+        description="Attached to a series on create.",
+        difficulty_level=DifficultyLevel.BEGINNER,
+        total_days=3,
+        language="en",
+        series_id=series_id,
+        display_order=2,
+    )
+
+    saved_plan = MagicMock()
+    saved_plan.id = uuid.uuid4()
+    saved_plan.title = request.title
+    saved_plan.description = request.description
+    saved_plan.difficulty_level = request.difficulty_level
+    saved_plan.image_url = None
+    saved_plan.tag_list = []
+    saved_plan.language = request.language
+    saved_plan.status = PlanStatus.DRAFT
+    saved_plan.start_date = None
+
+    mock_series = MagicMock()
+    mock_series.author_id = uuid.uuid4()
+
+    with patch("pecha_api.plans.cms.cms_plans_service.SessionLocal") as mock_session_local, \
+        patch("pecha_api.plans.cms.cms_plans_service.save_plan") as mock_save_plan, \
+        patch("pecha_api.plans.cms.cms_plans_service.save_plan_items") as mock_save_plan_items, \
+        patch("pecha_api.plans.cms.cms_plans_service.get_plan_progress") as mock_get_plan_progress, \
+        patch("pecha_api.plans.cms.cms_plans_service.validate_and_extract_author_details") as mock_validate_author, \
+        patch("pecha_api.plans.cms.cms_plans_service.get_series_by_id") as mock_get_series:
+        db_session = _mock_session_local(mock_session_local)
+        mock_save_plan.return_value = saved_plan
+        mock_save_plan_items.return_value = [MagicMock() for _ in range(request.total_days)]
+        mock_get_plan_progress.return_value = []
+        mock_get_series.return_value = mock_series
+
+        author = MagicMock()
+        author.id = mock_series.author_id
+        author.email = "author@example.com"
+        author.is_admin = False
+        mock_validate_author.return_value = author
+
+        create_new_plan(token="dummy", create_plan_request=request)
+
+        created_plan_model = mock_save_plan.call_args.kwargs["plan"]
+        assert created_plan_model.series_id == series_id
+        assert created_plan_model.display_order == 2
+        mock_get_series.assert_called_once_with(db=db_session, series_id=series_id)
+
+
+def test_create_new_plan_with_series_id_auto_display_order():
+    series_id = uuid.uuid4()
+    request = CreatePlanRequest(
+        title="Series Plan",
+        description="Auto display order.",
+        difficulty_level=DifficultyLevel.BEGINNER,
+        total_days=1,
+        language="en",
+        series_id=series_id,
+    )
+
+    saved_plan = MagicMock()
+    saved_plan.id = uuid.uuid4()
+    saved_plan.title = request.title
+    saved_plan.description = request.description
+    saved_plan.difficulty_level = request.difficulty_level
+    saved_plan.image_url = None
+    saved_plan.tag_list = []
+    saved_plan.language = request.language
+    saved_plan.status = PlanStatus.DRAFT
+    saved_plan.start_date = None
+
+    mock_series = MagicMock()
+    mock_series.author_id = uuid.uuid4()
+
+    with patch("pecha_api.plans.cms.cms_plans_service.SessionLocal") as mock_session_local, \
+        patch("pecha_api.plans.cms.cms_plans_service.save_plan") as mock_save_plan, \
+        patch("pecha_api.plans.cms.cms_plans_service.save_plan_items") as mock_save_plan_items, \
+        patch("pecha_api.plans.cms.cms_plans_service.get_plan_progress") as mock_get_plan_progress, \
+        patch("pecha_api.plans.cms.cms_plans_service.validate_and_extract_author_details") as mock_validate_author, \
+        patch("pecha_api.plans.cms.cms_plans_service.get_series_by_id") as mock_get_series:
+        db_session = _mock_session_local(mock_session_local)
+        db_session.query.return_value.filter.return_value.scalar.return_value = 4
+        mock_save_plan.return_value = saved_plan
+        mock_save_plan_items.return_value = [MagicMock()]
+        mock_get_plan_progress.return_value = []
+        mock_get_series.return_value = mock_series
+
+        author = MagicMock()
+        author.id = mock_series.author_id
+        author.email = "author@example.com"
+        author.is_admin = False
+        mock_validate_author.return_value = author
+
+        create_new_plan(token="dummy", create_plan_request=request)
+
+        created_plan_model = mock_save_plan.call_args.kwargs["plan"]
+        assert created_plan_model.series_id == series_id
+        assert created_plan_model.display_order == 5
+
+
+def test_create_new_plan_series_not_found():
+    series_id = uuid.uuid4()
+    request = CreatePlanRequest(
+        title="Series Plan",
+        description="Missing series.",
+        difficulty_level=DifficultyLevel.BEGINNER,
+        total_days=1,
+        language="en",
+        series_id=series_id,
+    )
+
+    with patch("pecha_api.plans.cms.cms_plans_service.SessionLocal") as mock_session_local, \
+        patch("pecha_api.plans.cms.cms_plans_service.validate_and_extract_author_details") as mock_validate_author, \
+        patch("pecha_api.plans.cms.cms_plans_service.get_series_by_id") as mock_get_series:
+        _mock_session_local(mock_session_local)
+        mock_get_series.return_value = None
+
+        author = MagicMock()
+        author.id = uuid.uuid4()
+        author.email = "author@example.com"
+        author.is_admin = False
+        mock_validate_author.return_value = author
+
+        with pytest.raises(HTTPException) as exc_info:
+            create_new_plan(token="dummy", create_plan_request=request)
+
+        assert exc_info.value.status_code == 404
+        assert str(series_id) in exc_info.value.detail
+
 
 @pytest.mark.asyncio
 async def test_get_filtered_plans_success():
@@ -970,6 +1102,114 @@ async def test_update_plan_details_no_image_url():
         )
         
         assert response.image_url is None
+
+
+@pytest.mark.asyncio
+async def test_update_plan_details_with_series_id():
+    plan_id = uuid.uuid4()
+    series_id = uuid.uuid4()
+    author_id = uuid.uuid4()
+
+    mock_plan = MagicMock(spec=Plan)
+    mock_plan.id = plan_id
+    mock_plan.author_id = author_id
+    mock_plan.title = "Test Plan"
+    mock_plan.description = "Test Description"
+    mock_plan.difficulty_level = DifficultyLevel.BEGINNER
+    mock_plan.image_url = None
+    mock_plan.tag_list = []
+    mock_plan.language = MagicMock(value="en")
+    mock_plan.status = PlanStatus.DRAFT
+    mock_plan.start_date = None
+    mock_plan.series_id = None
+    mock_plan.display_order = None
+
+    mock_series = MagicMock()
+    mock_series.author_id = author_id
+
+    existing_items = [MagicMock(spec=PlanItem, day_number=1)]
+    update_request = UpdatePlanRequest(series_id=series_id, display_order=1)
+
+    with patch("pecha_api.plans.cms.cms_plans_service.SessionLocal") as mock_session_local, \
+         patch("pecha_api.plans.cms.cms_plans_service.validate_and_extract_author_details") as mock_validate_author, \
+         patch("pecha_api.plans.cms.cms_plans_service.get_plan_by_id") as mock_get_plan, \
+         patch("pecha_api.plans.cms.cms_plans_service.update_plan") as mock_update_plan, \
+         patch("pecha_api.plans.cms.cms_plans_service.get_plan_items_by_plan_id") as mock_get_items, \
+         patch("pecha_api.plans.cms.cms_plans_service.get_series_by_id") as mock_get_series:
+        db_session = _mock_session_local(mock_session_local)
+        db_session.query.return_value.filter.return_value.scalar.return_value = 0
+
+        mock_author = MagicMock()
+        mock_author.id = author_id
+        mock_author.email = "author@example.com"
+        mock_author.is_admin = False
+        mock_validate_author.return_value = mock_author
+
+        mock_get_plan.return_value = mock_plan
+        mock_update_plan.return_value = mock_plan
+        mock_get_items.return_value = existing_items
+        mock_get_series.return_value = mock_series
+
+        await update_plan_details(
+            token="test-token",
+            plan_id=plan_id,
+            update_plan_request=update_request,
+        )
+
+        assert mock_plan.series_id == series_id
+        assert mock_plan.display_order == 1
+        mock_get_series.assert_called_once_with(db=db_session, series_id=series_id)
+
+
+@pytest.mark.asyncio
+async def test_update_plan_details_detach_series():
+    plan_id = uuid.uuid4()
+    author_id = uuid.uuid4()
+    existing_series_id = uuid.uuid4()
+
+    mock_plan = MagicMock(spec=Plan)
+    mock_plan.id = plan_id
+    mock_plan.author_id = author_id
+    mock_plan.title = "Test Plan"
+    mock_plan.description = "Test Description"
+    mock_plan.difficulty_level = DifficultyLevel.BEGINNER
+    mock_plan.image_url = None
+    mock_plan.tag_list = []
+    mock_plan.language = MagicMock(value="en")
+    mock_plan.status = PlanStatus.DRAFT
+    mock_plan.start_date = None
+    mock_plan.series_id = existing_series_id
+    mock_plan.display_order = 2
+
+    existing_items = [MagicMock(spec=PlanItem, day_number=1)]
+    update_request = UpdatePlanRequest.model_validate({"series_id": None})
+
+    with patch("pecha_api.plans.cms.cms_plans_service.SessionLocal") as mock_session_local, \
+         patch("pecha_api.plans.cms.cms_plans_service.validate_and_extract_author_details") as mock_validate_author, \
+         patch("pecha_api.plans.cms.cms_plans_service.get_plan_by_id") as mock_get_plan, \
+         patch("pecha_api.plans.cms.cms_plans_service.update_plan") as mock_update_plan, \
+         patch("pecha_api.plans.cms.cms_plans_service.get_plan_items_by_plan_id") as mock_get_items:
+        db_session = _mock_session_local(mock_session_local)
+        db_session.query.return_value.filter.return_value.scalar.return_value = 0
+
+        mock_author = MagicMock()
+        mock_author.id = author_id
+        mock_author.email = "author@example.com"
+        mock_author.is_admin = False
+        mock_validate_author.return_value = mock_author
+
+        mock_get_plan.return_value = mock_plan
+        mock_update_plan.return_value = mock_plan
+        mock_get_items.return_value = existing_items
+
+        await update_plan_details(
+            token="test-token",
+            plan_id=plan_id,
+            update_plan_request=update_request,
+        )
+
+        assert mock_plan.series_id is None
+        assert mock_plan.display_order is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
while updating and creating a plan it should take series id as optional. which is fixed in this case .