### PR TITLE
feat: add paginated audio retrieval for plan items

### DIFF
--- a/pecha_api/plans/audio/cms_plan_audio_service.py
+++ b/pecha_api/plans/audio/cms_plan_audio_service.py
@@ -1,0 +1,62 @@
+import os
+from typing import List, Optional
+
+from pecha_api.config import get
+from pecha_api.db.database import SessionLocal
+from pecha_api.plans.audio.plan_audio_response_models import PlanAudioDTO, PlanAudioListResponse
+from pecha_api.plans.audio.plan_item_audio_repository import get_plan_item_audio_paginated
+from pecha_api.plans.authors.plan_authors_service import validate_and_extract_author_details
+from pecha_api.uploads.S3_utils import generate_presigned_access_url
+
+
+def _audio_file_name(audio_key: str) -> str:
+    return os.path.basename(audio_key)
+
+
+def get_cms_plan_audio_list(
+    token: str,
+    search: Optional[str],
+    skip: int,
+    limit: int,
+) -> PlanAudioListResponse:
+    current_author = validate_and_extract_author_details(token=token)
+
+    with SessionLocal() as db_session:
+        rows, total = get_plan_item_audio_paginated(
+            db=db_session,
+            search=search,
+            author_id=current_author.id,
+            is_admin=current_author.is_admin,
+            skip=skip,
+            limit=limit,
+        )
+
+    bucket_name = get("AWS_BUCKET_NAME")
+    audio_items: List[PlanAudioDTO] = []
+    for audio_row, plan_item, _plan in rows:
+        audio_url = generate_presigned_access_url(
+            bucket_name=bucket_name,
+            s3_key=audio_row.audio_key,
+        )
+        audio_items.append(
+            PlanAudioDTO(
+                id=audio_row.id,
+                audio_key=audio_row.audio_key,
+                file_name=_audio_file_name(audio_row.audio_key),
+                audio_url=audio_url,
+                duration_ms=audio_row.duration_ms,
+                mime_type=audio_row.mime_type,
+                file_size_bytes=audio_row.file_size_bytes,
+                plan_item_id=plan_item.id,
+                plan_id=plan_item.plan_id,
+                day_number=plan_item.day_number,
+                created_at=audio_row.created_at,
+            )
+        )
+
+    return PlanAudioListResponse(
+        audio=audio_items,
+        skip=skip,
+        limit=limit,
+        total=total,
+    )

--- a/pecha_api/plans/audio/cms_plan_audio_service.py
+++ b/pecha_api/plans/audio/cms_plan_audio_service.py
@@ -1,11 +1,18 @@
 import os
 from typing import List, Optional
+from uuid import UUID
+
+from fastapi import HTTPException
+from starlette import status
 
 from pecha_api.config import get
 from pecha_api.db.database import SessionLocal
 from pecha_api.plans.audio.plan_audio_response_models import PlanAudioDTO, PlanAudioListResponse
 from pecha_api.plans.audio.plan_item_audio_repository import get_plan_item_audio_paginated
+from pecha_api.plans.auth.plan_auth_models import ResponseError
 from pecha_api.plans.authors.plan_authors_service import validate_and_extract_author_details
+from pecha_api.plans.cms.cms_plans_repository import get_plan_by_id
+from pecha_api.plans.response_message import BAD_REQUEST, PLAN_NOT_FOUND
 from pecha_api.uploads.S3_utils import generate_presigned_access_url
 
 
@@ -13,18 +20,41 @@ def _audio_file_name(audio_key: str) -> str:
     return os.path.basename(audio_key)
 
 
+def _validate_plan_access(db, plan_id: UUID, *, author_id: UUID, is_admin: bool) -> None:
+    plan = get_plan_by_id(db=db, plan_id=plan_id)
+    if not plan:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=ResponseError(error=BAD_REQUEST, message=PLAN_NOT_FOUND).model_dump(),
+        )
+    if not is_admin and plan.author_id != author_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=ResponseError(error=BAD_REQUEST, message=PLAN_NOT_FOUND).model_dump(),
+        )
+
+
 def get_cms_plan_audio_list(
     token: str,
     search: Optional[str],
+    plan_id: Optional[UUID],
     skip: int,
     limit: int,
 ) -> PlanAudioListResponse:
     current_author = validate_and_extract_author_details(token=token)
 
     with SessionLocal() as db_session:
+        if plan_id is not None:
+            _validate_plan_access(
+                db_session,
+                plan_id,
+                author_id=current_author.id,
+                is_admin=current_author.is_admin,
+            )
         rows, total = get_plan_item_audio_paginated(
             db=db_session,
             search=search,
+            plan_id=plan_id,
             author_id=current_author.id,
             is_admin=current_author.is_admin,
             skip=skip,

--- a/pecha_api/plans/audio/plan_audio_response_models.py
+++ b/pecha_api/plans/audio/plan_audio_response_models.py
@@ -24,3 +24,8 @@ class PlanAudioListResponse(BaseModel):
     skip: int
     limit: int
     total: int
+
+
+class AssignPlanDayAudioRequest(BaseModel):
+    audio_key: str
+    duration_ms: Optional[int] = None

--- a/pecha_api/plans/audio/plan_audio_response_models.py
+++ b/pecha_api/plans/audio/plan_audio_response_models.py
@@ -1,0 +1,26 @@
+from datetime import datetime
+from typing import List, Optional
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+class PlanAudioDTO(BaseModel):
+    id: UUID
+    audio_key: str
+    file_name: str
+    audio_url: str
+    duration_ms: Optional[int] = None
+    mime_type: Optional[str] = None
+    file_size_bytes: Optional[int] = None
+    plan_item_id: UUID
+    plan_id: UUID
+    day_number: int
+    created_at: datetime
+
+
+class PlanAudioListResponse(BaseModel):
+    audio: List[PlanAudioDTO]
+    skip: int
+    limit: int
+    total: int

--- a/pecha_api/plans/audio/plan_day_audio_service.py
+++ b/pecha_api/plans/audio/plan_day_audio_service.py
@@ -11,17 +11,22 @@ from pecha_api.config import DEFAULTS, get, get_int
 from pecha_api.db.database import SessionLocal
 from pecha_api.plans.audio.plan_item_audio_models import PlanItemAudio
 from pecha_api.plans.audio.plan_item_audio_repository import (
+    count_plan_item_audio_by_audio_key,
     delete_plan_item_audio,
+    get_accessible_plan_item_audio_by_key,
     get_plan_item_audio_by_plan_item_id,
     upsert_plan_item_audio,
 )
+from pecha_api.plans.audio.plan_audio_response_models import AssignPlanDayAudioRequest
 from pecha_api.plans.auth.plan_auth_models import ResponseError
 from pecha_api.plans.authors.plan_authors_service import validate_and_extract_author_details
 from pecha_api.plans.cms.cms_plans_repository import get_plan_by_id
 from pecha_api.plans.items.plan_items_repository import get_plan_item_by_id
 from pecha_api.plans.media.media_response_models import PlanDayAudioUploadResponse
 from pecha_api.plans.response_message import (
+    AUDIO_ASSIGN_SUCCESS,
     AUDIO_FILE_TOO_LARGE,
+    AUDIO_KEY_NOT_FOUND,
     AUDIO_UPLOAD_SUCCESS,
     BAD_REQUEST,
     INVALID_AUDIO_FILE_FORMAT,
@@ -123,6 +128,74 @@ def upload_plan_day_audio(
         audio_url=audio_url,
         duration_ms=audio_duration_ms,
         message=AUDIO_UPLOAD_SUCCESS,
+    )
+
+
+def assign_plan_day_audio(
+    token: str,
+    day_id: UUID,
+    request: AssignPlanDayAudioRequest,
+) -> PlanDayAudioUploadResponse:
+    audio_key = request.audio_key.strip()
+    if not audio_key:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=ResponseError(error=BAD_REQUEST, message=AUDIO_KEY_NOT_FOUND).model_dump(),
+        )
+
+    with SessionLocal() as db:
+        current_author = validate_and_extract_author_details(token=token)
+        plan_item = _get_author_plan_item_by_day_id(db=db, day_id=day_id, token=token)
+
+        source_audio = get_accessible_plan_item_audio_by_key(
+            db=db,
+            audio_key=audio_key,
+            author_id=current_author.id,
+            is_admin=current_author.is_admin,
+        )
+        if not source_audio:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=ResponseError(error=BAD_REQUEST, message=AUDIO_KEY_NOT_FOUND).model_dump(),
+            )
+
+        existing = get_plan_item_audio_by_plan_item_id(db=db, plan_item_id=plan_item.id)
+        old_key = existing.audio_key if existing else None
+        if old_key and old_key != audio_key and count_plan_item_audio_by_audio_key(db, old_key) <= 1:
+            delete_file(old_key)
+
+        duration_ms = (
+            request.duration_ms
+            if request.duration_ms is not None
+            else source_audio.duration_ms
+        )
+        audio_row = upsert_plan_item_audio(
+            db=db,
+            plan_item_audio=PlanItemAudio(
+                plan_item_id=plan_item.id,
+                audio_key=audio_key,
+                duration_ms=duration_ms,
+                mime_type=source_audio.mime_type,
+                file_size_bytes=source_audio.file_size_bytes,
+                created_by=current_author.email,
+                updated_by=current_author.email,
+            ),
+        )
+
+        plan_item_id_str = str(plan_item.id)
+        assigned_key = audio_row.audio_key
+        assigned_duration_ms = audio_row.duration_ms
+
+    audio_url = generate_presigned_access_url(
+        bucket_name=get("AWS_BUCKET_NAME"),
+        s3_key=assigned_key,
+    )
+    return PlanDayAudioUploadResponse(
+        plan_item_id=plan_item_id_str,
+        audio_key=assigned_key,
+        audio_url=audio_url,
+        duration_ms=assigned_duration_ms,
+        message=AUDIO_ASSIGN_SUCCESS,
     )
 
 

--- a/pecha_api/plans/audio/plan_item_audio_repository.py
+++ b/pecha_api/plans/audio/plan_item_audio_repository.py
@@ -40,6 +40,27 @@ def get_plan_item_audio_paginated(
     return rows, total
 
 
+def get_accessible_plan_item_audio_by_key(
+    db: Session,
+    audio_key: str,
+    author_id: UUID,
+    is_admin: bool,
+) -> Optional[PlanItemAudio]:
+    query = (
+        db.query(PlanItemAudio)
+        .join(PlanItem, PlanItem.id == PlanItemAudio.plan_item_id)
+        .join(Plan, Plan.id == PlanItem.plan_id)
+        .filter(Plan.deleted_at.is_(None), PlanItemAudio.audio_key == audio_key)
+    )
+    if not is_admin:
+        query = query.filter(Plan.author_id == author_id)
+    return query.first()
+
+
+def count_plan_item_audio_by_audio_key(db: Session, audio_key: str) -> int:
+    return db.query(PlanItemAudio).filter(PlanItemAudio.audio_key == audio_key).count()
+
+
 def get_plan_item_audio_by_plan_item_id(db: Session, plan_item_id: UUID) -> Optional[PlanItemAudio]:
     return (
         db.query(PlanItemAudio)

--- a/pecha_api/plans/audio/plan_item_audio_repository.py
+++ b/pecha_api/plans/audio/plan_item_audio_repository.py
@@ -1,9 +1,40 @@
-from typing import List, Optional
+from typing import List, Optional, Tuple
 from uuid import UUID
 
 from sqlalchemy.orm import Session
 
 from pecha_api.plans.audio.plan_item_audio_models import PlanItemAudio
+from pecha_api.plans.items.plan_items_models import PlanItem
+from pecha_api.plans.plans_models import Plan
+
+
+def get_plan_item_audio_paginated(
+    db: Session,
+    *,
+    search: Optional[str],
+    author_id: UUID,
+    is_admin: bool,
+    skip: int,
+    limit: int,
+) -> Tuple[List[Tuple[PlanItemAudio, PlanItem, Plan]], int]:
+    query = (
+        db.query(PlanItemAudio, PlanItem, Plan)
+        .join(PlanItem, PlanItem.id == PlanItemAudio.plan_item_id)
+        .join(Plan, Plan.id == PlanItem.plan_id)
+        .filter(Plan.deleted_at.is_(None))
+    )
+    if not is_admin:
+        query = query.filter(Plan.author_id == author_id)
+    if search:
+        query = query.filter(PlanItemAudio.audio_key.ilike(f"%{search}%"))
+    total = query.count()
+    rows = (
+        query.order_by(PlanItemAudio.created_at.desc())
+        .offset(skip)
+        .limit(limit)
+        .all()
+    )
+    return rows, total
 
 
 def get_plan_item_audio_by_plan_item_id(db: Session, plan_item_id: UUID) -> Optional[PlanItemAudio]:

--- a/pecha_api/plans/audio/plan_item_audio_repository.py
+++ b/pecha_api/plans/audio/plan_item_audio_repository.py
@@ -12,6 +12,7 @@ def get_plan_item_audio_paginated(
     db: Session,
     *,
     search: Optional[str],
+    plan_id: Optional[UUID],
     author_id: UUID,
     is_admin: bool,
     skip: int,
@@ -25,6 +26,8 @@ def get_plan_item_audio_paginated(
     )
     if not is_admin:
         query = query.filter(Plan.author_id == author_id)
+    if plan_id is not None:
+        query = query.filter(Plan.id == plan_id)
     if search:
         query = query.filter(PlanItemAudio.audio_key.ilike(f"%{search}%"))
     total = query.count()

--- a/pecha_api/plans/cms/cms_plans_views.py
+++ b/pecha_api/plans/cms/cms_plans_views.py
@@ -10,6 +10,8 @@ from pecha_api.plans.plans_response_models import PlansResponse, PlanDTO, Create
 from pecha_api.plans.cms.cms_plans_service import get_filtered_plans, create_new_plan, get_details_plan, update_plan_details, \
     delete_selected_plan, update_plan_featured_service, update_selected_plan_status, get_plan_day_details
 from pecha_api.plans.plans_enums import SortBy, SortOrder
+from pecha_api.plans.audio.cms_plan_audio_service import get_cms_plan_audio_list
+from pecha_api.plans.audio.plan_audio_response_models import PlanAudioListResponse
 
 oauth2_scheme = HTTPBearer()
 # Create router for CMS plan endpoints
@@ -44,6 +46,21 @@ async def create_plan(authentication_credential: Annotated[HTTPAuthorizationCred
     return create_new_plan(
         token=authentication_credential.credentials,
         create_plan_request=create_plan_request
+    )
+
+
+@cms_plans_router.get("/audio", status_code=status.HTTP_200_OK, response_model=PlanAudioListResponse)
+async def list_plan_audio(
+    authentication_credential: Annotated[HTTPAuthorizationCredentials, Depends(oauth2_scheme)],
+    search: Annotated[Optional[str], Query(description="Search by audio file name or S3 key")] = None,
+    skip: Annotated[int, Query()] = 0,
+    limit: Annotated[int, Query()] = 10,
+):
+    return get_cms_plan_audio_list(
+        token=authentication_credential.credentials,
+        search=search,
+        skip=skip,
+        limit=limit,
     )
 
 

--- a/pecha_api/plans/cms/cms_plans_views.py
+++ b/pecha_api/plans/cms/cms_plans_views.py
@@ -53,12 +53,14 @@ async def create_plan(authentication_credential: Annotated[HTTPAuthorizationCred
 async def list_plan_audio(
     authentication_credential: Annotated[HTTPAuthorizationCredentials, Depends(oauth2_scheme)],
     search: Annotated[Optional[str], Query(description="Search by audio file name or S3 key")] = None,
+    plan_id: Annotated[Optional[UUID], Query(description="Filter audio by plan id")] = None,
     skip: Annotated[int, Query()] = 0,
     limit: Annotated[int, Query()] = 10,
 ):
     return get_cms_plan_audio_list(
         token=authentication_credential.credentials,
         search=search,
+        plan_id=plan_id,
         skip=skip,
         limit=limit,
     )

--- a/pecha_api/plans/items/plan_items_views.py
+++ b/pecha_api/plans/items/plan_items_views.py
@@ -1,7 +1,9 @@
 from fastapi import APIRouter
 from .plan_items_response_models import ItemDTO, ReorderDaysRequest
 from .plan_items_services import create_plan_item, delete_plan_day_by_id, update_plans_day_number
-from pecha_api.plans.audio.plan_day_audio_service import delete_plan_day_audio
+from pecha_api.plans.audio.plan_day_audio_service import assign_plan_day_audio, delete_plan_day_audio
+from pecha_api.plans.audio.plan_audio_response_models import AssignPlanDayAudioRequest
+from pecha_api.plans.media.media_response_models import PlanDayAudioUploadResponse
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from fastapi import Depends
 from starlette import status
@@ -31,6 +33,19 @@ async def delete_item(authentication_credential: Annotated[HTTPAuthorizationCred
         token=authentication_credential.credentials,
         plan_id=plan_id,
         day_id=day_id
+    )
+
+
+@items_router.patch("/days/{day_id}/audio", status_code=status.HTTP_200_OK, response_model=PlanDayAudioUploadResponse)
+async def assign_day_audio(
+    authentication_credential: Annotated[HTTPAuthorizationCredentials, Depends(oauth2_scheme)],
+    day_id: UUID,
+    assign_audio_request: AssignPlanDayAudioRequest,
+):
+    return assign_plan_day_audio(
+        token=authentication_credential.credentials,
+        day_id=day_id,
+        request=assign_audio_request,
     )
 
 

--- a/pecha_api/plans/response_message.py
+++ b/pecha_api/plans/response_message.py
@@ -20,6 +20,8 @@ EMAIL_VERIFICATION_PENDING_STATUS = "EMAIL VERIFICATION PENDING"
 
 IMAGE_UPLOAD_SUCCESS = "Image uploaded successfully"
 AUDIO_UPLOAD_SUCCESS = "Day audio uploaded successfully"
+AUDIO_ASSIGN_SUCCESS = "Day audio assigned successfully"
+AUDIO_KEY_NOT_FOUND = "Audio not found or you do not have access to this audio key"
 INVALID_AUDIO_FILE_FORMAT = "Invalid audio format. Allowed: MP3, M4A, WAV, AAC, OGG"
 AUDIO_FILE_TOO_LARGE = "Audio file size exceeds limit"
 UNEXPECTED_ERROR_UPLOAD = "An unexpected error occurred during upload"

--- a/tests/plans/audio/test_cms_plan_audio_service.py
+++ b/tests/plans/audio/test_cms_plan_audio_service.py
@@ -39,11 +39,15 @@ def test_get_cms_plan_audio_list_maps_rows_and_pagination():
     audio_row = _make_audio_row(audio_key)
     plan_item = _make_plan_item(plan_id=plan_id, day_number=3)
     plan = MagicMock()
+    plan.author_id = author.id
 
     with patch(
         "pecha_api.plans.audio.cms_plan_audio_service.validate_and_extract_author_details",
         return_value=author,
     ), patch("pecha_api.plans.audio.cms_plan_audio_service.SessionLocal") as mock_session, patch(
+        "pecha_api.plans.audio.cms_plan_audio_service.get_plan_by_id",
+        return_value=plan,
+    ), patch(
         "pecha_api.plans.audio.cms_plan_audio_service.get_plan_item_audio_paginated",
         return_value=([(audio_row, plan_item, plan)], 1),
     ) as mock_repo, patch(
@@ -57,6 +61,7 @@ def test_get_cms_plan_audio_list_maps_rows_and_pagination():
         response = get_cms_plan_audio_list(
             token="token",
             search="recording",
+            plan_id=plan_id,
             skip=0,
             limit=10,
         )
@@ -64,6 +69,7 @@ def test_get_cms_plan_audio_list_maps_rows_and_pagination():
     mock_repo.assert_called_once_with(
         db=mock_db,
         search="recording",
+        plan_id=plan_id,
         author_id=author.id,
         is_admin=False,
         skip=0,
@@ -97,10 +103,40 @@ def test_get_cms_plan_audio_list_admin_passes_is_admin():
         mock_session.return_value.__enter__.return_value = MagicMock()
         mock_session.return_value.__exit__.return_value = False
 
-        response = get_cms_plan_audio_list(token="token", search=None, skip=5, limit=20)
+        response = get_cms_plan_audio_list(
+            token="token", search=None, plan_id=None, skip=5, limit=20
+        )
 
     mock_repo.assert_called_once()
     assert mock_repo.call_args.kwargs["is_admin"] is True
     assert response.total == 0
     assert response.skip == 5
     assert response.limit == 20
+
+
+def test_get_cms_plan_audio_list_validates_plan_access_when_plan_id_set():
+    author = _make_author()
+    plan_id = uuid.uuid4()
+    plan = MagicMock()
+    plan.author_id = author.id
+
+    with patch(
+        "pecha_api.plans.audio.cms_plan_audio_service.validate_and_extract_author_details",
+        return_value=author,
+    ), patch("pecha_api.plans.audio.cms_plan_audio_service.SessionLocal") as mock_session, patch(
+        "pecha_api.plans.audio.cms_plan_audio_service.get_plan_by_id",
+        return_value=plan,
+    ), patch(
+        "pecha_api.plans.audio.cms_plan_audio_service.get_plan_item_audio_paginated",
+        return_value=([], 0),
+    ):
+        mock_session.return_value.__enter__.return_value = MagicMock()
+        mock_session.return_value.__exit__.return_value = False
+
+        get_cms_plan_audio_list(
+            token="token",
+            search=None,
+            plan_id=plan_id,
+            skip=0,
+            limit=10,
+        )

--- a/tests/plans/audio/test_cms_plan_audio_service.py
+++ b/tests/plans/audio/test_cms_plan_audio_service.py
@@ -1,0 +1,106 @@
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+from pecha_api.plans.audio.cms_plan_audio_service import get_cms_plan_audio_list
+
+
+def _make_author(*, is_admin: bool = False):
+    author = MagicMock()
+    author.id = uuid.uuid4()
+    author.email = "author@example.com"
+    author.is_admin = is_admin
+    return author
+
+
+def _make_audio_row(audio_key: str):
+    audio = MagicMock()
+    audio.id = uuid.uuid4()
+    audio.audio_key = audio_key
+    audio.duration_ms = 120000
+    audio.mime_type = "audio/mpeg"
+    audio.file_size_bytes = 1024
+    audio.created_at = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    return audio
+
+
+def _make_plan_item(plan_id=None, day_number=1):
+    plan_item = MagicMock()
+    plan_item.id = uuid.uuid4()
+    plan_item.plan_id = plan_id or uuid.uuid4()
+    plan_item.day_number = day_number
+    return plan_item
+
+
+def test_get_cms_plan_audio_list_maps_rows_and_pagination():
+    author = _make_author()
+    plan_id = uuid.uuid4()
+    audio_key = f"audio/plan_days/{plan_id}/{uuid.uuid4()}/recording.mp3"
+    audio_row = _make_audio_row(audio_key)
+    plan_item = _make_plan_item(plan_id=plan_id, day_number=3)
+    plan = MagicMock()
+
+    with patch(
+        "pecha_api.plans.audio.cms_plan_audio_service.validate_and_extract_author_details",
+        return_value=author,
+    ), patch("pecha_api.plans.audio.cms_plan_audio_service.SessionLocal") as mock_session, patch(
+        "pecha_api.plans.audio.cms_plan_audio_service.get_plan_item_audio_paginated",
+        return_value=([(audio_row, plan_item, plan)], 1),
+    ) as mock_repo, patch(
+        "pecha_api.plans.audio.cms_plan_audio_service.generate_presigned_access_url",
+        return_value="https://audio.example.com/signed",
+    ):
+        mock_db = MagicMock()
+        mock_session.return_value.__enter__.return_value = mock_db
+        mock_session.return_value.__exit__.return_value = False
+
+        response = get_cms_plan_audio_list(
+            token="token",
+            search="recording",
+            skip=0,
+            limit=10,
+        )
+
+    mock_repo.assert_called_once_with(
+        db=mock_db,
+        search="recording",
+        author_id=author.id,
+        is_admin=False,
+        skip=0,
+        limit=10,
+    )
+    assert response.total == 1
+    assert response.skip == 0
+    assert response.limit == 10
+    assert len(response.audio) == 1
+    item = response.audio[0]
+    assert item.audio_key == audio_key
+    assert item.file_name == "recording.mp3"
+    assert item.audio_url == "https://audio.example.com/signed"
+    assert item.plan_id == plan_id
+    assert item.day_number == 3
+    assert item.duration_ms == 120000
+
+
+def test_get_cms_plan_audio_list_admin_passes_is_admin():
+    author = _make_author(is_admin=True)
+
+    with patch(
+        "pecha_api.plans.audio.cms_plan_audio_service.validate_and_extract_author_details",
+        return_value=author,
+    ), patch("pecha_api.plans.audio.cms_plan_audio_service.SessionLocal") as mock_session, patch(
+        "pecha_api.plans.audio.cms_plan_audio_service.get_plan_item_audio_paginated",
+        return_value=([], 0),
+    ) as mock_repo, patch(
+        "pecha_api.plans.audio.cms_plan_audio_service.generate_presigned_access_url",
+    ):
+        mock_session.return_value.__enter__.return_value = MagicMock()
+        mock_session.return_value.__exit__.return_value = False
+
+        response = get_cms_plan_audio_list(token="token", search=None, skip=5, limit=20)
+
+    mock_repo.assert_called_once()
+    assert mock_repo.call_args.kwargs["is_admin"] is True
+    assert response.total == 0
+    assert response.skip == 5
+    assert response.limit == 20

--- a/tests/plans/audio/test_plan_day_audio_service.py
+++ b/tests/plans/audio/test_plan_day_audio_service.py
@@ -4,8 +4,10 @@ from unittest.mock import MagicMock, patch
 from uuid import uuid4
 from fastapi import HTTPException, UploadFile
 
+from pecha_api.plans.audio.plan_audio_response_models import AssignPlanDayAudioRequest
 from pecha_api.plans.audio.plan_day_audio_service import (
     _validate_audio_file,
+    assign_plan_day_audio,
     upload_plan_day_audio,
 )
 
@@ -73,3 +75,94 @@ def test_upload_plan_day_audio_success(
     assert response.audio_key == "audio/key.mp3"
     assert response.audio_url == "https://audio.url"
     assert response.duration_ms == 120000
+
+
+@patch("pecha_api.plans.audio.plan_day_audio_service.generate_presigned_access_url", return_value="https://audio.url")
+@patch("pecha_api.plans.audio.plan_day_audio_service.upsert_plan_item_audio")
+@patch("pecha_api.plans.audio.plan_day_audio_service.count_plan_item_audio_by_audio_key", return_value=1)
+@patch("pecha_api.plans.audio.plan_day_audio_service.delete_file")
+@patch("pecha_api.plans.audio.plan_day_audio_service.get_plan_item_audio_by_plan_item_id")
+@patch("pecha_api.plans.audio.plan_day_audio_service.get_accessible_plan_item_audio_by_key")
+@patch("pecha_api.plans.audio.plan_day_audio_service._get_author_plan_item_by_day_id")
+@patch("pecha_api.plans.audio.plan_day_audio_service.validate_and_extract_author_details")
+@patch("pecha_api.plans.audio.plan_day_audio_service.SessionLocal")
+def test_assign_plan_day_audio_success(
+    mock_session,
+    mock_validate,
+    mock_get_item,
+    mock_get_source,
+    mock_get_existing,
+    mock_delete_file,
+    mock_count,
+    mock_upsert,
+    mock_presign,
+):
+    day_id = uuid4()
+    plan_item_id = day_id
+    library_key = "audio/plan_days/lib/recording.mp3"
+    old_key = "audio/plan_days/old/day.mp3"
+
+    author = MagicMock()
+    author.email = "author@test.com"
+    author.id = uuid4()
+    author.is_admin = False
+    mock_validate.return_value = author
+
+    plan_item = MagicMock()
+    plan_item.id = plan_item_id
+    mock_get_item.return_value = plan_item
+
+    source = MagicMock()
+    source.audio_key = library_key
+    source.duration_ms = 90000
+    source.mime_type = "audio/mpeg"
+    source.file_size_bytes = 2048
+    mock_get_source.return_value = source
+
+    existing = MagicMock()
+    existing.audio_key = old_key
+    mock_get_existing.return_value = existing
+
+    audio_row = MagicMock()
+    audio_row.audio_key = library_key
+    audio_row.duration_ms = 120000
+    mock_upsert.return_value = audio_row
+
+    mock_session.return_value.__enter__ = MagicMock(return_value=MagicMock())
+    mock_session.return_value.__exit__ = MagicMock(return_value=False)
+
+    response = assign_plan_day_audio(
+        token="token",
+        day_id=day_id,
+        request=AssignPlanDayAudioRequest(audio_key=library_key, duration_ms=120000),
+    )
+
+    mock_delete_file.assert_called_once_with(old_key)
+    mock_get_source.assert_called_once()
+    assert response.audio_key == library_key
+    assert response.duration_ms == 120000
+    assert response.message == "Day audio assigned successfully"
+
+
+@patch("pecha_api.plans.audio.plan_day_audio_service.get_accessible_plan_item_audio_by_key", return_value=None)
+@patch("pecha_api.plans.audio.plan_day_audio_service._get_author_plan_item_by_day_id")
+@patch("pecha_api.plans.audio.plan_day_audio_service.validate_and_extract_author_details")
+@patch("pecha_api.plans.audio.plan_day_audio_service.SessionLocal")
+def test_assign_plan_day_audio_unknown_key_returns_404(
+    mock_session,
+    mock_validate,
+    mock_get_item,
+    mock_get_source,
+):
+    mock_validate.return_value = MagicMock(email="a@test.com", id=uuid4(), is_admin=False)
+    mock_get_item.return_value = MagicMock(id=uuid4())
+    mock_session.return_value.__enter__ = MagicMock(return_value=MagicMock())
+    mock_session.return_value.__exit__ = MagicMock(return_value=False)
+
+    with pytest.raises(HTTPException) as exc:
+        assign_plan_day_audio(
+            token="token",
+            day_id=uuid4(),
+            request=AssignPlanDayAudioRequest(audio_key="audio/missing.mp3"),
+        )
+    assert exc.value.status_code == 404


### PR DESCRIPTION
- Implemented a new function to retrieve paginated audio data associated with plan items, including filtering by author and search terms.
- Added a new endpoint in the CMS for listing plan audio, allowing for search and pagination parameters.