### PR TITLE
feat: add author group filtering to plans and series retrieval

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -23,6 +23,7 @@ from pecha_api.users.users_models import Users, SocialMediaAccount, PasswordRese
 from pecha_api.plans.users.recitation.user_recitations_models import UserRecitations
 from pecha_api.texts.text_images_models import TextImage
 from pecha_api.routines.routines_models import Routine, RoutineTimeBlock, RoutineSession
+from pecha_api.plans.groups.groups_models import AuthorGroup, AuthorGroupMetadata, AuthorGroupMember, AuthorGroupSocialLink, AuthorGroupInvite
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.

--- a/migrations/versions/d1f3a9c2b7e4_add_author_groups_domain.py
+++ b/migrations/versions/d1f3a9c2b7e4_add_author_groups_domain.py
@@ -1,0 +1,222 @@
+"""add author groups domain
+
+Revision ID: d1f3a9c2b7e4
+Revises: ba8e2cb719be
+Create Date: 2026-05-28 13:10:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = "d1f3a9c2b7e4"
+down_revision: Union[str, None] = "ba8e2cb719be"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+author_group_member_role_enum = postgresql.ENUM(
+    "OWNER",
+    "ADMIN",
+    "EDITOR",
+    "AUTHOR",
+    "VIEWER",
+    name="author_group_member_role",
+    create_type=False,
+)
+
+
+def upgrade() -> None:
+    author_group_member_role_enum.create(op.get_bind(), checkfirst=True)
+
+    op.create_table(
+        "author_groups",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("slug", sa.String(length=255), nullable=False),
+        sa.Column("is_public", sa.Boolean(), nullable=False, server_default=sa.text("TRUE")),
+        sa.Column("avatar_key", sa.String(length=1000), nullable=True),
+        sa.Column("banner_key", sa.String(length=1000), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("created_by", sa.String(length=255), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("updated_by", sa.String(length=255), nullable=True),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("deleted_by", sa.String(length=255), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "idx_author_groups_slug",
+        "author_groups",
+        ["slug"],
+        unique=True,
+        postgresql_where=sa.text("deleted_at IS NULL"),
+    )
+
+    op.create_table(
+        "author_group_metadata",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("group_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("language", sa.String(length=10), nullable=False),
+        sa.Column("title", sa.String(length=255), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.ForeignKeyConstraint(["group_id"], ["author_groups.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("group_id", "language", name="uq_author_group_metadata_group_language"),
+    )
+    op.create_index(
+        "idx_author_group_metadata_group_language",
+        "author_group_metadata",
+        ["group_id", "language"],
+        unique=False,
+    )
+
+    op.create_table(
+        "author_group_members",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("group_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("author_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("role", author_group_member_role_enum, nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("created_by", sa.String(length=255), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("updated_by", sa.String(length=255), nullable=True),
+        sa.ForeignKeyConstraint(["author_id"], ["authors.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["group_id"], ["author_groups.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("group_id", "author_id", name="uq_author_group_members_group_author"),
+    )
+    op.create_index(
+        "idx_author_group_members_group_author",
+        "author_group_members",
+        ["group_id", "author_id"],
+        unique=False,
+    )
+
+    op.create_table(
+        "author_group_followers",
+        sa.Column("group_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["group_id"], ["author_groups.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("group_id", "user_id"),
+        sa.UniqueConstraint("group_id", "user_id", name="uq_author_group_followers_group_user"),
+    )
+    op.create_index(
+        "idx_author_group_followers_group_user",
+        "author_group_followers",
+        ["group_id", "user_id"],
+        unique=False,
+    )
+
+    op.create_table(
+        "author_group_tags",
+        sa.Column("group_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("tag_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.ForeignKeyConstraint(["group_id"], ["author_groups.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["tag_id"], ["tags.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("group_id", "tag_id"),
+        sa.UniqueConstraint("group_id", "tag_id", name="uq_author_group_tags_group_tag"),
+    )
+    op.create_index("idx_author_group_tags_group_tag", "author_group_tags", ["group_id", "tag_id"], unique=False)
+
+    op.create_table(
+        "author_group_social_links",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("group_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("platform", sa.String(length=50), nullable=False),
+        sa.Column("url", sa.String(length=1000), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["group_id"], ["author_groups.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_table(
+        "author_group_series",
+        sa.Column("group_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("series_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.ForeignKeyConstraint(["group_id"], ["author_groups.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["series_id"], ["series.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("group_id", "series_id"),
+        sa.UniqueConstraint("group_id", "series_id", name="uq_author_group_series_group_series"),
+    )
+    op.create_index(
+        "idx_author_group_series_group_series",
+        "author_group_series",
+        ["group_id", "series_id"],
+        unique=False,
+    )
+
+    op.create_table(
+        "author_group_plans",
+        sa.Column("group_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("plan_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.ForeignKeyConstraint(["group_id"], ["author_groups.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["plan_id"], ["plans.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("group_id", "plan_id"),
+        sa.UniqueConstraint("group_id", "plan_id", name="uq_author_group_plans_group_plan"),
+    )
+    op.create_index(
+        "idx_author_group_plans_group_plan",
+        "author_group_plans",
+        ["group_id", "plan_id"],
+        unique=False,
+    )
+
+    op.create_table(
+        "author_group_invites",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("group_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("target_email", sa.String(length=255), nullable=False),
+        sa.Column("role", author_group_member_role_enum, nullable=False),
+        sa.Column("token_hash", sa.String(length=255), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("max_uses", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("uses_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("revoked_by", sa.String(length=255), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("created_by", sa.String(length=255), nullable=False),
+        sa.ForeignKeyConstraint(["group_id"], ["author_groups.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("token_hash"),
+    )
+    op.create_index("idx_author_group_invites_token_hash", "author_group_invites", ["token_hash"], unique=False)
+    op.create_index("idx_author_group_invites_target_email", "author_group_invites", ["target_email"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("idx_author_group_invites_target_email", table_name="author_group_invites")
+    op.drop_index("idx_author_group_invites_token_hash", table_name="author_group_invites")
+    op.drop_table("author_group_invites")
+
+    op.drop_index("idx_author_group_plans_group_plan", table_name="author_group_plans")
+    op.drop_table("author_group_plans")
+
+    op.drop_index("idx_author_group_series_group_series", table_name="author_group_series")
+    op.drop_table("author_group_series")
+
+    op.drop_table("author_group_social_links")
+
+    op.drop_index("idx_author_group_tags_group_tag", table_name="author_group_tags")
+    op.drop_table("author_group_tags")
+
+    op.drop_index("idx_author_group_followers_group_user", table_name="author_group_followers")
+    op.drop_table("author_group_followers")
+
+    op.drop_index("idx_author_group_members_group_author", table_name="author_group_members")
+    op.drop_table("author_group_members")
+
+    op.drop_index("idx_author_group_metadata_group_language", table_name="author_group_metadata")
+    op.drop_table("author_group_metadata")
+
+    op.drop_index("idx_author_groups_slug", table_name="author_groups")
+    op.drop_table("author_groups")
+
+    author_group_member_role_enum.drop(op.get_bind(), checkfirst=True)

--- a/pecha_api/app.py
+++ b/pecha_api/app.py
@@ -31,6 +31,7 @@ from pecha_api.plans.items import plan_items_views
 from pecha_api.plans.authors import plan_authors_views as plan_authors_views
 from pecha_api.plans.featured import featured_day_views
 from pecha_api.plans.dashboard import dashboard_views as cms_dashboard_views
+from pecha_api.plans.groups import groups_views as author_groups_views
 from pecha_api.recitations import recitations_view
 from pecha_api.user_follows import user_follow_views
 from pecha_api.plans.users.recitation import user_recitations_views
@@ -68,9 +69,12 @@ api.include_router(cms_plans_views.cms_plans_router)
 api.include_router(cms_series_views.cms_series_router)
 api.include_router(cms_tags_views.cms_tags_router)
 api.include_router(cms_dashboard_views.dashboard_router)
+api.include_router(author_groups_views.cms_groups_router)
 api.include_router(public_series_views.public_series_router)
 api.include_router(media_views.media_router)
 api.include_router(public_plans_views.public_plans_router)
+api.include_router(author_groups_views.public_groups_router)
+api.include_router(author_groups_views.user_groups_router)
 api.include_router(user_plans_views.user_progress_router)
 api.include_router(plan_items_views.items_router)
 api.include_router(plan_tasks_views.plans_router)

--- a/pecha_api/plans/groups/__init__.py
+++ b/pecha_api/plans/groups/__init__.py
@@ -1,0 +1,1 @@
+"""Author groups domain for plans."""

--- a/pecha_api/plans/groups/groups_enums.py
+++ b/pecha_api/plans/groups/groups_enums.py
@@ -1,0 +1,17 @@
+import enum
+
+from sqlalchemy import Enum
+
+
+class AuthorGroupMemberRole(enum.Enum):
+    OWNER = "OWNER"
+    ADMIN = "ADMIN"
+    EDITOR = "EDITOR"
+    AUTHOR = "AUTHOR"
+    VIEWER = "VIEWER"
+
+
+AuthorGroupMemberRoleEnum = Enum(
+    AuthorGroupMemberRole,
+    name="author_group_member_role",
+)

--- a/pecha_api/plans/groups/groups_models.py
+++ b/pecha_api/plans/groups/groups_models.py
@@ -22,6 +22,9 @@ from pecha_api.db.database import Base
 
 from .groups_enums import AuthorGroupMemberRoleEnum
 
+FK_AUTHOR_GROUPS_ID = "author_groups.id"
+CASCADE_DELETE_ORPHAN = "all, delete-orphan"
+
 
 author_group_followers = Table(
     "author_group_followers",
@@ -29,7 +32,7 @@ author_group_followers = Table(
     Column(
         "group_id",
         UUID(as_uuid=True),
-        ForeignKey("author_groups.id", ondelete="CASCADE"),
+        ForeignKey(FK_AUTHOR_GROUPS_ID, ondelete="CASCADE"),
         primary_key=True,
     ),
     Column(
@@ -54,7 +57,7 @@ author_group_tags = Table(
     Column(
         "group_id",
         UUID(as_uuid=True),
-        ForeignKey("author_groups.id", ondelete="CASCADE"),
+        ForeignKey(FK_AUTHOR_GROUPS_ID, ondelete="CASCADE"),
         primary_key=True,
     ),
     Column(
@@ -73,7 +76,7 @@ author_group_series = Table(
     Column(
         "group_id",
         UUID(as_uuid=True),
-        ForeignKey("author_groups.id", ondelete="CASCADE"),
+        ForeignKey(FK_AUTHOR_GROUPS_ID, ondelete="CASCADE"),
         primary_key=True,
     ),
     Column(
@@ -92,7 +95,7 @@ author_group_plans = Table(
     Column(
         "group_id",
         UUID(as_uuid=True),
-        ForeignKey("author_groups.id", ondelete="CASCADE"),
+        ForeignKey(FK_AUTHOR_GROUPS_ID, ondelete="CASCADE"),
         primary_key=True,
     ),
     Column(
@@ -126,17 +129,17 @@ class AuthorGroup(Base):
     metadata_entries = relationship(
         "AuthorGroupMetadata",
         back_populates="group",
-        cascade="all, delete-orphan",
+        cascade=CASCADE_DELETE_ORPHAN,
     )
     members = relationship(
         "AuthorGroupMember",
         back_populates="group",
-        cascade="all, delete-orphan",
+        cascade=CASCADE_DELETE_ORPHAN,
     )
     social_links = relationship(
         "AuthorGroupSocialLink",
         back_populates="group",
-        cascade="all, delete-orphan",
+        cascade=CASCADE_DELETE_ORPHAN,
     )
     tags = relationship("Tag", secondary=author_group_tags, lazy="select")
     plans = relationship("Plan", secondary=author_group_plans, lazy="select")
@@ -159,7 +162,7 @@ class AuthorGroupMetadata(Base):
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
     group_id = Column(
         UUID(as_uuid=True),
-        ForeignKey("author_groups.id", ondelete="CASCADE"),
+        ForeignKey(FK_AUTHOR_GROUPS_ID, ondelete="CASCADE"),
         nullable=False,
     )
     language = Column(String(10), nullable=False)
@@ -180,7 +183,7 @@ class AuthorGroupMember(Base):
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
     group_id = Column(
         UUID(as_uuid=True),
-        ForeignKey("author_groups.id", ondelete="CASCADE"),
+        ForeignKey(FK_AUTHOR_GROUPS_ID, ondelete="CASCADE"),
         nullable=False,
     )
     author_id = Column(
@@ -211,7 +214,7 @@ class AuthorGroupSocialLink(Base):
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
     group_id = Column(
         UUID(as_uuid=True),
-        ForeignKey("author_groups.id", ondelete="CASCADE"),
+        ForeignKey(FK_AUTHOR_GROUPS_ID, ondelete="CASCADE"),
         nullable=False,
     )
     platform = Column(String(50), nullable=False)
@@ -230,7 +233,7 @@ class AuthorGroupInvite(Base):
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
     group_id = Column(
         UUID(as_uuid=True),
-        ForeignKey("author_groups.id", ondelete="CASCADE"),
+        ForeignKey(FK_AUTHOR_GROUPS_ID, ondelete="CASCADE"),
         nullable=False,
     )
     target_email = Column(String(255), nullable=False)

--- a/pecha_api/plans/groups/groups_models.py
+++ b/pecha_api/plans/groups/groups_models.py
@@ -1,0 +1,254 @@
+from _datetime import datetime
+import _datetime
+from uuid import uuid4
+
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Table,
+    Text,
+    UUID,
+    UniqueConstraint,
+    text,
+)
+from sqlalchemy.orm import relationship
+
+from pecha_api.db.database import Base
+
+from .groups_enums import AuthorGroupMemberRoleEnum
+
+
+author_group_followers = Table(
+    "author_group_followers",
+    Base.metadata,
+    Column(
+        "group_id",
+        UUID(as_uuid=True),
+        ForeignKey("author_groups.id", ondelete="CASCADE"),
+        primary_key=True,
+    ),
+    Column(
+        "user_id",
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        primary_key=True,
+    ),
+    Column(
+        "created_at",
+        DateTime(timezone=True),
+        default=datetime.now(_datetime.timezone.utc),
+        nullable=False,
+    ),
+    UniqueConstraint("group_id", "user_id", name="uq_author_group_followers_group_user"),
+)
+
+
+author_group_tags = Table(
+    "author_group_tags",
+    Base.metadata,
+    Column(
+        "group_id",
+        UUID(as_uuid=True),
+        ForeignKey("author_groups.id", ondelete="CASCADE"),
+        primary_key=True,
+    ),
+    Column(
+        "tag_id",
+        UUID(as_uuid=True),
+        ForeignKey("tags.id", ondelete="CASCADE"),
+        primary_key=True,
+    ),
+    UniqueConstraint("group_id", "tag_id", name="uq_author_group_tags_group_tag"),
+)
+
+
+author_group_series = Table(
+    "author_group_series",
+    Base.metadata,
+    Column(
+        "group_id",
+        UUID(as_uuid=True),
+        ForeignKey("author_groups.id", ondelete="CASCADE"),
+        primary_key=True,
+    ),
+    Column(
+        "series_id",
+        UUID(as_uuid=True),
+        ForeignKey("series.id", ondelete="CASCADE"),
+        primary_key=True,
+    ),
+    UniqueConstraint("group_id", "series_id", name="uq_author_group_series_group_series"),
+)
+
+
+author_group_plans = Table(
+    "author_group_plans",
+    Base.metadata,
+    Column(
+        "group_id",
+        UUID(as_uuid=True),
+        ForeignKey("author_groups.id", ondelete="CASCADE"),
+        primary_key=True,
+    ),
+    Column(
+        "plan_id",
+        UUID(as_uuid=True),
+        ForeignKey("plans.id", ondelete="CASCADE"),
+        primary_key=True,
+    ),
+    UniqueConstraint("group_id", "plan_id", name="uq_author_group_plans_group_plan"),
+)
+
+
+class AuthorGroup(Base):
+    __tablename__ = "author_groups"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+    slug = Column(String(255), nullable=False)
+    is_public = Column(Boolean, nullable=False, default=True)
+    avatar_key = Column(String(1000), nullable=True)
+    banner_key = Column(String(1000), nullable=True)
+
+    created_at = Column(
+        DateTime(timezone=True), default=datetime.now(_datetime.timezone.utc), nullable=False
+    )
+    created_by = Column(String(255), nullable=False)
+    updated_at = Column(DateTime(timezone=True), default=datetime.now(_datetime.timezone.utc))
+    updated_by = Column(String(255), nullable=True)
+    deleted_at = Column(DateTime(timezone=True), nullable=True)
+    deleted_by = Column(String(255), nullable=True)
+
+    metadata_entries = relationship(
+        "AuthorGroupMetadata",
+        back_populates="group",
+        cascade="all, delete-orphan",
+    )
+    members = relationship(
+        "AuthorGroupMember",
+        back_populates="group",
+        cascade="all, delete-orphan",
+    )
+    social_links = relationship(
+        "AuthorGroupSocialLink",
+        back_populates="group",
+        cascade="all, delete-orphan",
+    )
+    tags = relationship("Tag", secondary=author_group_tags, lazy="select")
+    plans = relationship("Plan", secondary=author_group_plans, lazy="select")
+    series = relationship("Series", secondary=author_group_series, lazy="select")
+    followers = relationship("Users", secondary=author_group_followers, lazy="select")
+
+    __table_args__ = (
+        Index(
+            "idx_author_groups_slug",
+            "slug",
+            unique=True,
+            postgresql_where=text("deleted_at IS NULL"),
+        ),
+    )
+
+
+class AuthorGroupMetadata(Base):
+    __tablename__ = "author_group_metadata"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+    group_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("author_groups.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    language = Column(String(10), nullable=False)
+    title = Column(String(255), nullable=False)
+    description = Column(Text, nullable=True)
+
+    group = relationship("AuthorGroup", back_populates="metadata_entries")
+
+    __table_args__ = (
+        UniqueConstraint("group_id", "language", name="uq_author_group_metadata_group_language"),
+        Index("idx_author_group_metadata_group_language", "group_id", "language"),
+    )
+
+
+class AuthorGroupMember(Base):
+    __tablename__ = "author_group_members"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+    group_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("author_groups.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    author_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("authors.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    role = Column(AuthorGroupMemberRoleEnum, nullable=False, default="AUTHOR")
+    created_at = Column(
+        DateTime(timezone=True), default=datetime.now(_datetime.timezone.utc), nullable=False
+    )
+    created_by = Column(String(255), nullable=False)
+    updated_at = Column(DateTime(timezone=True), default=datetime.now(_datetime.timezone.utc))
+    updated_by = Column(String(255), nullable=True)
+
+    group = relationship("AuthorGroup", back_populates="members")
+    author = relationship("Author")
+
+    __table_args__ = (
+        UniqueConstraint("group_id", "author_id", name="uq_author_group_members_group_author"),
+        Index("idx_author_group_members_group_author", "group_id", "author_id"),
+    )
+
+
+class AuthorGroupSocialLink(Base):
+    __tablename__ = "author_group_social_links"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+    group_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("author_groups.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    platform = Column(String(50), nullable=False)
+    url = Column(String(1000), nullable=False)
+    created_at = Column(
+        DateTime(timezone=True), default=datetime.now(_datetime.timezone.utc), nullable=False
+    )
+    updated_at = Column(DateTime(timezone=True), default=datetime.now(_datetime.timezone.utc))
+
+    group = relationship("AuthorGroup", back_populates="social_links")
+
+
+class AuthorGroupInvite(Base):
+    __tablename__ = "author_group_invites"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+    group_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("author_groups.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    target_email = Column(String(255), nullable=False)
+    role = Column(AuthorGroupMemberRoleEnum, nullable=False, default="AUTHOR")
+    token_hash = Column(String(255), nullable=False, unique=True)
+    expires_at = Column(DateTime(timezone=True), nullable=False)
+    max_uses = Column(Integer, nullable=False, default=1)
+    uses_count = Column(Integer, nullable=False, default=0)
+    revoked_at = Column(DateTime(timezone=True), nullable=True)
+    revoked_by = Column(String(255), nullable=True)
+    created_at = Column(
+        DateTime(timezone=True), default=datetime.now(_datetime.timezone.utc), nullable=False
+    )
+    created_by = Column(String(255), nullable=False)
+
+    group = relationship("AuthorGroup")
+
+    __table_args__ = (
+        Index("idx_author_group_invites_token_hash", "token_hash"),
+        Index("idx_author_group_invites_target_email", "target_email"),
+    )

--- a/pecha_api/plans/groups/groups_repository.py
+++ b/pecha_api/plans/groups/groups_repository.py
@@ -1,0 +1,341 @@
+from datetime import datetime, timezone
+from typing import List, Optional, Sequence, Tuple
+from uuid import UUID
+
+from sqlalchemy import and_, delete, exists, func, or_, select
+from sqlalchemy.orm import Session, selectinload
+
+from pecha_api.plans.groups.groups_models import (
+    AuthorGroup,
+    AuthorGroupInvite,
+    AuthorGroupMember,
+    AuthorGroupMetadata,
+    AuthorGroupSocialLink,
+    author_group_followers,
+    author_group_plans,
+    author_group_series,
+    author_group_tags,
+)
+from pecha_api.plans.plans_models import Plan
+from pecha_api.plans.series.series_model import Series
+from pecha_api.plans.tags.tag_model import Tag
+
+
+def get_group_by_id(db: Session, group_id: UUID) -> Optional[AuthorGroup]:
+    return (
+        db.query(AuthorGroup)
+        .options(
+            selectinload(AuthorGroup.metadata_entries),
+            selectinload(AuthorGroup.members).selectinload(AuthorGroupMember.author),
+            selectinload(AuthorGroup.social_links),
+            selectinload(AuthorGroup.tags),
+            selectinload(AuthorGroup.plans),
+            selectinload(AuthorGroup.series),
+        )
+        .filter(AuthorGroup.id == group_id, AuthorGroup.deleted_at.is_(None))
+        .first()
+    )
+
+
+def get_group_by_slug(db: Session, slug: str) -> Optional[AuthorGroup]:
+    return (
+        db.query(AuthorGroup)
+        .filter(AuthorGroup.slug == slug, AuthorGroup.deleted_at.is_(None))
+        .first()
+    )
+
+
+def get_group_member(
+    db: Session,
+    group_id: UUID,
+    author_id: UUID,
+) -> Optional[AuthorGroupMember]:
+    return (
+        db.query(AuthorGroupMember)
+        .options(selectinload(AuthorGroupMember.author))
+        .filter(
+            AuthorGroupMember.group_id == group_id,
+            AuthorGroupMember.author_id == author_id,
+        )
+        .first()
+    )
+
+
+def get_owner_count(db: Session, group_id: UUID) -> int:
+    return (
+        db.query(func.count(AuthorGroupMember.id))
+        .filter(
+            AuthorGroupMember.group_id == group_id,
+            AuthorGroupMember.role == "OWNER",
+        )
+        .scalar()
+        or 0
+    )
+
+
+def get_groups_paginated(
+    db: Session,
+    skip: int,
+    limit: int,
+    search: Optional[str] = None,
+    language: Optional[str] = None,
+    tag_id: Optional[UUID] = None,
+    group_ids: Optional[Sequence[UUID]] = None,
+    public_only: bool = True,
+) -> Tuple[List[AuthorGroup], int]:
+    filters = [AuthorGroup.deleted_at.is_(None)]
+    if public_only:
+        filters.append(AuthorGroup.is_public.is_(True))
+    if language:
+        filters.append(
+            exists(
+                select(1).where(
+                    AuthorGroupMetadata.group_id == AuthorGroup.id,
+                    AuthorGroupMetadata.language == language.upper(),
+                )
+            )
+        )
+    if search:
+        filters.append(
+            exists(
+                select(1).where(
+                    AuthorGroupMetadata.group_id == AuthorGroup.id,
+                    or_(
+                        AuthorGroupMetadata.title.ilike(f"%{search}%"),
+                        AuthorGroupMetadata.description.ilike(f"%{search}%"),
+                    ),
+                )
+            )
+        )
+    if tag_id:
+        filters.append(
+            exists(
+                select(1).where(
+                    and_(
+                        author_group_tags.c.group_id == AuthorGroup.id,
+                        author_group_tags.c.tag_id == tag_id,
+                    )
+                )
+            )
+        )
+    if group_ids is not None:
+        if not group_ids:
+            return [], 0
+        filters.append(AuthorGroup.id.in_(group_ids))
+
+    query = (
+        db.query(AuthorGroup)
+        .options(
+            selectinload(AuthorGroup.metadata_entries),
+            selectinload(AuthorGroup.members),
+            selectinload(AuthorGroup.tags),
+        )
+        .filter(*filters)
+    )
+    total = query.count()
+    groups = query.order_by(AuthorGroup.created_at.desc()).offset(skip).limit(limit).all()
+    return groups, total
+
+
+def create_group(
+    db: Session,
+    group: AuthorGroup,
+    metadata_entries: List[AuthorGroupMetadata],
+    owner_member: AuthorGroupMember,
+) -> AuthorGroup:
+    db.add(group)
+    db.flush()
+    for entry in metadata_entries:
+        entry.group_id = group.id
+        db.add(entry)
+    owner_member.group_id = group.id
+    db.add(owner_member)
+    db.commit()
+    db.refresh(group)
+    return group
+
+
+def replace_group_metadata(
+    db: Session,
+    group_id: UUID,
+    metadata_entries: List[AuthorGroupMetadata],
+) -> None:
+    db.execute(delete(AuthorGroupMetadata).where(AuthorGroupMetadata.group_id == group_id))
+    for entry in metadata_entries:
+        entry.group_id = group_id
+        db.add(entry)
+
+
+def replace_group_social_links(
+    db: Session,
+    group_id: UUID,
+    social_links: List[AuthorGroupSocialLink],
+) -> None:
+    db.execute(delete(AuthorGroupSocialLink).where(AuthorGroupSocialLink.group_id == group_id))
+    for link in social_links:
+        link.group_id = group_id
+        db.add(link)
+
+
+def replace_group_relation_ids(
+    db: Session,
+    table,
+    group_id: UUID,
+    column_name: str,
+    ids: List[UUID],
+) -> None:
+    db.execute(delete(table).where(table.c.group_id == group_id))
+    if not ids:
+        return
+    rows = [{"group_id": group_id, column_name: item_id} for item_id in ids]
+    db.execute(table.insert(), rows)
+
+
+def set_group_member_role(
+    db: Session,
+    member: AuthorGroupMember,
+    role: str,
+    updated_by: str,
+) -> AuthorGroupMember:
+    member.role = role
+    member.updated_at = datetime.now(timezone.utc)
+    member.updated_by = updated_by
+    db.add(member)
+    db.commit()
+    db.refresh(member)
+    return member
+
+
+def remove_group_member(
+    db: Session,
+    member: AuthorGroupMember,
+) -> None:
+    db.delete(member)
+    db.commit()
+
+
+def create_group_invite(db: Session, invite: AuthorGroupInvite) -> AuthorGroupInvite:
+    db.add(invite)
+    db.commit()
+    db.refresh(invite)
+    return invite
+
+
+def get_invite_by_token_hash(db: Session, token_hash: str) -> Optional[AuthorGroupInvite]:
+    return (
+        db.query(AuthorGroupInvite)
+        .options(selectinload(AuthorGroupInvite.group))
+        .filter(AuthorGroupInvite.token_hash == token_hash)
+        .first()
+    )
+
+
+def get_invite_by_id(db: Session, invite_id: UUID) -> Optional[AuthorGroupInvite]:
+    return db.query(AuthorGroupInvite).filter(AuthorGroupInvite.id == invite_id).first()
+
+
+def revoke_invite(db: Session, invite: AuthorGroupInvite, revoked_by: str) -> None:
+    invite.revoked_at = datetime.now(timezone.utc)
+    invite.revoked_by = revoked_by
+    db.add(invite)
+    db.commit()
+
+
+def increase_invite_use_count(db: Session, invite: AuthorGroupInvite) -> None:
+    invite.uses_count = (invite.uses_count or 0) + 1
+    db.add(invite)
+    db.commit()
+
+
+def add_group_member(db: Session, member: AuthorGroupMember) -> AuthorGroupMember:
+    db.add(member)
+    db.commit()
+    db.refresh(member)
+    return member
+
+
+def upsert_group_follow(
+    db: Session,
+    group_id: UUID,
+    user_id: UUID,
+) -> None:
+    exists_row = db.execute(
+        select(author_group_followers.c.group_id).where(
+            author_group_followers.c.group_id == group_id,
+            author_group_followers.c.user_id == user_id,
+        )
+    ).first()
+    if exists_row:
+        return
+    db.execute(
+        author_group_followers.insert().values(
+            group_id=group_id,
+            user_id=user_id,
+            created_at=datetime.now(timezone.utc),
+        )
+    )
+    db.commit()
+
+
+def remove_group_follow(
+    db: Session,
+    group_id: UUID,
+    user_id: UUID,
+) -> None:
+    db.execute(
+        delete(author_group_followers).where(
+            author_group_followers.c.group_id == group_id,
+            author_group_followers.c.user_id == user_id,
+        )
+    )
+    db.commit()
+
+
+def get_following_group_ids_by_user(
+    db: Session,
+    user_id: UUID,
+) -> List[UUID]:
+    rows = db.execute(
+        select(author_group_followers.c.group_id).where(author_group_followers.c.user_id == user_id)
+    ).all()
+    return [row[0] for row in rows]
+
+
+def get_followers_count_map(db: Session, group_ids: Sequence[UUID]) -> dict[UUID, int]:
+    if not group_ids:
+        return {}
+    rows = (
+        db.query(
+            author_group_followers.c.group_id,
+            func.count(author_group_followers.c.user_id),
+        )
+        .filter(author_group_followers.c.group_id.in_(group_ids))
+        .group_by(author_group_followers.c.group_id)
+        .all()
+    )
+    return {group_id: int(count or 0) for group_id, count in rows}
+
+
+def get_tags_by_ids(db: Session, tag_ids: List[UUID]) -> List[Tag]:
+    if not tag_ids:
+        return []
+    return db.query(Tag).filter(Tag.id.in_(tag_ids), Tag.deleted_at.is_(None)).all()
+
+
+def get_plans_by_ids(db: Session, plan_ids: List[UUID]) -> List[Plan]:
+    if not plan_ids:
+        return []
+    return db.query(Plan).filter(Plan.id.in_(plan_ids), Plan.deleted_at.is_(None)).all()
+
+
+def get_series_by_ids(db: Session, series_ids: List[UUID]) -> List[Series]:
+    if not series_ids:
+        return []
+    return db.query(Series).filter(Series.id.in_(series_ids), Series.deleted_at.is_(None)).all()
+
+
+def update_group(db: Session, group: AuthorGroup) -> AuthorGroup:
+    db.add(group)
+    db.commit()
+    db.refresh(group)
+    return group

--- a/pecha_api/plans/groups/groups_response_models.py
+++ b/pecha_api/plans/groups/groups_response_models.py
@@ -1,0 +1,136 @@
+from datetime import datetime
+from typing import List, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, field_validator
+
+from pecha_api.plans.groups.groups_enums import AuthorGroupMemberRole
+from pecha_api.plans.plans_enums import LanguageCode
+from pecha_api.plans.tags.tag_response_models import TagSummaryDTO
+
+
+class GroupMetadataInput(BaseModel):
+    title: str
+    description: Optional[str] = None
+    language: LanguageCode
+
+
+class GroupMetadataDTO(BaseModel):
+    id: UUID
+    title: str
+    description: Optional[str] = None
+    language: str
+
+
+class GroupSocialLinkInput(BaseModel):
+    platform: str
+    url: str
+
+
+class GroupSocialLinkDTO(BaseModel):
+    id: UUID
+    platform: str
+    url: str
+
+
+class AuthorGroupMemberDTO(BaseModel):
+    author_id: UUID
+    role: AuthorGroupMemberRole
+    firstname: str
+    lastname: str
+    email: str
+
+
+class AuthorGroupSummaryDTO(BaseModel):
+    id: UUID
+    slug: str
+    is_public: bool
+    metadata: List[GroupMetadataDTO]
+    tags: List[TagSummaryDTO] = []
+    follower_count: int = 0
+    member_count: int = 0
+
+
+class AuthorGroupDetailDTO(BaseModel):
+    id: UUID
+    slug: str
+    is_public: bool
+    avatar_key: Optional[str] = None
+    banner_key: Optional[str] = None
+    metadata: List[GroupMetadataDTO]
+    members: List[AuthorGroupMemberDTO] = []
+    tags: List[TagSummaryDTO] = []
+    social_links: List[GroupSocialLinkDTO] = []
+    series_ids: List[UUID] = []
+    plan_ids: List[UUID] = []
+    follower_count: int = 0
+
+
+class AuthorGroupListResponse(BaseModel):
+    groups: List[AuthorGroupSummaryDTO]
+    skip: int
+    limit: int
+    total: int
+
+
+class CreateAuthorGroupRequest(BaseModel):
+    slug: str
+    is_public: bool = True
+    avatar_key: Optional[str] = None
+    banner_key: Optional[str] = None
+    metadata: List[GroupMetadataInput]
+
+    @field_validator("metadata")
+    @classmethod
+    def validate_metadata_not_empty(cls, value: List[GroupMetadataInput]):
+        if not value:
+            raise ValueError("At least one metadata entry is required")
+        return value
+
+
+class UpdateAuthorGroupRequest(BaseModel):
+    slug: Optional[str] = None
+    is_public: Optional[bool] = None
+    avatar_key: Optional[str] = None
+    banner_key: Optional[str] = None
+    metadata: Optional[List[GroupMetadataInput]] = None
+
+
+class ReplaceGroupTagsRequest(BaseModel):
+    tag_ids: List[UUID]
+
+
+class ReplaceGroupSeriesRequest(BaseModel):
+    series_ids: List[UUID]
+
+
+class ReplaceGroupPlansRequest(BaseModel):
+    plan_ids: List[UUID]
+
+
+class ReplaceGroupSocialLinksRequest(BaseModel):
+    social_links: List[GroupSocialLinkInput]
+
+
+class CreateGroupInviteRequest(BaseModel):
+    target_email: str
+    role: AuthorGroupMemberRole
+    expires_at: datetime
+    max_uses: int = 1
+
+
+class GroupInviteCreatedResponse(BaseModel):
+    invite_id: UUID
+    token: str
+    target_email: str
+    role: AuthorGroupMemberRole
+    expires_at: datetime
+    max_uses: int
+
+
+class AcceptGroupInviteRequest(BaseModel):
+    token: str
+
+
+class UpdateGroupMemberRoleRequest(BaseModel):
+    role: AuthorGroupMemberRole

--- a/pecha_api/plans/groups/groups_service.py
+++ b/pecha_api/plans/groups/groups_service.py
@@ -70,6 +70,8 @@ from pecha_api.plans.groups.groups_models import (
 from pecha_api.plans.tags.tag_helpers import tags_to_summary_dtos
 from pecha_api.users.users_service import validate_and_extract_user_details
 
+GROUP_NOT_FOUND = "Group not found"
+
 
 class InviteEmailMismatchError(Exception):
     pass
@@ -235,7 +237,7 @@ def update_author_group(token: str, group_id: UUID, request: UpdateAuthorGroupRe
     with SessionLocal() as db:
         group = get_group_by_id(db=db, group_id=group_id)
         if not group:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Group not found")
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=GROUP_NOT_FOUND)
         if not author.is_admin:
             member = _get_member_or_403(db=db, group_id=group_id, author_id=author.id)
             _assert_role_allowed(member=member, allowed_roles=[AuthorGroupMemberRole.OWNER, AuthorGroupMemberRole.ADMIN, AuthorGroupMemberRole.EDITOR])
@@ -275,9 +277,9 @@ def get_author_group_detail(group_id: UUID, require_public: bool = True) -> Auth
     with SessionLocal() as db:
         group = get_group_by_id(db=db, group_id=group_id)
         if not group:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Group not found")
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=GROUP_NOT_FOUND)
         if require_public and not group.is_public:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Group not found")
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=GROUP_NOT_FOUND)
         follower_count = get_followers_count_map(db=db, group_ids=[group_id]).get(group_id, 0)
         return _group_to_detail(group=group, follower_count=follower_count)
 
@@ -287,7 +289,7 @@ def get_cms_group_detail(token: str, group_id: UUID) -> AuthorGroupDetailDTO:
     with SessionLocal() as db:
         group = get_group_by_id(db=db, group_id=group_id)
         if not group:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Group not found")
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=GROUP_NOT_FOUND)
         if not author.is_admin:
             _get_member_or_403(db=db, group_id=group_id, author_id=author.id)
         follower_count = get_followers_count_map(db=db, group_ids=[group_id]).get(group_id, 0)
@@ -360,7 +362,7 @@ def replace_group_tags(token: str, group_id: UUID, request: ReplaceGroupTagsRequ
     with SessionLocal() as db:
         group = get_group_by_id(db=db, group_id=group_id)
         if not group:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Group not found")
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=GROUP_NOT_FOUND)
         if not author.is_admin:
             member = _get_member_or_403(db=db, group_id=group_id, author_id=author.id)
             _assert_role_allowed(member=member, allowed_roles=[AuthorGroupMemberRole.OWNER, AuthorGroupMemberRole.ADMIN, AuthorGroupMemberRole.EDITOR])
@@ -381,7 +383,7 @@ def replace_group_social_links_by_id(
     with SessionLocal() as db:
         group = get_group_by_id(db=db, group_id=group_id)
         if not group:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Group not found")
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=GROUP_NOT_FOUND)
         if not author.is_admin:
             member = _get_member_or_403(db=db, group_id=group_id, author_id=author.id)
             _assert_role_allowed(member=member, allowed_roles=[AuthorGroupMemberRole.OWNER, AuthorGroupMemberRole.ADMIN, AuthorGroupMemberRole.EDITOR])
@@ -398,7 +400,7 @@ def replace_group_series_by_id(token: str, group_id: UUID, request: ReplaceGroup
     with SessionLocal() as db:
         group = get_group_by_id(db=db, group_id=group_id)
         if not group:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Group not found")
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=GROUP_NOT_FOUND)
         if not author.is_admin:
             member = _get_member_or_403(db=db, group_id=group_id, author_id=author.id)
             _assert_role_allowed(member=member, allowed_roles=[AuthorGroupMemberRole.OWNER, AuthorGroupMemberRole.ADMIN, AuthorGroupMemberRole.EDITOR])
@@ -415,7 +417,7 @@ def replace_group_plans_by_id(token: str, group_id: UUID, request: ReplaceGroupP
     with SessionLocal() as db:
         group = get_group_by_id(db=db, group_id=group_id)
         if not group:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Group not found")
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=GROUP_NOT_FOUND)
         if not author.is_admin:
             member = _get_member_or_403(db=db, group_id=group_id, author_id=author.id)
             _assert_role_allowed(member=member, allowed_roles=[AuthorGroupMemberRole.OWNER, AuthorGroupMemberRole.ADMIN, AuthorGroupMemberRole.EDITOR])
@@ -432,7 +434,7 @@ def follow_group(token: str, group_id: UUID) -> None:
     with SessionLocal() as db:
         group = get_group_by_id(db=db, group_id=group_id)
         if not group or not group.is_public:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Group not found")
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=GROUP_NOT_FOUND)
         upsert_group_follow(db=db, group_id=group_id, user_id=user.id)
 
 
@@ -471,7 +473,7 @@ def create_group_member_invite(
     with SessionLocal() as db:
         group = get_group_by_id(db=db, group_id=group_id)
         if not group:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Group not found")
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=GROUP_NOT_FOUND)
         if not author.is_admin:
             member = _get_member_or_403(db=db, group_id=group_id, author_id=author.id)
             _assert_role_allowed(member=member, allowed_roles=[AuthorGroupMemberRole.OWNER, AuthorGroupMemberRole.ADMIN])
@@ -521,7 +523,7 @@ def accept_group_invite(token: str, request: AcceptGroupInviteRequest) -> Author
 
         group = get_group_by_id(db=db, group_id=invite.group_id)
         if not group:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Group not found")
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=GROUP_NOT_FOUND)
 
         existing_member = get_group_member(db=db, group_id=group.id, author_id=author.id)
         if existing_member is None:
@@ -545,7 +547,7 @@ def revoke_group_invite(token: str, group_id: UUID, invite_id: UUID) -> None:
     with SessionLocal() as db:
         group = get_group_by_id(db=db, group_id=group_id)
         if not group:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Group not found")
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=GROUP_NOT_FOUND)
         if not author.is_admin:
             member = _get_member_or_403(db=db, group_id=group_id, author_id=author.id)
             _assert_role_allowed(member=member, allowed_roles=[AuthorGroupMemberRole.OWNER, AuthorGroupMemberRole.ADMIN])
@@ -566,7 +568,7 @@ def update_group_member_role(
     with SessionLocal() as db:
         group = get_group_by_id(db=db, group_id=group_id)
         if not group:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Group not found")
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=GROUP_NOT_FOUND)
         if not current_author.is_admin:
             current_member = _get_member_or_403(db=db, group_id=group_id, author_id=current_author.id)
             _assert_role_allowed(current_member, [AuthorGroupMemberRole.OWNER, AuthorGroupMemberRole.ADMIN])
@@ -593,7 +595,7 @@ def delete_group_member(token: str, group_id: UUID, author_id: UUID) -> None:
     with SessionLocal() as db:
         group = get_group_by_id(db=db, group_id=group_id)
         if not group:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Group not found")
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=GROUP_NOT_FOUND)
         if not current_author.is_admin:
             current_member = _get_member_or_403(db=db, group_id=group_id, author_id=current_author.id)
             _assert_role_allowed(current_member, [AuthorGroupMemberRole.OWNER, AuthorGroupMemberRole.ADMIN])

--- a/pecha_api/plans/groups/groups_service.py
+++ b/pecha_api/plans/groups/groups_service.py
@@ -1,0 +1,608 @@
+import hashlib
+import secrets
+from datetime import datetime, timezone
+from typing import List, Optional
+from uuid import UUID
+
+from fastapi import HTTPException
+from starlette import status
+
+from pecha_api.db.database import SessionLocal
+from pecha_api.plans.authors.plan_authors_service import validate_and_extract_author_details
+from pecha_api.plans.groups.groups_enums import AuthorGroupMemberRole
+from pecha_api.plans.groups.groups_models import (
+    AuthorGroup,
+    AuthorGroupInvite,
+    AuthorGroupMember,
+    AuthorGroupMetadata,
+    AuthorGroupSocialLink,
+)
+from pecha_api.plans.groups.groups_repository import (
+    add_group_member,
+    create_group,
+    create_group_invite,
+    get_followers_count_map,
+    get_following_group_ids_by_user,
+    get_group_by_id,
+    get_group_by_slug,
+    get_group_member,
+    get_groups_paginated,
+    get_invite_by_id,
+    get_invite_by_token_hash,
+    get_owner_count,
+    get_plans_by_ids,
+    get_series_by_ids,
+    get_tags_by_ids,
+    increase_invite_use_count,
+    remove_group_follow,
+    remove_group_member,
+    replace_group_metadata,
+    replace_group_relation_ids,
+    replace_group_social_links,
+    revoke_invite,
+    set_group_member_role,
+    update_group,
+    upsert_group_follow,
+)
+from pecha_api.plans.groups.groups_response_models import (
+    AcceptGroupInviteRequest,
+    AuthorGroupDetailDTO,
+    AuthorGroupListResponse,
+    AuthorGroupMemberDTO,
+    AuthorGroupSummaryDTO,
+    CreateAuthorGroupRequest,
+    CreateGroupInviteRequest,
+    GroupInviteCreatedResponse,
+    GroupMetadataDTO,
+    GroupSocialLinkDTO,
+    ReplaceGroupPlansRequest,
+    ReplaceGroupSeriesRequest,
+    ReplaceGroupSocialLinksRequest,
+    ReplaceGroupTagsRequest,
+    UpdateAuthorGroupRequest,
+    UpdateGroupMemberRoleRequest,
+)
+from pecha_api.plans.groups.groups_models import (
+    author_group_plans,
+    author_group_series,
+    author_group_tags,
+)
+from pecha_api.plans.tags.tag_helpers import tags_to_summary_dtos
+from pecha_api.users.users_service import validate_and_extract_user_details
+
+
+class InviteEmailMismatchError(Exception):
+    pass
+
+
+def _to_role_value(role: AuthorGroupMemberRole | str) -> str:
+    if hasattr(role, "value"):
+        return role.value
+    return str(role)
+
+
+def _metadata_to_dtos(metadata_entries) -> List[GroupMetadataDTO]:
+    return [
+        GroupMetadataDTO(
+            id=item.id,
+            title=item.title,
+            description=item.description,
+            language=item.language,
+        )
+        for item in sorted(metadata_entries, key=lambda value: value.language)
+    ]
+
+
+def _members_to_dtos(members) -> List[AuthorGroupMemberDTO]:
+    return [
+        AuthorGroupMemberDTO(
+            author_id=member.author_id,
+            role=AuthorGroupMemberRole(_to_role_value(member.role)),
+            firstname=member.author.first_name,
+            lastname=member.author.last_name,
+            email=member.author.email,
+        )
+        for member in members
+    ]
+
+
+def _social_links_to_dtos(links) -> List[GroupSocialLinkDTO]:
+    return [GroupSocialLinkDTO(id=link.id, platform=link.platform, url=link.url) for link in links]
+
+
+def _assert_metadata_valid(metadata_entries: List) -> None:
+    if not metadata_entries:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Group must have at least one metadata entry",
+        )
+    seen_languages = set()
+    for item in metadata_entries:
+        if not item.title:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Metadata title is required",
+            )
+        language = item.language.value if hasattr(item.language, "value") else item.language
+        if language in seen_languages:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Metadata language must be unique per group",
+            )
+        seen_languages.add(language)
+
+
+def _get_member_or_403(db, group_id: UUID, author_id: UUID):
+    member = get_group_member(db=db, group_id=group_id, author_id=author_id)
+    if not member:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You are not a member of this group",
+        )
+    return member
+
+
+def _assert_role_allowed(member: AuthorGroupMember, allowed_roles: List[AuthorGroupMemberRole]):
+    role_value = _to_role_value(member.role)
+    if role_value not in [_to_role_value(role) for role in allowed_roles]:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You do not have permission for this action",
+        )
+
+
+def _validate_group_links(db, tag_ids: Optional[List[UUID]], series_ids: Optional[List[UUID]], plan_ids: Optional[List[UUID]]) -> None:
+    if tag_ids is not None:
+        found_tags = get_tags_by_ids(db=db, tag_ids=tag_ids)
+        if len(found_tags) != len(set(tag_ids)):
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="One or more tags do not exist")
+    if series_ids is not None:
+        found_series = get_series_by_ids(db=db, series_ids=series_ids)
+        if len(found_series) != len(set(series_ids)):
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="One or more series do not exist")
+    if plan_ids is not None:
+        found_plans = get_plans_by_ids(db=db, plan_ids=plan_ids)
+        if len(found_plans) != len(set(plan_ids)):
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="One or more plans do not exist")
+
+
+def _group_to_summary(group: AuthorGroup, follower_count: int = 0) -> AuthorGroupSummaryDTO:
+    return AuthorGroupSummaryDTO(
+        id=group.id,
+        slug=group.slug,
+        is_public=group.is_public,
+        metadata=_metadata_to_dtos(group.metadata_entries),
+        tags=tags_to_summary_dtos(group.tags),
+        follower_count=follower_count,
+        member_count=len(group.members),
+    )
+
+
+def _group_to_detail(group: AuthorGroup, follower_count: int = 0) -> AuthorGroupDetailDTO:
+    return AuthorGroupDetailDTO(
+        id=group.id,
+        slug=group.slug,
+        is_public=group.is_public,
+        avatar_key=group.avatar_key,
+        banner_key=group.banner_key,
+        metadata=_metadata_to_dtos(group.metadata_entries),
+        members=_members_to_dtos(group.members),
+        tags=tags_to_summary_dtos(group.tags),
+        social_links=_social_links_to_dtos(group.social_links),
+        series_ids=[series.id for series in group.series],
+        plan_ids=[plan.id for plan in group.plans],
+        follower_count=follower_count,
+    )
+
+
+def create_author_group(token: str, request: CreateAuthorGroupRequest) -> AuthorGroupDetailDTO:
+    _assert_metadata_valid(request.metadata)
+    author = validate_and_extract_author_details(token=token)
+
+    with SessionLocal() as db:
+        if get_group_by_slug(db=db, slug=request.slug):
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Group slug already exists")
+
+        metadata_entries = [
+            AuthorGroupMetadata(
+                language=item.language.value,
+                title=item.title,
+                description=item.description,
+            )
+            for item in request.metadata
+        ]
+        group = AuthorGroup(
+            slug=request.slug,
+            is_public=request.is_public,
+            avatar_key=request.avatar_key,
+            banner_key=request.banner_key,
+            created_by=author.email,
+            updated_by=author.email,
+        )
+        owner_member = AuthorGroupMember(
+            author_id=author.id,
+            role=AuthorGroupMemberRole.OWNER,
+            created_by=author.email,
+            updated_by=author.email,
+        )
+        created = create_group(db=db, group=group, metadata_entries=metadata_entries, owner_member=owner_member)
+        loaded = get_group_by_id(db=db, group_id=created.id)
+        return _group_to_detail(loaded, follower_count=0)
+
+
+def update_author_group(token: str, group_id: UUID, request: UpdateAuthorGroupRequest) -> AuthorGroupDetailDTO:
+    author = validate_and_extract_author_details(token=token)
+    with SessionLocal() as db:
+        group = get_group_by_id(db=db, group_id=group_id)
+        if not group:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Group not found")
+        if not author.is_admin:
+            member = _get_member_or_403(db=db, group_id=group_id, author_id=author.id)
+            _assert_role_allowed(member=member, allowed_roles=[AuthorGroupMemberRole.OWNER, AuthorGroupMemberRole.ADMIN, AuthorGroupMemberRole.EDITOR])
+
+        if request.slug is not None and request.slug != group.slug:
+            existing = get_group_by_slug(db=db, slug=request.slug)
+            if existing and existing.id != group.id:
+                raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Group slug already exists")
+            group.slug = request.slug
+        if request.is_public is not None:
+            group.is_public = request.is_public
+        if request.avatar_key is not None:
+            group.avatar_key = request.avatar_key
+        if request.banner_key is not None:
+            group.banner_key = request.banner_key
+        if request.metadata is not None:
+            _assert_metadata_valid(request.metadata)
+            metadata_entries = [
+                AuthorGroupMetadata(
+                    language=item.language.value,
+                    title=item.title,
+                    description=item.description,
+                )
+                for item in request.metadata
+            ]
+            replace_group_metadata(db=db, group_id=group_id, metadata_entries=metadata_entries)
+
+        group.updated_by = author.email
+        group.updated_at = datetime.now(timezone.utc)
+        update_group(db=db, group=group)
+        loaded = get_group_by_id(db=db, group_id=group_id)
+        followers_count = get_followers_count_map(db=db, group_ids=[group_id]).get(group_id, 0)
+        return _group_to_detail(group=loaded, follower_count=followers_count)
+
+
+def get_author_group_detail(group_id: UUID, require_public: bool = True) -> AuthorGroupDetailDTO:
+    with SessionLocal() as db:
+        group = get_group_by_id(db=db, group_id=group_id)
+        if not group:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Group not found")
+        if require_public and not group.is_public:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Group not found")
+        follower_count = get_followers_count_map(db=db, group_ids=[group_id]).get(group_id, 0)
+        return _group_to_detail(group=group, follower_count=follower_count)
+
+
+def get_cms_group_detail(token: str, group_id: UUID) -> AuthorGroupDetailDTO:
+    author = validate_and_extract_author_details(token=token)
+    with SessionLocal() as db:
+        group = get_group_by_id(db=db, group_id=group_id)
+        if not group:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Group not found")
+        if not author.is_admin:
+            _get_member_or_403(db=db, group_id=group_id, author_id=author.id)
+        follower_count = get_followers_count_map(db=db, group_ids=[group_id]).get(group_id, 0)
+        return _group_to_detail(group=group, follower_count=follower_count)
+
+
+def list_public_groups(
+    skip: int,
+    limit: int,
+    search: Optional[str] = None,
+    language: Optional[str] = None,
+    tag_id: Optional[UUID] = None,
+) -> AuthorGroupListResponse:
+    with SessionLocal() as db:
+        groups, total = get_groups_paginated(
+            db=db,
+            skip=skip,
+            limit=limit,
+            search=search,
+            language=language,
+            tag_id=tag_id,
+            public_only=True,
+        )
+        group_ids = [group.id for group in groups]
+        follower_count_map = get_followers_count_map(db=db, group_ids=group_ids)
+        return AuthorGroupListResponse(
+            groups=[_group_to_summary(group=item, follower_count=follower_count_map.get(item.id, 0)) for item in groups],
+            skip=skip,
+            limit=limit,
+            total=total,
+        )
+
+
+def list_cms_groups(
+    token: str,
+    skip: int,
+    limit: int,
+    search: Optional[str] = None,
+    language: Optional[str] = None,
+    tag_id: Optional[UUID] = None,
+) -> AuthorGroupListResponse:
+    author = validate_and_extract_author_details(token=token)
+    with SessionLocal() as db:
+        group_ids = None
+        if not author.is_admin:
+            membership_rows = db.query(AuthorGroupMember.group_id).filter(AuthorGroupMember.author_id == author.id).all()
+            group_ids = [row.group_id for row in membership_rows]
+        groups, total = get_groups_paginated(
+            db=db,
+            skip=skip,
+            limit=limit,
+            search=search,
+            language=language,
+            tag_id=tag_id,
+            group_ids=group_ids,
+            public_only=False,
+        )
+        ids = [group.id for group in groups]
+        follower_count_map = get_followers_count_map(db=db, group_ids=ids)
+        return AuthorGroupListResponse(
+            groups=[_group_to_summary(group=item, follower_count=follower_count_map.get(item.id, 0)) for item in groups],
+            skip=skip,
+            limit=limit,
+            total=total,
+        )
+
+
+def replace_group_tags(token: str, group_id: UUID, request: ReplaceGroupTagsRequest) -> AuthorGroupDetailDTO:
+    author = validate_and_extract_author_details(token=token)
+    with SessionLocal() as db:
+        group = get_group_by_id(db=db, group_id=group_id)
+        if not group:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Group not found")
+        if not author.is_admin:
+            member = _get_member_or_403(db=db, group_id=group_id, author_id=author.id)
+            _assert_role_allowed(member=member, allowed_roles=[AuthorGroupMemberRole.OWNER, AuthorGroupMemberRole.ADMIN, AuthorGroupMemberRole.EDITOR])
+        _validate_group_links(db=db, tag_ids=request.tag_ids, series_ids=None, plan_ids=None)
+        replace_group_relation_ids(db=db, table=author_group_tags, group_id=group_id, column_name="tag_id", ids=request.tag_ids)
+        db.commit()
+        loaded = get_group_by_id(db=db, group_id=group_id)
+        follower_count = get_followers_count_map(db=db, group_ids=[group_id]).get(group_id, 0)
+        return _group_to_detail(loaded, follower_count=follower_count)
+
+
+def replace_group_social_links_by_id(
+    token: str,
+    group_id: UUID,
+    request: ReplaceGroupSocialLinksRequest,
+) -> AuthorGroupDetailDTO:
+    author = validate_and_extract_author_details(token=token)
+    with SessionLocal() as db:
+        group = get_group_by_id(db=db, group_id=group_id)
+        if not group:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Group not found")
+        if not author.is_admin:
+            member = _get_member_or_403(db=db, group_id=group_id, author_id=author.id)
+            _assert_role_allowed(member=member, allowed_roles=[AuthorGroupMemberRole.OWNER, AuthorGroupMemberRole.ADMIN, AuthorGroupMemberRole.EDITOR])
+        social_links = [AuthorGroupSocialLink(platform=item.platform, url=item.url) for item in request.social_links]
+        replace_group_social_links(db=db, group_id=group_id, social_links=social_links)
+        db.commit()
+        loaded = get_group_by_id(db=db, group_id=group_id)
+        follower_count = get_followers_count_map(db=db, group_ids=[group_id]).get(group_id, 0)
+        return _group_to_detail(loaded, follower_count=follower_count)
+
+
+def replace_group_series_by_id(token: str, group_id: UUID, request: ReplaceGroupSeriesRequest) -> AuthorGroupDetailDTO:
+    author = validate_and_extract_author_details(token=token)
+    with SessionLocal() as db:
+        group = get_group_by_id(db=db, group_id=group_id)
+        if not group:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Group not found")
+        if not author.is_admin:
+            member = _get_member_or_403(db=db, group_id=group_id, author_id=author.id)
+            _assert_role_allowed(member=member, allowed_roles=[AuthorGroupMemberRole.OWNER, AuthorGroupMemberRole.ADMIN, AuthorGroupMemberRole.EDITOR])
+        _validate_group_links(db=db, tag_ids=None, series_ids=request.series_ids, plan_ids=None)
+        replace_group_relation_ids(db=db, table=author_group_series, group_id=group_id, column_name="series_id", ids=request.series_ids)
+        db.commit()
+        loaded = get_group_by_id(db=db, group_id=group_id)
+        follower_count = get_followers_count_map(db=db, group_ids=[group_id]).get(group_id, 0)
+        return _group_to_detail(loaded, follower_count=follower_count)
+
+
+def replace_group_plans_by_id(token: str, group_id: UUID, request: ReplaceGroupPlansRequest) -> AuthorGroupDetailDTO:
+    author = validate_and_extract_author_details(token=token)
+    with SessionLocal() as db:
+        group = get_group_by_id(db=db, group_id=group_id)
+        if not group:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Group not found")
+        if not author.is_admin:
+            member = _get_member_or_403(db=db, group_id=group_id, author_id=author.id)
+            _assert_role_allowed(member=member, allowed_roles=[AuthorGroupMemberRole.OWNER, AuthorGroupMemberRole.ADMIN, AuthorGroupMemberRole.EDITOR])
+        _validate_group_links(db=db, tag_ids=None, series_ids=None, plan_ids=request.plan_ids)
+        replace_group_relation_ids(db=db, table=author_group_plans, group_id=group_id, column_name="plan_id", ids=request.plan_ids)
+        db.commit()
+        loaded = get_group_by_id(db=db, group_id=group_id)
+        follower_count = get_followers_count_map(db=db, group_ids=[group_id]).get(group_id, 0)
+        return _group_to_detail(loaded, follower_count=follower_count)
+
+
+def follow_group(token: str, group_id: UUID) -> None:
+    user = validate_and_extract_user_details(token=token)
+    with SessionLocal() as db:
+        group = get_group_by_id(db=db, group_id=group_id)
+        if not group or not group.is_public:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Group not found")
+        upsert_group_follow(db=db, group_id=group_id, user_id=user.id)
+
+
+def unfollow_group(token: str, group_id: UUID) -> None:
+    user = validate_and_extract_user_details(token=token)
+    with SessionLocal() as db:
+        remove_group_follow(db=db, group_id=group_id, user_id=user.id)
+
+
+def list_followed_groups(token: str, skip: int, limit: int) -> AuthorGroupListResponse:
+    user = validate_and_extract_user_details(token=token)
+    with SessionLocal() as db:
+        group_ids = get_following_group_ids_by_user(db=db, user_id=user.id)
+        groups, total = get_groups_paginated(
+            db=db,
+            skip=skip,
+            limit=limit,
+            group_ids=group_ids,
+            public_only=False,
+        )
+        follower_count_map = get_followers_count_map(db=db, group_ids=[group.id for group in groups])
+        return AuthorGroupListResponse(
+            groups=[_group_to_summary(group=item, follower_count=follower_count_map.get(item.id, 0)) for item in groups],
+            skip=skip,
+            limit=limit,
+            total=total,
+        )
+
+
+def create_group_member_invite(
+    token: str,
+    group_id: UUID,
+    request: CreateGroupInviteRequest,
+) -> GroupInviteCreatedResponse:
+    author = validate_and_extract_author_details(token=token)
+    with SessionLocal() as db:
+        group = get_group_by_id(db=db, group_id=group_id)
+        if not group:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Group not found")
+        if not author.is_admin:
+            member = _get_member_or_403(db=db, group_id=group_id, author_id=author.id)
+            _assert_role_allowed(member=member, allowed_roles=[AuthorGroupMemberRole.OWNER, AuthorGroupMemberRole.ADMIN])
+
+        raw_token = secrets.token_urlsafe(48)
+        token_hash = hashlib.sha256(raw_token.encode("utf-8")).hexdigest()
+        invite = AuthorGroupInvite(
+            group_id=group_id,
+            target_email=request.target_email.lower(),
+            role=request.role,
+            token_hash=token_hash,
+            expires_at=request.expires_at,
+            max_uses=request.max_uses,
+            created_by=author.email,
+        )
+        created = create_group_invite(db=db, invite=invite)
+        return GroupInviteCreatedResponse(
+            invite_id=created.id,
+            token=raw_token,
+            target_email=created.target_email,
+            role=AuthorGroupMemberRole(_to_role_value(created.role)),
+            expires_at=created.expires_at,
+            max_uses=created.max_uses,
+        )
+
+
+def _validate_invite_acceptance(invite: AuthorGroupInvite) -> None:
+    now = datetime.now(timezone.utc)
+    if invite.revoked_at is not None:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invite has been revoked")
+    if invite.expires_at < now:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invite has expired")
+    if invite.uses_count >= invite.max_uses:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invite usage limit exceeded")
+
+
+def accept_group_invite(token: str, request: AcceptGroupInviteRequest) -> AuthorGroupDetailDTO:
+    author = validate_and_extract_author_details(token=token)
+    token_hash = hashlib.sha256(request.token.encode("utf-8")).hexdigest()
+    with SessionLocal() as db:
+        invite = get_invite_by_token_hash(db=db, token_hash=token_hash)
+        if not invite:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Invite not found")
+        _validate_invite_acceptance(invite=invite)
+        if author.email.lower() != invite.target_email.lower():
+            raise InviteEmailMismatchError("This invite was sent to a different email address.")
+
+        group = get_group_by_id(db=db, group_id=invite.group_id)
+        if not group:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Group not found")
+
+        existing_member = get_group_member(db=db, group_id=group.id, author_id=author.id)
+        if existing_member is None:
+            add_group_member(
+                db=db,
+                member=AuthorGroupMember(
+                    group_id=group.id,
+                    author_id=author.id,
+                    role=invite.role,
+                    created_by=author.email,
+                ),
+            )
+        increase_invite_use_count(db=db, invite=invite)
+        loaded = get_group_by_id(db=db, group_id=group.id)
+        follower_count = get_followers_count_map(db=db, group_ids=[group.id]).get(group.id, 0)
+        return _group_to_detail(loaded, follower_count=follower_count)
+
+
+def revoke_group_invite(token: str, group_id: UUID, invite_id: UUID) -> None:
+    author = validate_and_extract_author_details(token=token)
+    with SessionLocal() as db:
+        group = get_group_by_id(db=db, group_id=group_id)
+        if not group:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Group not found")
+        if not author.is_admin:
+            member = _get_member_or_403(db=db, group_id=group_id, author_id=author.id)
+            _assert_role_allowed(member=member, allowed_roles=[AuthorGroupMemberRole.OWNER, AuthorGroupMemberRole.ADMIN])
+
+        invite = get_invite_by_id(db=db, invite_id=invite_id)
+        if not invite or invite.group_id != group_id:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Invite not found")
+        revoke_invite(db=db, invite=invite, revoked_by=author.email)
+
+
+def update_group_member_role(
+    token: str,
+    group_id: UUID,
+    author_id: UUID,
+    request: UpdateGroupMemberRoleRequest,
+) -> AuthorGroupDetailDTO:
+    current_author = validate_and_extract_author_details(token=token)
+    with SessionLocal() as db:
+        group = get_group_by_id(db=db, group_id=group_id)
+        if not group:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Group not found")
+        if not current_author.is_admin:
+            current_member = _get_member_or_403(db=db, group_id=group_id, author_id=current_author.id)
+            _assert_role_allowed(current_member, [AuthorGroupMemberRole.OWNER, AuthorGroupMemberRole.ADMIN])
+
+        target_member = get_group_member(db=db, group_id=group_id, author_id=author_id)
+        if not target_member:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Group member not found")
+
+        target_role = _to_role_value(target_member.role)
+        requested_role = _to_role_value(request.role)
+        if target_role == "OWNER" and requested_role != "OWNER":
+            owner_count = get_owner_count(db=db, group_id=group_id)
+            if owner_count <= 1:
+                raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="At least one OWNER must always remain")
+
+        set_group_member_role(db=db, member=target_member, role=request.role.value, updated_by=current_author.email)
+        loaded = get_group_by_id(db=db, group_id=group_id)
+        follower_count = get_followers_count_map(db=db, group_ids=[group_id]).get(group_id, 0)
+        return _group_to_detail(loaded, follower_count=follower_count)
+
+
+def delete_group_member(token: str, group_id: UUID, author_id: UUID) -> None:
+    current_author = validate_and_extract_author_details(token=token)
+    with SessionLocal() as db:
+        group = get_group_by_id(db=db, group_id=group_id)
+        if not group:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Group not found")
+        if not current_author.is_admin:
+            current_member = _get_member_or_403(db=db, group_id=group_id, author_id=current_author.id)
+            _assert_role_allowed(current_member, [AuthorGroupMemberRole.OWNER, AuthorGroupMemberRole.ADMIN])
+
+        member = get_group_member(db=db, group_id=group_id, author_id=author_id)
+        if not member:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Group member not found")
+        if _to_role_value(member.role) == "OWNER":
+            owner_count = get_owner_count(db=db, group_id=group_id)
+            if owner_count <= 1:
+                raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="OWNER cannot be removed if they are the last owner")
+        remove_group_member(db=db, member=member)

--- a/pecha_api/plans/groups/groups_views.py
+++ b/pecha_api/plans/groups/groups_views.py
@@ -84,11 +84,11 @@ def get_cms_group(
 @cms_groups_router.get("", status_code=status.HTTP_200_OK, response_model=AuthorGroupListResponse)
 def get_cms_groups(
     authentication_credential: Annotated[HTTPAuthorizationCredentials, Depends(oauth2_scheme)],
-    search: Optional[str] = Query(default=None),
-    language: Optional[str] = Query(default=None),
-    tag_id: Optional[UUID] = Query(default=None),
-    skip: int = Query(default=0, ge=0),
-    limit: int = Query(default=20, ge=1, le=100),
+    search: Annotated[Optional[str], Query()] = None,
+    language: Annotated[Optional[str], Query()] = None,
+    tag_id: Annotated[Optional[UUID], Query()] = None,
+    skip: Annotated[int, Query(ge=0)] = 0,
+    limit: Annotated[int, Query(ge=1, le=100)] = 20,
 ):
     return list_cms_groups(
         token=authentication_credential.credentials,
@@ -235,11 +235,11 @@ def get_public_group(group_id: UUID):
 
 @public_groups_router.get("", status_code=status.HTTP_200_OK, response_model=AuthorGroupListResponse)
 def get_public_groups(
-    search: Optional[str] = Query(default=None),
-    language: Optional[str] = Query(default=None),
-    tag_id: Optional[UUID] = Query(default=None),
-    skip: int = Query(default=0, ge=0),
-    limit: int = Query(default=20, ge=1, le=100),
+    search: Annotated[Optional[str], Query()] = None,
+    language: Annotated[Optional[str], Query()] = None,
+    tag_id: Annotated[Optional[UUID], Query()] = None,
+    skip: Annotated[int, Query(ge=0)] = 0,
+    limit: Annotated[int, Query(ge=1, le=100)] = 20,
 ):
     return list_public_groups(
         search=search,
@@ -271,8 +271,8 @@ def delete_follow_group(
 @user_groups_router.get("", status_code=status.HTTP_200_OK, response_model=AuthorGroupListResponse)
 def get_my_followed_groups(
     authentication_credential: Annotated[HTTPAuthorizationCredentials, Depends(oauth2_scheme)],
-    skip: int = Query(default=0, ge=0),
-    limit: int = Query(default=20, ge=1, le=100),
+    skip: Annotated[int, Query(ge=0)] = 0,
+    limit: Annotated[int, Query(ge=1, le=100)] = 20,
 ):
     return list_followed_groups(
         token=authentication_credential.credentials,

--- a/pecha_api/plans/groups/groups_views.py
+++ b/pecha_api/plans/groups/groups_views.py
@@ -1,0 +1,281 @@
+from typing import Annotated, Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Query
+from fastapi.responses import JSONResponse
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from starlette import status
+
+from pecha_api.plans.groups.groups_response_models import (
+    AcceptGroupInviteRequest,
+    AuthorGroupDetailDTO,
+    AuthorGroupListResponse,
+    CreateAuthorGroupRequest,
+    CreateGroupInviteRequest,
+    GroupInviteCreatedResponse,
+    ReplaceGroupPlansRequest,
+    ReplaceGroupSeriesRequest,
+    ReplaceGroupSocialLinksRequest,
+    ReplaceGroupTagsRequest,
+    UpdateAuthorGroupRequest,
+    UpdateGroupMemberRoleRequest,
+)
+from pecha_api.plans.groups.groups_service import (
+    InviteEmailMismatchError,
+    accept_group_invite,
+    create_author_group,
+    create_group_member_invite,
+    delete_group_member,
+    follow_group,
+    get_author_group_detail,
+    get_cms_group_detail,
+    list_cms_groups,
+    list_followed_groups,
+    list_public_groups,
+    replace_group_plans_by_id,
+    replace_group_series_by_id,
+    replace_group_social_links_by_id,
+    replace_group_tags,
+    revoke_group_invite,
+    unfollow_group,
+    update_author_group,
+    update_group_member_role,
+)
+
+oauth2_scheme = HTTPBearer()
+
+cms_groups_router = APIRouter(prefix="/cms/groups", tags=["CMS Groups"])
+public_groups_router = APIRouter(prefix="/groups", tags=["Author Groups"])
+user_groups_router = APIRouter(prefix="/users/me/following/groups", tags=["Author Groups"])
+
+
+@cms_groups_router.post("", status_code=status.HTTP_201_CREATED, response_model=AuthorGroupDetailDTO)
+def post_cms_group(
+    create_group_request: CreateAuthorGroupRequest,
+    authentication_credential: Annotated[HTTPAuthorizationCredentials, Depends(oauth2_scheme)],
+):
+    return create_author_group(
+        token=authentication_credential.credentials,
+        request=create_group_request,
+    )
+
+
+@cms_groups_router.patch("/{group_id}", status_code=status.HTTP_200_OK, response_model=AuthorGroupDetailDTO)
+def patch_cms_group(
+    group_id: UUID,
+    update_group_request: UpdateAuthorGroupRequest,
+    authentication_credential: Annotated[HTTPAuthorizationCredentials, Depends(oauth2_scheme)],
+):
+    return update_author_group(
+        token=authentication_credential.credentials,
+        group_id=group_id,
+        request=update_group_request,
+    )
+
+
+@cms_groups_router.get("/{group_id}", status_code=status.HTTP_200_OK, response_model=AuthorGroupDetailDTO)
+def get_cms_group(
+    group_id: UUID,
+    authentication_credential: Annotated[HTTPAuthorizationCredentials, Depends(oauth2_scheme)],
+):
+    return get_cms_group_detail(token=authentication_credential.credentials, group_id=group_id)
+
+
+@cms_groups_router.get("", status_code=status.HTTP_200_OK, response_model=AuthorGroupListResponse)
+def get_cms_groups(
+    authentication_credential: Annotated[HTTPAuthorizationCredentials, Depends(oauth2_scheme)],
+    search: Optional[str] = Query(default=None),
+    language: Optional[str] = Query(default=None),
+    tag_id: Optional[UUID] = Query(default=None),
+    skip: int = Query(default=0, ge=0),
+    limit: int = Query(default=20, ge=1, le=100),
+):
+    return list_cms_groups(
+        token=authentication_credential.credentials,
+        search=search,
+        language=language,
+        tag_id=tag_id,
+        skip=skip,
+        limit=limit,
+    )
+
+
+@cms_groups_router.put("/{group_id}/tags", status_code=status.HTTP_200_OK, response_model=AuthorGroupDetailDTO)
+def put_cms_group_tags(
+    group_id: UUID,
+    request: ReplaceGroupTagsRequest,
+    authentication_credential: Annotated[HTTPAuthorizationCredentials, Depends(oauth2_scheme)],
+):
+    return replace_group_tags(
+        token=authentication_credential.credentials,
+        group_id=group_id,
+        request=request,
+    )
+
+
+@cms_groups_router.put("/{group_id}/social-links", status_code=status.HTTP_200_OK, response_model=AuthorGroupDetailDTO)
+def put_cms_group_social_links(
+    group_id: UUID,
+    request: ReplaceGroupSocialLinksRequest,
+    authentication_credential: Annotated[HTTPAuthorizationCredentials, Depends(oauth2_scheme)],
+):
+    return replace_group_social_links_by_id(
+        token=authentication_credential.credentials,
+        group_id=group_id,
+        request=request,
+    )
+
+
+@cms_groups_router.put("/{group_id}/series", status_code=status.HTTP_200_OK, response_model=AuthorGroupDetailDTO)
+def put_cms_group_series(
+    group_id: UUID,
+    request: ReplaceGroupSeriesRequest,
+    authentication_credential: Annotated[HTTPAuthorizationCredentials, Depends(oauth2_scheme)],
+):
+    return replace_group_series_by_id(
+        token=authentication_credential.credentials,
+        group_id=group_id,
+        request=request,
+    )
+
+
+@cms_groups_router.put("/{group_id}/plans", status_code=status.HTTP_200_OK, response_model=AuthorGroupDetailDTO)
+def put_cms_group_plans(
+    group_id: UUID,
+    request: ReplaceGroupPlansRequest,
+    authentication_credential: Annotated[HTTPAuthorizationCredentials, Depends(oauth2_scheme)],
+):
+    return replace_group_plans_by_id(
+        token=authentication_credential.credentials,
+        group_id=group_id,
+        request=request,
+    )
+
+
+@cms_groups_router.post("/{group_id}/members/invites", status_code=status.HTTP_201_CREATED, response_model=GroupInviteCreatedResponse)
+def post_cms_group_invite(
+    group_id: UUID,
+    request: CreateGroupInviteRequest,
+    authentication_credential: Annotated[HTTPAuthorizationCredentials, Depends(oauth2_scheme)],
+):
+    return create_group_member_invite(
+        token=authentication_credential.credentials,
+        group_id=group_id,
+        request=request,
+    )
+
+
+@cms_groups_router.post("/invites/accept", status_code=status.HTTP_200_OK, response_model=AuthorGroupDetailDTO)
+def post_accept_group_invite(
+    request: AcceptGroupInviteRequest,
+    authentication_credential: Annotated[HTTPAuthorizationCredentials, Depends(oauth2_scheme)],
+):
+    try:
+        return accept_group_invite(
+            token=authentication_credential.credentials,
+            request=request,
+        )
+    except InviteEmailMismatchError as exc:
+        return JSONResponse(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            content={
+                "detail": str(exc),
+                "code": "INVITE_EMAIL_MISMATCH",
+            },
+        )
+
+
+@cms_groups_router.post("/{group_id}/members/invites/{invite_id}/revoke", status_code=status.HTTP_204_NO_CONTENT)
+def post_revoke_group_invite(
+    group_id: UUID,
+    invite_id: UUID,
+    authentication_credential: Annotated[HTTPAuthorizationCredentials, Depends(oauth2_scheme)],
+):
+    revoke_group_invite(
+        token=authentication_credential.credentials,
+        group_id=group_id,
+        invite_id=invite_id,
+    )
+    return None
+
+
+@cms_groups_router.patch("/{group_id}/members/{author_id}/role", status_code=status.HTTP_200_OK, response_model=AuthorGroupDetailDTO)
+def patch_group_member_role(
+    group_id: UUID,
+    author_id: UUID,
+    request: UpdateGroupMemberRoleRequest,
+    authentication_credential: Annotated[HTTPAuthorizationCredentials, Depends(oauth2_scheme)],
+):
+    return update_group_member_role(
+        token=authentication_credential.credentials,
+        group_id=group_id,
+        author_id=author_id,
+        request=request,
+    )
+
+
+@cms_groups_router.delete("/{group_id}/members/{author_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_group_member_by_id(
+    group_id: UUID,
+    author_id: UUID,
+    authentication_credential: Annotated[HTTPAuthorizationCredentials, Depends(oauth2_scheme)],
+):
+    delete_group_member(
+        token=authentication_credential.credentials,
+        group_id=group_id,
+        author_id=author_id,
+    )
+    return None
+
+
+@public_groups_router.get("/{group_id}", status_code=status.HTTP_200_OK, response_model=AuthorGroupDetailDTO)
+def get_public_group(group_id: UUID):
+    return get_author_group_detail(group_id=group_id, require_public=True)
+
+
+@public_groups_router.get("", status_code=status.HTTP_200_OK, response_model=AuthorGroupListResponse)
+def get_public_groups(
+    search: Optional[str] = Query(default=None),
+    language: Optional[str] = Query(default=None),
+    tag_id: Optional[UUID] = Query(default=None),
+    skip: int = Query(default=0, ge=0),
+    limit: int = Query(default=20, ge=1, le=100),
+):
+    return list_public_groups(
+        search=search,
+        language=language,
+        tag_id=tag_id,
+        skip=skip,
+        limit=limit,
+    )
+
+
+@public_groups_router.post("/{group_id}/follow", status_code=status.HTTP_204_NO_CONTENT)
+def post_follow_group(
+    group_id: UUID,
+    authentication_credential: Annotated[HTTPAuthorizationCredentials, Depends(oauth2_scheme)],
+):
+    follow_group(token=authentication_credential.credentials, group_id=group_id)
+    return None
+
+
+@public_groups_router.delete("/{group_id}/follow", status_code=status.HTTP_204_NO_CONTENT)
+def delete_follow_group(
+    group_id: UUID,
+    authentication_credential: Annotated[HTTPAuthorizationCredentials, Depends(oauth2_scheme)],
+):
+    unfollow_group(token=authentication_credential.credentials, group_id=group_id)
+    return None
+
+
+@user_groups_router.get("", status_code=status.HTTP_200_OK, response_model=AuthorGroupListResponse)
+def get_my_followed_groups(
+    authentication_credential: Annotated[HTTPAuthorizationCredentials, Depends(oauth2_scheme)],
+    skip: int = Query(default=0, ge=0),
+    limit: int = Query(default=20, ge=1, le=100),
+):
+    return list_followed_groups(
+        token=authentication_credential.credentials,
+        skip=skip,
+        limit=limit,
+    )

--- a/pecha_api/plans/public/plan_repository.py
+++ b/pecha_api/plans/public/plan_repository.py
@@ -1,8 +1,9 @@
 from sqlalchemy.orm import Session, selectinload
-from sqlalchemy import func, desc, asc
+from sqlalchemy import and_, exists, func, desc, asc, or_, select
 from typing import Optional, Tuple, List
 from uuid import UUID
 from pecha_api.plans.plans_models import Plan
+from pecha_api.plans.groups.groups_models import author_group_plans, author_group_series
 from pecha_api.plans.tags.tag_model import Tag, plan_tags
 from pecha_api.plans.items.plan_items_models import PlanItem
 from pecha_api.plans.users.plan_users_models import UserPlanProgress
@@ -16,6 +17,7 @@ DEFAULT_SEARCH = None
 DEFAULT_SORT_BY = "title"
 DEFAULT_SORT_ORDER = "asc"
 DEFAULT_TAG = None
+DEFAULT_GROUP_ID = None
 
 def get_aggregate_counts():
     total_days_label = func.count(func.distinct(PlanItem.id)).label("total_days")
@@ -54,6 +56,28 @@ def apply_tag_filter(query, tag: Optional[str]):
         )
     return query
 
+
+def apply_group_filter(query, group_id: Optional[UUID]):
+    if group_id:
+        direct_plan_exists = exists(
+            select(1).where(
+                and_(
+                    author_group_plans.c.group_id == group_id,
+                    author_group_plans.c.plan_id == Plan.id,
+                )
+            )
+        )
+        series_plan_exists = exists(
+            select(1).where(
+                and_(
+                    author_group_series.c.group_id == group_id,
+                    author_group_series.c.series_id == Plan.series_id,
+                )
+            )
+        )
+        query = query.filter(or_(direct_plan_exists, series_plan_exists))
+    return query
+
 def apply_sorting(query, sort_by: str, sort_order: str, total_days_label, subscription_count_label):
     sort_column_map = {
         "title": Plan.title,
@@ -83,19 +107,27 @@ def get_published_plans_from_db(db: Session,
     language: str = DEFAULT_LANGUAGE,  
     sort_by: str = DEFAULT_SORT_BY,
     sort_order: str = DEFAULT_SORT_ORDER,
-    tag: Optional[str] = DEFAULT_TAG
+    tag: Optional[str] = DEFAULT_TAG,
+    group_id: Optional[UUID] = DEFAULT_GROUP_ID,
 ):
     total_days_label, subscription_count_label = get_aggregate_counts()
     query = get_published_plans_query(db, total_days_label, subscription_count_label, language)
     query = apply_search_filter(query, search)
     query = apply_tag_filter(query, tag)
+    query = apply_group_filter(query, group_id)
     query = apply_sorting(query, sort_by, sort_order, total_days_label, subscription_count_label)
     rows = query.offset(skip).limit(limit).all()
     
     return convert_to_plan_aggregates(rows)
 
 
-def get_published_plans_count(db: Session, search: Optional[str] = DEFAULT_SEARCH, language: str = DEFAULT_LANGUAGE, tag: Optional[str] = DEFAULT_TAG) -> int:
+def get_published_plans_count(
+    db: Session,
+    search: Optional[str] = DEFAULT_SEARCH,
+    language: str = DEFAULT_LANGUAGE,
+    tag: Optional[str] = DEFAULT_TAG,
+    group_id: Optional[UUID] = DEFAULT_GROUP_ID,
+) -> int:
     query = db.query(func.count(Plan.id)).filter(
         Plan.deleted_at.is_(None),
         Plan.status == PlanStatus.PUBLISHED,
@@ -109,6 +141,7 @@ def get_published_plans_count(db: Session, search: Optional[str] = DEFAULT_SEARC
             .join(Tag, Tag.id == plan_tags.c.tag_id)
             .filter(Tag.deleted_at.is_(None), func.lower(Tag.name) == tag.lower())
         )
+    query = apply_group_filter(query, group_id)
     return query.scalar()
 
 

--- a/pecha_api/plans/public/plan_service.py
+++ b/pecha_api/plans/public/plan_service.py
@@ -42,6 +42,7 @@ async def get_image_url(image_url: Optional[str]) -> Optional[ImageUrlModel]:
 
 async def get_published_plans(
     tag: Optional[str] = None,
+    group_id: Optional[UUID] = None,
     search: Optional[str] = None, 
     language: str = "en", 
     sort_by: str = "title", 
@@ -53,7 +54,17 @@ async def get_published_plans(
     try:
         with SessionLocal() as db:
             language_upper = language.upper()
-            plan_aggregates = get_published_plans_from_db(db=db, skip=skip, limit=limit, search=search, language=language_upper, sort_by=sort_by, sort_order=sort_order, tag=tag)
+            plan_aggregates = get_published_plans_from_db(
+                db=db,
+                skip=skip,
+                limit=limit,
+                search=search,
+                language=language_upper,
+                sort_by=sort_by,
+                sort_order=sort_order,
+                tag=tag,
+                group_id=group_id,
+            )
             
             plan_dtos = []
             for plan_aggregate in plan_aggregates:
@@ -86,7 +97,13 @@ async def get_published_plans(
                 )
                 plan_dtos.append(plan_dto)
             
-            total = get_published_plans_count(db=db, search=search, language=language_upper, tag=tag)
+            total = get_published_plans_count(
+                db=db,
+                search=search,
+                language=language_upper,
+                tag=tag,
+                group_id=group_id,
+            )
             
             return PublicPlansResponse(plans=plan_dtos, skip=skip, limit=limit, total=total)
     

--- a/pecha_api/plans/public/plan_views.py
+++ b/pecha_api/plans/public/plan_views.py
@@ -29,14 +29,17 @@ public_plans_router = APIRouter(
 
 @public_plans_router.get("", status_code=status.HTTP_200_OK, response_model=PublicPlansResponse)
 async def get_plans(
-    tag: Optional[str] = Query(None, description="Filter by tag"),
-    group_id: Optional[UUID] = Query(None, description="Filter by author group"),
-    search: Optional[str] = Query(None, description="Search by plan title"),
-    language: str = Query("en", description="Filter by language code (e.g., 'bo', 'en', 'zh'). Defaults to 'en'."),
-    sort_by: str = Query("title", enum=["title", "total_days", "subscription_count"]),
-    sort_order: str = Query("asc", enum=["asc", "desc"]),
-    skip: int = Query(0, ge=0),
-    limit: int = Query(20, ge=1, le=50)
+    tag: Annotated[Optional[str], Query(description="Filter by tag")] = None,
+    group_id: Annotated[Optional[UUID], Query(description="Filter by author group")] = None,
+    search: Annotated[Optional[str], Query(description="Search by plan title")] = None,
+    language: Annotated[
+        str,
+        Query(description="Filter by language code (e.g., 'bo', 'en', 'zh'). Defaults to 'en'."),
+    ] = "en",
+    sort_by: Annotated[str, Query(enum=["title", "total_days", "subscription_count"])] = "title",
+    sort_order: Annotated[str, Query(enum=["asc", "desc"])] = "asc",
+    skip: Annotated[int, Query(ge=0)] = 0,
+    limit: Annotated[int, Query(ge=1, le=50)] = 20,
 ):
     return await get_published_plans(
         tag=tag,
@@ -54,10 +57,10 @@ async def get_plans(
     "/tags", status_code=status.HTTP_200_OK, response_model=TagsResponse
 )
 def get_plan_tags(
-    language: str = Query(
-        "en",
-        description="Filter by language code (e.g., 'bo', 'en', 'zh'). Defaults to 'en'.",
-    )
+    language: Annotated[
+        str,
+        Query(description="Filter by language code (e.g., 'bo', 'en', 'zh'). Defaults to 'en'."),
+    ] = "en",
 ):
     return get_tags(language=language)
 
@@ -71,7 +74,10 @@ async def get_plan_details(plan_id: UUID):
 
 async def get_plan_daily(
     plan_id: UUID,
-    date: Optional[DateType] = Query(None, description="Date in YYYY-MM-DD format. Defaults to today if not provided.")
+    date: Annotated[
+        Optional[DateType],
+        Query(description="Date in YYYY-MM-DD format. Defaults to today if not provided."),
+    ] = None,
 ):
     return await get_plan_daily_content(plan_id=plan_id, requested_date=date)
 

--- a/pecha_api/plans/public/plan_views.py
+++ b/pecha_api/plans/public/plan_views.py
@@ -30,6 +30,7 @@ public_plans_router = APIRouter(
 @public_plans_router.get("", status_code=status.HTTP_200_OK, response_model=PublicPlansResponse)
 async def get_plans(
     tag: Optional[str] = Query(None, description="Filter by tag"),
+    group_id: Optional[UUID] = Query(None, description="Filter by author group"),
     search: Optional[str] = Query(None, description="Search by plan title"),
     language: str = Query("en", description="Filter by language code (e.g., 'bo', 'en', 'zh'). Defaults to 'en'."),
     sort_by: str = Query("title", enum=["title", "total_days", "subscription_count"]),
@@ -37,7 +38,16 @@ async def get_plans(
     skip: int = Query(0, ge=0),
     limit: int = Query(20, ge=1, le=50)
 ):
-    return await get_published_plans(tag=tag, search=search, language=language, sort_by=sort_by, sort_order=sort_order, skip=skip, limit=limit)
+    return await get_published_plans(
+        tag=tag,
+        group_id=group_id,
+        search=search,
+        language=language,
+        sort_by=sort_by,
+        sort_order=sort_order,
+        skip=skip,
+        limit=limit,
+    )
 
 
 @public_plans_router.get(

--- a/pecha_api/plans/series/public_series_view.py
+++ b/pecha_api/plans/series/public_series_view.py
@@ -21,10 +21,14 @@ async def get_series_list(
         Optional[str],
         Query(description="Filter by series metadata language (e.g. 'en', 'bo', 'zh')"),
     ] = None,
+    group_id: Annotated[
+        Optional[UUID],
+        Query(description="Filter by author group id"),
+    ] = None,
     skip: Annotated[int, Query()] = 0,
     limit: Annotated[int, Query()] = 10,
 ):
-    return get_filtered_series(search=search, skip=skip, limit=limit, language=language)
+    return get_filtered_series(search=search, skip=skip, limit=limit, language=language, group_id=group_id)
 
 
 @public_series_router.get(

--- a/pecha_api/plans/series/series_repository.py
+++ b/pecha_api/plans/series/series_repository.py
@@ -9,6 +9,7 @@ from pecha_api.plans.plans_enums import PlanStatus
 from pecha_api.plans.series.series_model import Series
 from pecha_api.plans.series.series_metadata_model import SeriesMetadata
 from pecha_api.plans.plans_models import Plan
+from pecha_api.plans.groups.groups_models import author_group_series
 
 
 def _series_active_plans_count_subquery(published_only: bool = False):
@@ -207,6 +208,7 @@ def get_series_paginated(
     status: Optional[PlanStatus] = None,
     featured: Optional[bool] = None,
     published_only: bool = False,
+    group_id: Optional[UUID] = None,
 ) -> Tuple[List[Tuple[Series, int]], int]:
 
     filters = []
@@ -237,6 +239,15 @@ def get_series_paginated(
                 select(1).where(
                     SeriesMetadata.series_id == Series.id,
                     SeriesMetadata.language == language_upper,
+                )
+            )
+        )
+    if group_id:
+        filters.append(
+            exists(
+                select(1).where(
+                    author_group_series.c.group_id == group_id,
+                    author_group_series.c.series_id == Series.id,
                 )
             )
         )

--- a/pecha_api/plans/series/series_service.py
+++ b/pecha_api/plans/series/series_service.py
@@ -190,6 +190,7 @@ def get_filtered_series(
     skip: int,
     limit: int,
     language: Optional[str] = None,
+    group_id: Optional[UUID] = None,
 ) -> SeriesListResponse:
     with SessionLocal() as db_session:
         rows, total = get_series_paginated(
@@ -203,6 +204,7 @@ def get_filtered_series(
             language=language,
             status=PlanStatus.PUBLISHED,
             published_only=True,
+            group_id=group_id,
         )
 
     series_dtos: List[SeriesListItemDTO] = [

--- a/tests/plans/groups/test_groups_service.py
+++ b/tests/plans/groups/test_groups_service.py
@@ -1,0 +1,831 @@
+import hashlib
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+from starlette import status
+
+from pecha_api.plans.groups.groups_enums import AuthorGroupMemberRole
+from pecha_api.plans.groups.groups_response_models import (
+    AcceptGroupInviteRequest,
+    CreateAuthorGroupRequest,
+    CreateGroupInviteRequest,
+    GroupMetadataInput,
+    GroupSocialLinkInput,
+    ReplaceGroupPlansRequest,
+    ReplaceGroupSeriesRequest,
+    ReplaceGroupSocialLinksRequest,
+    ReplaceGroupTagsRequest,
+    UpdateAuthorGroupRequest,
+    UpdateGroupMemberRoleRequest,
+)
+from pecha_api.plans.groups.groups_service import (
+    GROUP_NOT_FOUND,
+    InviteEmailMismatchError,
+    _assert_metadata_valid,
+    _get_member_or_403,
+    _to_role_value,
+    accept_group_invite,
+    create_author_group,
+    create_group_member_invite,
+    delete_group_member,
+    follow_group,
+    get_author_group_detail,
+    get_cms_group_detail,
+    list_cms_groups,
+    list_followed_groups,
+    list_public_groups,
+    replace_group_plans_by_id,
+    replace_group_series_by_id,
+    replace_group_social_links_by_id,
+    replace_group_tags,
+    revoke_group_invite,
+    unfollow_group,
+    update_author_group,
+    update_group_member_role,
+)
+from pecha_api.plans.plans_enums import LanguageCode
+
+
+def _session_local_context(mock_session_local):
+    mock_db = MagicMock()
+    mock_session_local.return_value.__enter__.return_value = mock_db
+    mock_session_local.return_value.__exit__.return_value = False
+    return mock_db
+
+
+def _make_author(author_id=None, email="author@example.org", is_admin=False):
+    author = MagicMock()
+    author.id = author_id or uuid4()
+    author.email = email
+    author.is_admin = is_admin
+    return author
+
+
+def _make_group(is_public=True, slug="test-group"):
+    group = MagicMock()
+    group.id = uuid4()
+    group.slug = slug
+    group.is_public = is_public
+    group.avatar_key = None
+    group.banner_key = None
+    group.metadata_entries = []
+    group.members = []
+    group.social_links = []
+    group.tags = []
+    group.plans = []
+    group.series = []
+    return group
+
+
+def _metadata_input(title="Title", language=LanguageCode.EN):
+    return GroupMetadataInput(title=title, description="Desc", language=language)
+
+
+def test_assert_metadata_valid_rejects_empty():
+    with pytest.raises(HTTPException) as exc:
+        _assert_metadata_valid([])
+    assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_assert_metadata_valid_rejects_duplicate_language():
+    with pytest.raises(HTTPException) as exc:
+        _assert_metadata_valid(
+            [
+                _metadata_input(language=LanguageCode.EN),
+                _metadata_input(title="Other", language=LanguageCode.EN),
+            ]
+        )
+    assert "unique" in exc.value.detail.lower()
+
+
+def test_assert_metadata_valid_rejects_missing_title():
+    entry = _metadata_input()
+    entry.title = ""
+    with pytest.raises(HTTPException) as exc:
+        _assert_metadata_valid([entry])
+    assert "title" in exc.value.detail.lower()
+
+
+def test_to_role_value_accepts_string():
+    assert _to_role_value("OWNER") == "OWNER"
+
+
+def test_get_member_or_403_raises_when_not_member():
+    with patch("pecha_api.plans.groups.groups_service.get_group_member", return_value=None):
+        with pytest.raises(HTTPException) as exc:
+            _get_member_or_403(db=MagicMock(), group_id=uuid4(), author_id=uuid4())
+    assert exc.value.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_get_cms_group_detail_success():
+    author = _make_author(is_admin=True)
+    group = _make_group()
+    meta = MagicMock()
+    meta.id = uuid4()
+    meta.title = "T"
+    meta.description = "D"
+    meta.language = "EN"
+    group.metadata_entries = [meta]
+
+    with patch("pecha_api.plans.groups.groups_service.SessionLocal") as mock_session, patch(
+        "pecha_api.plans.groups.groups_service.validate_and_extract_author_details",
+        return_value=author,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_group_by_id",
+        return_value=group,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_followers_count_map",
+        return_value={group.id: 2},
+    ):
+        _session_local_context(mock_session)
+        result = get_cms_group_detail(token="t", group_id=group.id)
+    assert result.follower_count == 2
+
+
+def test_update_author_group_success_as_admin():
+    author = _make_author(is_admin=True)
+    group = _make_group()
+    meta = MagicMock()
+    meta.id = uuid4()
+    meta.title = "T"
+    meta.description = "D"
+    meta.language = "EN"
+    group.metadata_entries = [meta]
+
+    with patch("pecha_api.plans.groups.groups_service.SessionLocal") as mock_session, patch(
+        "pecha_api.plans.groups.groups_service.validate_and_extract_author_details",
+        return_value=author,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_group_by_id",
+        return_value=group,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.update_group",
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_followers_count_map",
+        return_value={group.id: 0},
+    ):
+        _session_local_context(mock_session)
+        result = update_author_group(
+            token="t",
+            group_id=group.id,
+            request=UpdateAuthorGroupRequest(is_public=False),
+        )
+    assert result.is_public is False
+
+
+def test_accept_group_invite_revoked():
+    author = _make_author(email="a@b.com")
+    invite = MagicMock()
+    invite.target_email = "a@b.com"
+    invite.revoked_at = datetime.now(timezone.utc)
+    invite.expires_at = datetime.now(timezone.utc) + timedelta(days=1)
+    invite.max_uses = 1
+    invite.uses_count = 0
+
+    with patch("pecha_api.plans.groups.groups_service.SessionLocal") as mock_session, patch(
+        "pecha_api.plans.groups.groups_service.validate_and_extract_author_details",
+        return_value=author,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_invite_by_token_hash",
+        return_value=invite,
+    ):
+        _session_local_context(mock_session)
+        with pytest.raises(HTTPException) as exc:
+            accept_group_invite(token="t", request=AcceptGroupInviteRequest(token="raw"))
+    assert "revoked" in exc.value.detail.lower()
+
+
+def test_accept_group_invite_not_found():
+    author = _make_author()
+    with patch("pecha_api.plans.groups.groups_service.SessionLocal") as mock_session, patch(
+        "pecha_api.plans.groups.groups_service.validate_and_extract_author_details",
+        return_value=author,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_invite_by_token_hash",
+        return_value=None,
+    ):
+        _session_local_context(mock_session)
+        with pytest.raises(HTTPException) as exc:
+            accept_group_invite(token="t", request=AcceptGroupInviteRequest(token="raw"))
+    assert exc.value.detail == "Invite not found"
+
+
+def test_replace_group_series_invalid_ids():
+    author = _make_author()
+    group = _make_group()
+    series_id = uuid4()
+    current = MagicMock()
+    current.role = AuthorGroupMemberRole.OWNER
+
+    with patch("pecha_api.plans.groups.groups_service.SessionLocal") as mock_session, patch(
+        "pecha_api.plans.groups.groups_service.validate_and_extract_author_details",
+        return_value=author,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_group_by_id",
+        return_value=group,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_group_member",
+        return_value=current,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_series_by_ids",
+        return_value=[],
+    ):
+        _session_local_context(mock_session)
+        with pytest.raises(HTTPException) as exc:
+            replace_group_series_by_id(
+                token="t",
+                group_id=group.id,
+                request=ReplaceGroupSeriesRequest(series_ids=[series_id]),
+            )
+    assert "series" in exc.value.detail.lower()
+
+
+def test_create_author_group_success():
+    author = _make_author()
+    request = CreateAuthorGroupRequest(
+        slug="new-group",
+        is_public=True,
+        metadata=[_metadata_input()],
+    )
+    created = _make_group(slug="new-group")
+    created.id = uuid4()
+    meta = MagicMock()
+    meta.id = uuid4()
+    meta.title = "Title"
+    meta.description = "Desc"
+    meta.language = "EN"
+    created.metadata_entries = [meta]
+
+    with patch("pecha_api.plans.groups.groups_service.SessionLocal") as mock_session, patch(
+        "pecha_api.plans.groups.groups_service.validate_and_extract_author_details",
+        return_value=author,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_group_by_slug",
+        return_value=None,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.create_group",
+        return_value=created,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_group_by_id",
+        return_value=created,
+    ):
+        _session_local_context(mock_session)
+        result = create_author_group(token="t", request=request)
+
+    assert result.slug == "new-group"
+
+
+def test_create_author_group_slug_exists():
+    author = _make_author()
+    request = CreateAuthorGroupRequest(slug="taken", metadata=[_metadata_input()])
+
+    with patch("pecha_api.plans.groups.groups_service.SessionLocal") as mock_session, patch(
+        "pecha_api.plans.groups.groups_service.validate_and_extract_author_details",
+        return_value=author,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_group_by_slug",
+        return_value=_make_group(slug="taken"),
+    ):
+        _session_local_context(mock_session)
+        with pytest.raises(HTTPException) as exc:
+            create_author_group(token="t", request=request)
+    assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_get_author_group_detail_not_found():
+    with patch("pecha_api.plans.groups.groups_service.SessionLocal") as mock_session, patch(
+        "pecha_api.plans.groups.groups_service.get_group_by_id",
+        return_value=None,
+    ):
+        _session_local_context(mock_session)
+        with pytest.raises(HTTPException) as exc:
+            get_author_group_detail(group_id=uuid4())
+    assert exc.value.detail == GROUP_NOT_FOUND
+
+
+def test_get_author_group_detail_private_group_hidden():
+    private_group = _make_group(is_public=False)
+    with patch("pecha_api.plans.groups.groups_service.SessionLocal") as mock_session, patch(
+        "pecha_api.plans.groups.groups_service.get_group_by_id",
+        return_value=private_group,
+    ):
+        _session_local_context(mock_session)
+        with pytest.raises(HTTPException) as exc:
+            get_author_group_detail(group_id=private_group.id, require_public=True)
+    assert exc.value.detail == GROUP_NOT_FOUND
+
+
+def test_list_public_groups_returns_paginated():
+    group = _make_group()
+    meta = MagicMock()
+    meta.id = uuid4()
+    meta.title = "T"
+    meta.description = None
+    meta.language = "EN"
+    group.metadata_entries = [meta]
+    with patch("pecha_api.plans.groups.groups_service.SessionLocal") as mock_session, patch(
+        "pecha_api.plans.groups.groups_service.get_groups_paginated",
+        return_value=([group], 1),
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_followers_count_map",
+        return_value={group.id: 3},
+    ):
+        _session_local_context(mock_session)
+        result = list_public_groups(skip=0, limit=10)
+
+    assert result.total == 1
+    assert result.groups[0].follower_count == 3
+
+
+def test_list_cms_groups_scopes_to_member_groups_for_non_admin():
+    author = _make_author(is_admin=False)
+    group = _make_group()
+    membership = MagicMock()
+    membership.group_id = group.id
+
+    mock_db = MagicMock()
+    mock_db.query.return_value.filter.return_value.all.return_value = [membership]
+
+    with patch("pecha_api.plans.groups.groups_service.SessionLocal") as mock_session, patch(
+        "pecha_api.plans.groups.groups_service.validate_and_extract_author_details",
+        return_value=author,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_groups_paginated",
+        return_value=([group], 1),
+    ) as mock_paginated, patch(
+        "pecha_api.plans.groups.groups_service.get_followers_count_map",
+        return_value={},
+    ):
+        mock_session.return_value.__enter__.return_value = mock_db
+        mock_session.return_value.__exit__.return_value = False
+        list_cms_groups(token="t", skip=0, limit=10)
+
+    assert mock_paginated.call_args.kwargs["group_ids"] == [group.id]
+
+
+def test_follow_group_requires_public_group():
+    user = MagicMock()
+    user.id = uuid4()
+    with patch("pecha_api.plans.groups.groups_service.SessionLocal") as mock_session, patch(
+        "pecha_api.plans.groups.groups_service.validate_and_extract_user_details",
+        return_value=user,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_group_by_id",
+        return_value=None,
+    ):
+        _session_local_context(mock_session)
+        with pytest.raises(HTTPException) as exc:
+            follow_group(token="t", group_id=uuid4())
+    assert exc.value.detail == GROUP_NOT_FOUND
+
+
+def test_follow_group_success():
+    user = MagicMock()
+    user.id = uuid4()
+    group = _make_group(is_public=True)
+
+    with patch("pecha_api.plans.groups.groups_service.SessionLocal") as mock_session, patch(
+        "pecha_api.plans.groups.groups_service.validate_and_extract_user_details",
+        return_value=user,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_group_by_id",
+        return_value=group,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.upsert_group_follow",
+    ) as mock_follow:
+        _session_local_context(mock_session)
+        follow_group(token="t", group_id=group.id)
+    mock_follow.assert_called_once()
+
+
+def test_unfollow_group_calls_repository():
+    user = MagicMock()
+    user.id = uuid4()
+    with patch("pecha_api.plans.groups.groups_service.SessionLocal") as mock_session, patch(
+        "pecha_api.plans.groups.groups_service.validate_and_extract_user_details",
+        return_value=user,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.remove_group_follow",
+    ) as mock_unfollow:
+        _session_local_context(mock_session)
+        unfollow_group(token="t", group_id=uuid4())
+    mock_unfollow.assert_called_once()
+
+
+def test_list_followed_groups():
+    user = MagicMock()
+    user.id = uuid4()
+    group = _make_group()
+    with patch("pecha_api.plans.groups.groups_service.SessionLocal") as mock_session, patch(
+        "pecha_api.plans.groups.groups_service.validate_and_extract_user_details",
+        return_value=user,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_following_group_ids_by_user",
+        return_value=[group.id],
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_groups_paginated",
+        return_value=([group], 1),
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_followers_count_map",
+        return_value={},
+    ):
+        _session_local_context(mock_session)
+        result = list_followed_groups(token="t", skip=0, limit=20)
+    assert result.total == 1
+
+
+def test_create_group_member_invite_returns_raw_token():
+    author = _make_author()
+    group = _make_group()
+    invite = MagicMock()
+    invite.id = uuid4()
+    invite.target_email = "invitee@example.org"
+    invite.role = AuthorGroupMemberRole.AUTHOR
+    invite.expires_at = datetime.now(timezone.utc) + timedelta(days=1)
+    invite.max_uses = 1
+
+    with patch("pecha_api.plans.groups.groups_service.SessionLocal") as mock_session, patch(
+        "pecha_api.plans.groups.groups_service.validate_and_extract_author_details",
+        return_value=author,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_group_by_id",
+        return_value=group,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_group_member",
+        return_value=MagicMock(role=AuthorGroupMemberRole.OWNER),
+    ), patch(
+        "pecha_api.plans.groups.groups_service.create_group_invite",
+        return_value=invite,
+    ):
+        _session_local_context(mock_session)
+        result = create_group_member_invite(
+            token="t",
+            group_id=group.id,
+            request=CreateGroupInviteRequest(
+                target_email="invitee@example.org",
+                role=AuthorGroupMemberRole.AUTHOR,
+                expires_at=invite.expires_at,
+                max_uses=1,
+            ),
+        )
+    assert result.token
+    assert result.target_email == "invitee@example.org"
+
+
+def test_accept_group_invite_email_mismatch():
+    author = _make_author(email="other@example.org")
+    invite = MagicMock()
+    invite.target_email = "invitee@example.org"
+    invite.revoked_at = None
+    invite.expires_at = datetime.now(timezone.utc) + timedelta(days=1)
+    invite.max_uses = 1
+    invite.uses_count = 0
+    invite.group_id = uuid4()
+
+    with patch("pecha_api.plans.groups.groups_service.SessionLocal") as mock_session, patch(
+        "pecha_api.plans.groups.groups_service.validate_and_extract_author_details",
+        return_value=author,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_invite_by_token_hash",
+        return_value=invite,
+    ):
+        _session_local_context(mock_session)
+        with pytest.raises(InviteEmailMismatchError):
+            accept_group_invite(
+                token="t",
+                request=AcceptGroupInviteRequest(token="raw"),
+            )
+
+
+def test_accept_group_invite_expired():
+    author = _make_author(email="invitee@example.org")
+    invite = MagicMock()
+    invite.target_email = "invitee@example.org"
+    invite.revoked_at = None
+    invite.expires_at = datetime.now(timezone.utc) - timedelta(days=1)
+    invite.max_uses = 1
+    invite.uses_count = 0
+
+    with patch("pecha_api.plans.groups.groups_service.SessionLocal") as mock_session, patch(
+        "pecha_api.plans.groups.groups_service.validate_and_extract_author_details",
+        return_value=author,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_invite_by_token_hash",
+        return_value=invite,
+    ):
+        _session_local_context(mock_session)
+        with pytest.raises(HTTPException) as exc:
+            accept_group_invite(token="t", request=AcceptGroupInviteRequest(token="raw"))
+    assert "expired" in exc.value.detail.lower()
+
+
+def test_accept_group_invite_success_adds_member():
+    author = _make_author(email="invitee@example.org")
+    group = _make_group()
+    invite = MagicMock()
+    invite.target_email = "invitee@example.org"
+    invite.revoked_at = None
+    invite.expires_at = datetime.now(timezone.utc) + timedelta(days=1)
+    invite.max_uses = 1
+    invite.uses_count = 0
+    invite.role = AuthorGroupMemberRole.AUTHOR
+    invite.group_id = group.id
+
+    with patch("pecha_api.plans.groups.groups_service.SessionLocal") as mock_session, patch(
+        "pecha_api.plans.groups.groups_service.validate_and_extract_author_details",
+        return_value=author,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_invite_by_token_hash",
+        return_value=invite,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_group_by_id",
+        return_value=group,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_group_member",
+        return_value=None,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.add_group_member",
+    ) as mock_add, patch(
+        "pecha_api.plans.groups.groups_service.increase_invite_use_count",
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_followers_count_map",
+        return_value={},
+    ):
+        _session_local_context(mock_session)
+        accept_group_invite(token="t", request=AcceptGroupInviteRequest(token="raw-token"))
+    mock_add.assert_called_once()
+
+
+def test_update_group_member_role_blocks_last_owner_demotion():
+    author = _make_author()
+    group = _make_group()
+    target = MagicMock()
+    target.role = AuthorGroupMemberRole.OWNER
+    current = MagicMock()
+    current.role = AuthorGroupMemberRole.ADMIN
+
+    with patch("pecha_api.plans.groups.groups_service.SessionLocal") as mock_session, patch(
+        "pecha_api.plans.groups.groups_service.validate_and_extract_author_details",
+        return_value=author,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_group_by_id",
+        return_value=group,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_group_member",
+        side_effect=[current, target],
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_owner_count",
+        return_value=1,
+    ):
+        _session_local_context(mock_session)
+        with pytest.raises(HTTPException) as exc:
+            update_group_member_role(
+                token="t",
+                group_id=group.id,
+                author_id=uuid4(),
+                request=UpdateGroupMemberRoleRequest(role=AuthorGroupMemberRole.ADMIN),
+            )
+    assert "OWNER" in exc.value.detail
+
+
+def test_delete_group_member_blocks_last_owner_removal():
+    author = _make_author()
+    group = _make_group()
+    member = MagicMock()
+    member.role = AuthorGroupMemberRole.OWNER
+    current = MagicMock()
+    current.role = AuthorGroupMemberRole.ADMIN
+
+    with patch("pecha_api.plans.groups.groups_service.SessionLocal") as mock_session, patch(
+        "pecha_api.plans.groups.groups_service.validate_and_extract_author_details",
+        return_value=author,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_group_by_id",
+        return_value=group,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_group_member",
+        side_effect=[current, member],
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_owner_count",
+        return_value=1,
+    ):
+        _session_local_context(mock_session)
+        with pytest.raises(HTTPException) as exc:
+            delete_group_member(token="t", group_id=group.id, author_id=uuid4())
+    assert "last owner" in exc.value.detail.lower()
+
+
+def test_replace_group_tags_invalid_tag_ids():
+    author = _make_author()
+    group = _make_group()
+    tag_id = uuid4()
+    current = MagicMock()
+    current.role = AuthorGroupMemberRole.OWNER
+
+    with patch("pecha_api.plans.groups.groups_service.SessionLocal") as mock_session, patch(
+        "pecha_api.plans.groups.groups_service.validate_and_extract_author_details",
+        return_value=author,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_group_by_id",
+        return_value=group,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_group_member",
+        return_value=current,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_tags_by_ids",
+        return_value=[],
+    ):
+        _session_local_context(mock_session)
+        with pytest.raises(HTTPException) as exc:
+            replace_group_tags(
+                token="t",
+                group_id=group.id,
+                request=ReplaceGroupTagsRequest(tag_ids=[tag_id]),
+            )
+    assert "tags" in exc.value.detail.lower()
+
+
+def test_update_author_group_forbidden_for_viewer():
+    author = _make_author()
+    group = _make_group()
+    viewer = MagicMock()
+    viewer.role = AuthorGroupMemberRole.VIEWER
+
+    with patch("pecha_api.plans.groups.groups_service.SessionLocal") as mock_session, patch(
+        "pecha_api.plans.groups.groups_service.validate_and_extract_author_details",
+        return_value=author,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_group_by_id",
+        return_value=group,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_group_member",
+        return_value=viewer,
+    ):
+        _session_local_context(mock_session)
+        with pytest.raises(HTTPException) as exc:
+            update_author_group(
+                token="t",
+                group_id=group.id,
+                request=UpdateAuthorGroupRequest(slug="updated"),
+            )
+    assert exc.value.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_revoke_group_invite_not_found():
+    author = _make_author()
+    group = _make_group()
+    current = MagicMock()
+    current.role = AuthorGroupMemberRole.ADMIN
+
+    with patch("pecha_api.plans.groups.groups_service.SessionLocal") as mock_session, patch(
+        "pecha_api.plans.groups.groups_service.validate_and_extract_author_details",
+        return_value=author,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_group_by_id",
+        return_value=group,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_group_member",
+        return_value=current,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_invite_by_id",
+        return_value=None,
+    ):
+        _session_local_context(mock_session)
+        with pytest.raises(HTTPException) as exc:
+            revoke_group_invite(token="t", group_id=group.id, invite_id=uuid4())
+    assert exc.value.detail == "Invite not found"
+
+
+def test_accept_group_invite_uses_token_hash():
+    raw = "secret-token"
+    expected_hash = hashlib.sha256(raw.encode("utf-8")).hexdigest()
+    author = _make_author(email="a@b.com")
+    invite = MagicMock()
+    invite.target_email = "a@b.com"
+    invite.revoked_at = None
+    invite.expires_at = datetime.now(timezone.utc) + timedelta(days=1)
+    invite.max_uses = 1
+    invite.uses_count = 0
+    invite.role = AuthorGroupMemberRole.AUTHOR
+    invite.group_id = uuid4()
+
+    with patch("pecha_api.plans.groups.groups_service.SessionLocal") as mock_session, patch(
+        "pecha_api.plans.groups.groups_service.validate_and_extract_author_details",
+        return_value=author,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_invite_by_token_hash",
+        return_value=invite,
+    ) as mock_lookup, patch(
+        "pecha_api.plans.groups.groups_service.get_group_by_id",
+        return_value=_make_group(),
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_group_member",
+        return_value=MagicMock(),
+    ), patch(
+        "pecha_api.plans.groups.groups_service.increase_invite_use_count",
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_followers_count_map",
+        return_value={},
+    ):
+        _session_local_context(mock_session)
+        accept_group_invite(token="t", request=AcceptGroupInviteRequest(token=raw))
+    mock_lookup.assert_called_once_with(db=mock_session.return_value.__enter__.return_value, token_hash=expected_hash)
+
+
+def test_replace_group_plans_and_series_delegate_to_repository():
+    author = _make_author()
+    group = _make_group()
+    plan_id = uuid4()
+    series_id = uuid4()
+    current = MagicMock()
+    current.role = AuthorGroupMemberRole.EDITOR
+    loaded = _make_group()
+
+    base_patches = {
+        "validate_and_extract_author_details": author,
+        "get_group_by_id": group,
+        "get_group_member": current,
+        "get_plans_by_ids": [MagicMock(id=plan_id)],
+        "get_series_by_ids": [MagicMock(id=series_id)],
+        "get_followers_count_map": {},
+    }
+
+    with patch("pecha_api.plans.groups.groups_service.SessionLocal") as mock_session, patch(
+        "pecha_api.plans.groups.groups_service.validate_and_extract_author_details",
+        return_value=author,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_group_by_id",
+        side_effect=[group, loaded],
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_group_member",
+        return_value=current,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_plans_by_ids",
+        return_value=[MagicMock(id=plan_id)],
+    ), patch(
+        "pecha_api.plans.groups.groups_service.replace_group_relation_ids",
+    ) as mock_replace, patch(
+        "pecha_api.plans.groups.groups_service.get_followers_count_map",
+        return_value={},
+    ):
+        db = _session_local_context(mock_session)
+        replace_group_plans_by_id(
+            token="t",
+            group_id=group.id,
+            request=ReplaceGroupPlansRequest(plan_ids=[plan_id]),
+        )
+        db.commit.assert_called()
+        mock_replace.assert_called_once()
+
+    with patch("pecha_api.plans.groups.groups_service.SessionLocal") as mock_session, patch(
+        "pecha_api.plans.groups.groups_service.validate_and_extract_author_details",
+        return_value=author,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_group_by_id",
+        side_effect=[group, loaded],
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_group_member",
+        return_value=current,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_series_by_ids",
+        return_value=[MagicMock(id=series_id)],
+    ), patch(
+        "pecha_api.plans.groups.groups_service.replace_group_relation_ids",
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_followers_count_map",
+        return_value={},
+    ):
+        _session_local_context(mock_session)
+        replace_group_series_by_id(
+            token="t",
+            group_id=group.id,
+            request=ReplaceGroupSeriesRequest(series_ids=[series_id]),
+        )
+
+    with patch("pecha_api.plans.groups.groups_service.SessionLocal") as mock_session, patch(
+        "pecha_api.plans.groups.groups_service.validate_and_extract_author_details",
+        return_value=author,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_group_by_id",
+        side_effect=[group, loaded],
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_group_member",
+        return_value=current,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.replace_group_social_links",
+    ) as mock_links, patch(
+        "pecha_api.plans.groups.groups_service.get_followers_count_map",
+        return_value={},
+    ):
+        _session_local_context(mock_session)
+        replace_group_social_links_by_id(
+            token="t",
+            group_id=group.id,
+            request=ReplaceGroupSocialLinksRequest(
+                social_links=[GroupSocialLinkInput(platform="twitter", url="https://x.com/g")]
+            ),
+        )
+    mock_links.assert_called_once()

--- a/tests/plans/groups/test_groups_views.py
+++ b/tests/plans/groups/test_groups_views.py
@@ -138,3 +138,164 @@ def test_accept_group_invite_email_mismatch_returns_code():
         "detail": "This invite was sent to a different email address.",
         "code": "INVITE_EMAIL_MISMATCH",
     }
+
+
+def test_patch_cms_group_delegates_to_service():
+    group_id = uuid4()
+    detail = _group_detail()
+    with patch(
+        "pecha_api.plans.groups.groups_views.update_author_group",
+        return_value=detail,
+    ) as mock_service:
+        response = client.patch(
+            f"/cms/groups/{group_id}",
+            json={"slug": "updated-slug"},
+            headers={"Authorization": "Bearer dummy"},
+        )
+    assert response.status_code == status.HTTP_200_OK
+    mock_service.assert_called_once()
+
+
+def test_get_cms_group_by_id():
+    group_id = uuid4()
+    with patch(
+        "pecha_api.plans.groups.groups_views.get_cms_group_detail",
+        return_value=_group_detail(),
+    ) as mock_service:
+        response = client.get(
+            f"/cms/groups/{group_id}",
+            headers={"Authorization": "Bearer dummy"},
+        )
+    assert response.status_code == status.HTTP_200_OK
+    mock_service.assert_called_once()
+
+
+def test_get_cms_groups_with_filters():
+    summary = AuthorGroupSummaryDTO(
+        id=uuid4(),
+        slug="g",
+        is_public=True,
+        metadata=_metadata(),
+        tags=[],
+        follower_count=0,
+        member_count=1,
+    )
+    listing = AuthorGroupListResponse(groups=[summary], skip=5, limit=10, total=1)
+    tag_id = uuid4()
+    with patch(
+        "pecha_api.plans.groups.groups_views.list_cms_groups",
+        return_value=listing,
+    ) as mock_service:
+        response = client.get(
+            f"/cms/groups?search=foo&language=EN&skip=5&limit=10&tag_id={tag_id}",
+            headers={"Authorization": "Bearer dummy"},
+        )
+    assert response.status_code == status.HTTP_200_OK
+    mock_service.assert_called_once_with(
+        token="dummy",
+        search="foo",
+        language="EN",
+        tag_id=tag_id,
+        skip=5,
+        limit=10,
+    )
+
+
+def test_put_cms_group_relations():
+    group_id = uuid4()
+    detail = _group_detail()
+    tag_id = uuid4()
+    plan_id = uuid4()
+    series_id = uuid4()
+    headers = {"Authorization": "Bearer dummy"}
+
+    with patch("pecha_api.plans.groups.groups_views.replace_group_tags", return_value=detail) as mock_tags:
+        assert client.put(f"/cms/groups/{group_id}/tags", json={"tag_ids": [str(tag_id)]}, headers=headers).status_code == 200
+        mock_tags.assert_called_once()
+
+    with patch(
+        "pecha_api.plans.groups.groups_views.replace_group_social_links_by_id",
+        return_value=detail,
+    ) as mock_links:
+        assert (
+            client.put(
+                f"/cms/groups/{group_id}/social-links",
+                json={"social_links": [{"platform": "x", "url": "https://x.com/g"}]},
+                headers=headers,
+            ).status_code
+            == 200
+        )
+        mock_links.assert_called_once()
+
+    with patch("pecha_api.plans.groups.groups_views.replace_group_series_by_id", return_value=detail) as mock_series:
+        assert client.put(f"/cms/groups/{group_id}/series", json={"series_ids": [str(series_id)]}, headers=headers).status_code == 200
+        mock_series.assert_called_once()
+
+    with patch("pecha_api.plans.groups.groups_views.replace_group_plans_by_id", return_value=detail) as mock_plans:
+        assert client.put(f"/cms/groups/{group_id}/plans", json={"plan_ids": [str(plan_id)]}, headers=headers).status_code == 200
+        mock_plans.assert_called_once()
+
+
+def test_revoke_invite_and_member_endpoints():
+    group_id = uuid4()
+    invite_id = uuid4()
+    author_id = uuid4()
+    headers = {"Authorization": "Bearer dummy"}
+
+    with patch("pecha_api.plans.groups.groups_views.revoke_group_invite") as mock_revoke:
+        response = client.post(f"/cms/groups/{group_id}/members/invites/{invite_id}/revoke", headers=headers)
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        mock_revoke.assert_called_once()
+
+    with patch("pecha_api.plans.groups.groups_views.update_group_member_role", return_value=_group_detail()) as mock_role:
+        response = client.patch(
+            f"/cms/groups/{group_id}/members/{author_id}/role",
+            json={"role": "ADMIN"},
+            headers=headers,
+        )
+        assert response.status_code == status.HTTP_200_OK
+        mock_role.assert_called_once()
+
+    with patch("pecha_api.plans.groups.groups_views.delete_group_member") as mock_delete:
+        response = client.delete(f"/cms/groups/{group_id}/members/{author_id}", headers=headers)
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        mock_delete.assert_called_once()
+
+
+def test_get_public_group_by_id():
+    """Call the view directly; legacy texts router also registers GET /groups/{group_id}."""
+    from pecha_api.plans.groups.groups_views import get_public_group
+
+    group_id = uuid4()
+    with patch(
+        "pecha_api.plans.groups.groups_views.get_author_group_detail",
+        return_value=_group_detail(),
+    ) as mock_service:
+        result = get_public_group(group_id=group_id)
+    assert result.slug == "bodhichitta-authors"
+    mock_service.assert_called_once_with(group_id=group_id, require_public=True)
+
+
+def test_follow_and_unfollow_group():
+    group_id = uuid4()
+    headers = {"Authorization": "Bearer dummy"}
+    with patch("pecha_api.plans.groups.groups_views.follow_group") as mock_follow:
+        assert client.post(f"/groups/{group_id}/follow", headers=headers).status_code == status.HTTP_204_NO_CONTENT
+        mock_follow.assert_called_once()
+    with patch("pecha_api.plans.groups.groups_views.unfollow_group") as mock_unfollow:
+        assert client.delete(f"/groups/{group_id}/follow", headers=headers).status_code == status.HTTP_204_NO_CONTENT
+        mock_unfollow.assert_called_once()
+
+
+def test_get_my_followed_groups():
+    listing = AuthorGroupListResponse(groups=[], skip=0, limit=20, total=0)
+    with patch(
+        "pecha_api.plans.groups.groups_views.list_followed_groups",
+        return_value=listing,
+    ) as mock_service:
+        response = client.get(
+            "/users/me/following/groups?skip=0&limit=20",
+            headers={"Authorization": "Bearer dummy"},
+        )
+    assert response.status_code == status.HTTP_200_OK
+    mock_service.assert_called_once_with(token="dummy", skip=0, limit=20)

--- a/tests/plans/groups/test_groups_views.py
+++ b/tests/plans/groups/test_groups_views.py
@@ -1,0 +1,140 @@
+from datetime import datetime, timezone, timedelta
+from uuid import uuid4
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+from starlette import status
+
+from pecha_api.app import api
+from pecha_api.plans.groups.groups_enums import AuthorGroupMemberRole
+from pecha_api.plans.groups.groups_response_models import (
+    AuthorGroupDetailDTO,
+    AuthorGroupListResponse,
+    AuthorGroupSummaryDTO,
+    GroupInviteCreatedResponse,
+    GroupMetadataDTO,
+)
+from pecha_api.plans.groups.groups_service import InviteEmailMismatchError
+
+
+client = TestClient(api)
+
+
+def _metadata() -> list[GroupMetadataDTO]:
+    return [
+        GroupMetadataDTO(
+            id=uuid4(),
+            title="Bodhichitta Authors",
+            description="Meditation and Dharma writers",
+            language="EN",
+        )
+    ]
+
+
+def _group_detail() -> AuthorGroupDetailDTO:
+    return AuthorGroupDetailDTO(
+        id=uuid4(),
+        slug="bodhichitta-authors",
+        is_public=True,
+        metadata=_metadata(),
+        members=[],
+        tags=[],
+        social_links=[],
+        series_ids=[],
+        plan_ids=[],
+        follower_count=0,
+    )
+
+
+def test_create_cms_group_success():
+    group_detail = _group_detail()
+    payload = {
+        "slug": "bodhichitta-authors",
+        "is_public": True,
+        "metadata": [{"title": "Bodhichitta Authors", "description": "Dharma", "language": "EN"}],
+    }
+    with patch(
+        "pecha_api.plans.groups.groups_views.create_author_group",
+        return_value=group_detail,
+    ) as mock_service:
+        response = client.post(
+            "/cms/groups",
+            json=payload,
+            headers={"Authorization": "Bearer dummy"},
+        )
+
+    assert response.status_code == status.HTTP_201_CREATED
+    mock_service.assert_called_once()
+    assert response.json()["slug"] == "bodhichitta-authors"
+
+
+def test_get_public_groups_success():
+    group_summary = AuthorGroupSummaryDTO(
+        id=uuid4(),
+        slug="bodhichitta-authors",
+        is_public=True,
+        metadata=_metadata(),
+        tags=[],
+        follower_count=4,
+        member_count=2,
+    )
+    response_model = AuthorGroupListResponse(groups=[group_summary], skip=0, limit=20, total=1)
+    with patch(
+        "pecha_api.plans.groups.groups_views.list_public_groups",
+        return_value=response_model,
+    ) as mock_service:
+        response = client.get("/groups")
+
+    assert response.status_code == status.HTTP_200_OK
+    mock_service.assert_called_once_with(search=None, language=None, tag_id=None, skip=0, limit=20)
+    assert response.json()["total"] == 1
+
+
+def test_create_group_invite_success():
+    group_id = uuid4()
+    invite_response = GroupInviteCreatedResponse(
+        invite_id=uuid4(),
+        token="raw-token",
+        target_email="author@example.org",
+        role=AuthorGroupMemberRole.AUTHOR,
+        expires_at=datetime.now(timezone.utc) + timedelta(days=2),
+        max_uses=1,
+    )
+    payload = {
+        "target_email": "author@example.org",
+        "role": "AUTHOR",
+        "expires_at": "2026-05-31T12:00:00Z",
+        "max_uses": 1,
+    }
+    with patch(
+        "pecha_api.plans.groups.groups_views.create_group_member_invite",
+        return_value=invite_response,
+    ) as mock_service:
+        response = client.post(
+            f"/cms/groups/{group_id}/members/invites",
+            json=payload,
+            headers={"Authorization": "Bearer dummy"},
+        )
+
+    assert response.status_code == status.HTTP_201_CREATED
+    assert response.json()["token"] == "raw-token"
+    mock_service.assert_called_once()
+
+
+def test_accept_group_invite_email_mismatch_returns_code():
+    payload = {"token": "wrong-user-token"}
+    with patch(
+        "pecha_api.plans.groups.groups_views.accept_group_invite",
+        side_effect=InviteEmailMismatchError("This invite was sent to a different email address."),
+    ):
+        response = client.post(
+            "/cms/groups/invites/accept",
+            json=payload,
+            headers={"Authorization": "Bearer dummy"},
+        )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json() == {
+        "detail": "This invite was sent to a different email address.",
+        "code": "INVITE_EMAIL_MISMATCH",
+    }

--- a/tests/plans/public/test_plan_public_service.py
+++ b/tests/plans/public/test_plan_public_service.py
@@ -126,7 +126,8 @@ async def test_get_published_plans_success(sample_plan_aggregate, mock_db_sessio
             language="EN",  
             sort_by="title",
             sort_order="asc",
-            tag=None
+            tag=None,
+            group_id=None,
         )
 
 
@@ -155,7 +156,8 @@ async def test_get_published_plans_with_search(sample_plan_aggregate, mock_db_se
             language="EN", 
             sort_by="title",
             sort_order="asc",
-            tag=None
+            tag=None,
+            group_id=None,
         )
 
 
@@ -184,7 +186,8 @@ async def test_get_published_plans_with_language_filter(sample_plan_aggregate, m
             language="EN", 
             sort_by="title",
             sort_order="asc",
-            tag=None
+            tag=None,
+            group_id=None,
         )
 
 
@@ -439,7 +442,8 @@ async def test_get_published_plans_with_pagination(sample_plan_aggregate, mock_d
             language="EN",  # Service converts to uppercase before calling repository
             sort_by="title",
             sort_order="asc",
-            tag=None
+            tag=None,
+            group_id=None,
         )
 
 
@@ -929,6 +933,7 @@ async def test_get_published_plans_with_tag_filter(
             sort_order="asc",
             skip=0,
             limit=20,
+            group_id=None,
         )
 
         assert len(result.plans) == 1
@@ -941,6 +946,7 @@ async def test_get_published_plans_with_tag_filter(
             sort_by="title",
             sort_order="asc",
             tag="meditation",
+            group_id=None,
         )
 
 

--- a/tests/plans/public/test_plan_public_views.py
+++ b/tests/plans/public/test_plan_public_views.py
@@ -91,6 +91,7 @@ async def test_get_plans_success(sample_plans_response):
         
         mock_service.assert_called_once_with(
             tag=None,
+            group_id=None,
             search=None,
             language="en",
             sort_by="title",
@@ -112,6 +113,7 @@ async def test_get_plans_with_search_filter(sample_plans_response):
         
         mock_service.assert_called_once_with(
             tag=None,
+            group_id=None,
             search="meditation",
             language="en",
             sort_by="title",
@@ -133,6 +135,7 @@ async def test_get_plans_with_language_filter(sample_plans_response):
         
         mock_service.assert_called_once_with(
             tag=None,
+            group_id=None,
             search=None,
             language="en",
             sort_by="title",
@@ -154,6 +157,7 @@ async def test_get_plans_with_sorting(sample_plans_response):
         
         mock_service.assert_called_once_with(
             tag=None,
+            group_id=None,
             search=None,
             language="en",
             sort_by="subscription_count",
@@ -170,10 +174,10 @@ async def test_get_plans_with_pagination(sample_plans_response):
         response = client.get("/api/v1/plans?skip=10&limit=5")
         
         assert response.status_code == status.HTTP_200_OK
-        data = response.json()
         
         mock_service.assert_called_once_with(
             tag=None,
+            group_id=None,
             search=None,
             language="en",
             sort_by="title",
@@ -192,10 +196,10 @@ async def test_get_plans_with_all_filters(sample_plans_response):
         )
         
         assert response.status_code == status.HTTP_200_OK
-        data = response.json()
         
         mock_service.assert_called_once_with(
             tag=None,
+            group_id=None,
             search="meditation",
             language="en",
             sort_by="total_days",
@@ -630,6 +634,30 @@ async def test_get_plans_with_tag_filter(sample_plans_response):
 
         mock_service.assert_called_once_with(
             tag="meditation",
+            group_id=None,
+            search=None,
+            language="en",
+            sort_by="title",
+            sort_order="asc",
+            skip=0,
+            limit=20,
+        )
+
+
+@pytest.mark.asyncio
+async def test_get_plans_with_group_filter(sample_plans_response):
+    group_id = uuid4()
+    with patch(
+        "pecha_api.plans.public.plan_views.get_published_plans",
+        return_value=sample_plans_response,
+    ) as mock_service:
+        response = client.get(f"/api/v1/plans?group_id={group_id}")
+
+        assert response.status_code == status.HTTP_200_OK
+
+        mock_service.assert_called_once_with(
+            tag=None,
+            group_id=group_id,
             search=None,
             language="en",
             sort_by="title",

--- a/tests/plans/series/test_series_views.py
+++ b/tests/plans/series/test_series_views.py
@@ -90,7 +90,7 @@ def test_get_series_list_success(sample_series_list_response):
         assert response.status_code == status.HTTP_200_OK
         data = response.json()
 
-        mock_service.assert_called_once_with(search=None, skip=0, limit=10, language=None)
+        mock_service.assert_called_once_with(search=None, skip=0, limit=10, language=None, group_id=None)
 
         assert "series" in data
         assert data["skip"] == 0
@@ -120,7 +120,7 @@ def test_get_series_list_with_search_pagination(sample_series_dto):
         assert response.status_code == status.HTTP_200_OK
         data = response.json()
 
-        mock_service.assert_called_once_with(search="meditation", skip=2, limit=5, language=None)
+        mock_service.assert_called_once_with(search="meditation", skip=2, limit=5, language=None, group_id=None)
 
         assert data["series"] == []
         assert data["skip"] == 2
@@ -327,16 +327,30 @@ def test_get_series_list_returns_plan_count_not_plans():
     with patch(
         "pecha_api.plans.series.public_series_view.get_filtered_series",
         return_value=series_list_response,
-    ):
+    ) as mock_service:
         response = client.get("/series")
 
         assert response.status_code == status.HTTP_200_OK
         data = response.json()
+        mock_service.assert_called_once_with(search=None, skip=0, limit=10, language=None, group_id=None)
 
         assert len(data["series"]) == 1
         assert data["series"][0]["plan_count"] == 0
         assert data["series"][0]["total_days"] == 0
         assert "plans" not in data["series"][0]
+
+
+def test_get_series_list_with_group_filter():
+    series_list_response = SeriesListResponse(series=[], skip=0, limit=10, total=0)
+    group_id = uuid.uuid4()
+    with patch(
+        "pecha_api.plans.series.public_series_view.get_filtered_series",
+        return_value=series_list_response,
+    ) as mock_service:
+        response = client.get("/series", params={"group_id": str(group_id)})
+
+    assert response.status_code == status.HTTP_200_OK
+    mock_service.assert_called_once_with(search=None, skip=0, limit=10, language=None, group_id=group_id)
 
 
 def test_update_series_accepts_empty_body():


### PR DESCRIPTION
- Introduced group_id parameter to filter published plans and series by author group.
- Updated relevant service and repository functions to support group-based filtering.
- Enhanced API views to accept group_id as a query parameter for filtering.
- Added tests to verify functionality of group filtering in plans and series endpoints.