### PR TITLE
feat(texts): make category_id and collection_id optional in text fetc…

### DIFF
--- a/openpecha_api/text/openpecha_text_service.py
+++ b/openpecha_api/text/openpecha_text_service.py
@@ -7,17 +7,18 @@ logger = logging.getLogger(__name__)
 
 
 async def fetch_texts_by_category(
-    category_id: str,
+    category_id: Optional[str] = None,
     language: Optional[str] = None,
     title: Optional[str] = None,
     limit: int = 20,
     offset: int = 0,
 ) -> Dict[str, Any]:
     params: Dict[str, Any] = {
-        "category_id": category_id,
         "limit": limit,
         "offset": offset,
     }
+    if category_id:
+        params["category_id"] = category_id
     if language:
         params["language"] = language
     if title:

--- a/pecha_api/texts/texts_openpecha_service.py
+++ b/pecha_api/texts/texts_openpecha_service.py
@@ -81,7 +81,7 @@ def map_external_text_to_dto(item: Dict[str, Any], language: Optional[str] = Non
 
 
 async def _get_texts_by_collection_id(
-    collection_id: str,
+    collection_id: Optional[str],
     skip: int,
     limit: int,
     title: Optional[str] = None,
@@ -107,7 +107,7 @@ async def _get_texts_by_collection_id(
 
 
 async def get_texts_by_collection_from_openpecha(
-    collection_id: str,
+    collection_id: Optional[str] = None,
     language: Optional[str] = None,
     title: Optional[str] = None,
     skip: int = 0,
@@ -120,21 +120,23 @@ async def get_texts_by_collection_from_openpecha(
         limit=limit,
     )
 
-    category_title = ""
-    try:
-        category_data = await fetch_category_by_id(collection_id, language=language)
-        if category_data:
-            category_title = _extract_title(category_data.get("title", {}), language)
-    except Exception:
-        raise HTTPException(
-            status_code=status.HTTP_502_BAD_GATEWAY,
-            detail="Failed to fetch category title from upstream service",
-        )
+    collection: Optional[V2CollectionModel] = None
+    if collection_id:
+        category_title = ""
+        try:
+            category_data = await fetch_category_by_id(collection_id, language=language)
+            if category_data:
+                category_title = _extract_title(category_data.get("title", {}), language)
+        except Exception:
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail="Failed to fetch category title from upstream service",
+            )
 
-    collection = V2CollectionModel(
-        id=collection_id,
-        title=category_title,
-    )
+        collection = V2CollectionModel(
+            id=collection_id,
+            title=category_title,
+        )
 
     return V2TextsCategoryResponse(
         collection=collection,

--- a/pecha_api/texts/texts_openpecha_views.py
+++ b/pecha_api/texts/texts_openpecha_views.py
@@ -30,7 +30,7 @@ texts_v2_router = APIRouter(
     description="Retrieve texts for a collection from OpenPecha API. "
 )
 async def get_texts_by_collection(
-    collection_id: Annotated[str, Query(description="Collection ID to filter texts")],
+    collection_id: Annotated[Optional[str], Query(description="Collection ID to filter texts")] = None,
     language: Annotated[Optional[str], Query(description="Language code filter")] = None,
     title: Annotated[Optional[str], Query(description="Filter texts by title (case-insensitive substring)")] = None,
     skip: Annotated[int, Query(ge=0, description="Number of records to skip")] = 0,

--- a/pecha_api/texts/texts_response_models.py
+++ b/pecha_api/texts/texts_response_models.py
@@ -173,7 +173,7 @@ class TextsCategoryResponse(BaseModel):
 
 
 class V2TextsCategoryResponse(BaseModel):
-    collection: V2CollectionModel
+    collection: Optional[V2CollectionModel] = None
     texts: List[V2TextDTO]
     skip: int
     limit: int

--- a/tests/openpecha_api/test_openpecha_text_service.py
+++ b/tests/openpecha_api/test_openpecha_text_service.py
@@ -33,6 +33,21 @@ async def test_fetch_texts_by_category(mock_get_client):
 
 @pytest.mark.asyncio
 @patch("openpecha_api.text.openpecha_text_service.get_authenticated_open_pecha_client")
+async def test_fetch_texts_by_category_omits_category_id_when_not_provided(mock_get_client):
+    mock_get_client.return_value.get_async_httpx_client.return_value = _mock_http_client(
+        {"items": []}
+    )
+
+    await fetch_texts_by_category(limit=10, offset=0)
+
+    http = mock_get_client.return_value.get_async_httpx_client.return_value
+    params = http.get.await_args.kwargs["params"]
+    assert "category_id" not in params
+    assert params == {"limit": 10, "offset": 0}
+
+
+@pytest.mark.asyncio
+@patch("openpecha_api.text.openpecha_text_service.get_authenticated_open_pecha_client")
 async def test_fetch_texts_by_category_omits_title_when_not_provided(mock_get_client):
     mock_get_client.return_value.get_async_httpx_client.return_value = _mock_http_client(
         {"items": []}

--- a/tests/texts/test_texts_openpecha_service.py
+++ b/tests/texts/test_texts_openpecha_service.py
@@ -489,6 +489,27 @@ class TestGetTextsByCollectionFromOpenpecha:
         assert exc_info.value.status_code == 502
         assert "category" in exc_info.value.detail.lower()
 
+    @pytest.mark.asyncio
+    @patch("pecha_api.texts.texts_openpecha_service.fetch_category_by_id", new_callable=AsyncMock)
+    @patch("pecha_api.texts.texts_openpecha_service.fetch_texts_by_category", new_callable=AsyncMock)
+    async def test_get_texts_without_collection_id(self, mock_fetch_texts, mock_fetch_category):
+        mock_fetch_texts.return_value = {
+            "items": [{"id": "t1", "title": {"en": "Text 1"}, "language": "en"}],
+            "has_more": False,
+        }
+
+        result = await get_texts_by_collection_from_openpecha(skip=0, limit=10)
+
+        assert result.collection is None
+        assert len(result.texts) == 1
+        mock_fetch_texts.assert_awaited_once_with(
+            category_id=None,
+            title=None,
+            offset=0,
+            limit=10,
+        )
+        mock_fetch_category.assert_not_awaited()
+
 
 # =============================================================================
 # Service Function Tests - get_text_by_id_from_openpecha (V2)

--- a/tests/texts/test_texts_openpecha_views.py
+++ b/tests/texts/test_texts_openpecha_views.py
@@ -80,6 +80,29 @@ MOCK_TEXT_VERSION_2 = TextVersion(
 
 class TestTextsV2Endpoint:
     @patch("pecha_api.texts.texts_openpecha_views.get_texts_by_collection_from_openpecha")
+    def test_get_texts_without_collection_id(self, mock_service):
+        mock_service.return_value = V2TextsCategoryResponse(
+            collection=None,
+            texts=[V2TextDTO(id="t1", title="Text 1", language="en")],
+            skip=0,
+            limit=10,
+        )
+
+        response = client.get("/texts")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["collection"] is None
+        assert len(data["texts"]) == 1
+        mock_service.assert_awaited_once_with(
+            collection_id=None,
+            language=None,
+            title=None,
+            skip=0,
+            limit=10,
+        )
+
+    @patch("pecha_api.texts.texts_openpecha_views.get_texts_by_collection_from_openpecha")
     def test_get_texts_by_collection_success(self, mock_service):
         mock_service.return_value = V2TextsCategoryResponse(
             collection=V2CollectionModel(id="cat-1", title="Discourses"),


### PR DESCRIPTION
…hing functions

- Updated the `fetch_texts_by_category` and `get_texts_by_collection_from_openpecha` functions to accept `category_id` and `collection_id` as optional parameters.
- Adjusted related service and view functions to handle cases where these IDs are not provided, ensuring proper functionality without them.
- Enhanced tests to verify the behavior of the updated functions when no category or collection ID is supplied, confirming that the parameters are omitted as expected.