### PR TITLE
Enhance series retrieval by adding optional language filtering

### DIFF
--- a/pecha_api/plans/series/public_series_view.py
+++ b/pecha_api/plans/series/public_series_view.py
@@ -34,5 +34,11 @@ async def get_series_list(
 @public_series_router.get(
     "/{series_id}", status_code=status.HTTP_200_OK, response_model=SeriesDTO
 )
-async def get_series(series_id: UUID):
-    return get_series_detail(series_id=series_id)
+async def get_series(
+    series_id: UUID,
+    language: Annotated[
+        Optional[str],
+        Query(description="Filter plans by language (e.g. 'en', 'bo', 'zh')"),
+    ] = None,
+):
+    return get_series_detail(series_id=series_id, language=language)

--- a/pecha_api/plans/series/series_service.py
+++ b/pecha_api/plans/series/series_service.py
@@ -245,7 +245,7 @@ def get_filtered_series(
     )
 
 
-def get_series_detail(series_id: UUID) -> SeriesDTO:
+def get_series_detail(series_id: UUID, language: Optional[str] = None) -> SeriesDTO:
     with SessionLocal() as db_session:
         row = get_series_by_id(db=db_session, series_id=series_id)
         if not row or _to_plan_status(row.status) != PlanStatus.PUBLISHED:
@@ -258,6 +258,7 @@ def get_series_detail(series_id: UUID) -> SeriesDTO:
             row,
             include_plans=True,
             published_only=True,
+            plan_language=language,
         )
 
 def get_cms_filtered_series(

--- a/spec/series-openapi-spec.yaml
+++ b/spec/series-openapi-spec.yaml
@@ -382,10 +382,21 @@ paths:
         Public, unauthenticated retrieval of a single Series. Only attached
         plans that are published and active are included in the response.
 
+        Optional `language` query filters the returned plans (and
+        `total_days`) to those matching the given language code (e.g. `en`,
+        `bo`, `zh`); case-insensitive.
+
         Returns 404 if the Series does not exist, is soft-deleted, OR exists
         but does not have status PUBLISHED. A non-published Series is
         deliberately indistinguishable from a missing one on this endpoint.
       security: []
+      parameters:
+        - name: language
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Filter plans by language (e.g. en, bo, zh).
       responses:
         '200':
           description: The requested Series.

--- a/tests/plans/series/test_series_service.py
+++ b/tests/plans/series/test_series_service.py
@@ -610,6 +610,62 @@ def test_get_series_detail_excludes_non_published_plans():
     assert dto.plans[0].status == PlanStatus.PUBLISHED
 
 
+def test_get_series_detail_filters_plans_by_language():
+    series_id = uuid.uuid4()
+    author_id = uuid.uuid4()
+
+    plan_en = MagicMock()
+    plan_en.deleted_at = None
+    plan_en.display_order = 0
+    plan_en.id = uuid.uuid4()
+    plan_en.title = "English plan"
+    plan_en.description = None
+    plan_en.language = LanguageCode.EN
+    plan_en.difficulty_level = None
+    plan_en.image_url = None
+    plan_en.tag_list = []
+    plan_en.status = PlanStatus.PUBLISHED
+    plan_en.featured = False
+    plan_en.start_date = None
+    plan_en.items = []
+
+    plan_bo = MagicMock()
+    plan_bo.deleted_at = None
+    plan_bo.display_order = 1
+    plan_bo.id = uuid.uuid4()
+    plan_bo.title = "Tibetan plan"
+    plan_bo.description = None
+    plan_bo.language = LanguageCode.BO
+    plan_bo.difficulty_level = None
+    plan_bo.image_url = None
+    plan_bo.tag_list = []
+    plan_bo.status = PlanStatus.PUBLISHED
+    plan_bo.featured = False
+    plan_bo.start_date = None
+    plan_bo.items = []
+
+    row = MagicMock()
+    row.id = series_id
+    row.metadata_entries = []
+    row.image = None
+    row.author_id = author_id
+    row.featured = False
+    row.status = PlanStatus.PUBLISHED
+    row.plans = [plan_en, plan_bo]
+
+    with patch("pecha_api.plans.series.series_service.SessionLocal") as mock_session_local, patch(
+        "pecha_api.plans.series.series_service.get_series_by_id",
+        return_value=row,
+    ):
+        _session_local_context(mock_session_local)
+
+        dto = get_series_detail(series_id=series_id, language="bo")
+
+    assert len(dto.plans) == 1
+    assert dto.plans[0].id == plan_bo.id
+    assert dto.plans[0].language == "BO"
+
+
 # ---------------------------------------------------------------------------
 # Helpers shared by update_existing_series tests
 # ---------------------------------------------------------------------------

--- a/tests/plans/series/test_series_views.py
+++ b/tests/plans/series/test_series_views.py
@@ -213,7 +213,7 @@ def test_get_series_by_id_success(sample_series_dto):
         response = client.get(f"/series/{series_id}")
 
         assert response.status_code == status.HTTP_200_OK
-        mock_detail.assert_called_once_with(series_id=series_id)
+        mock_detail.assert_called_once_with(series_id=series_id, language=None)
 
         data = response.json()
         assert data["id"] == str(sample_series_dto.id)
@@ -293,7 +293,7 @@ def test_get_series_by_id_includes_total_days_in_response():
         assert response.status_code == status.HTTP_200_OK
         data = response.json()
 
-        mock_detail.assert_called_once_with(series_id=series_id)
+        mock_detail.assert_called_once_with(series_id=series_id, language=None)
 
         assert data["total_days"] == 8
         assert len(data["plans"]) == 2
@@ -526,6 +526,18 @@ def test_get_cms_series_by_id_forbidden():
         )
 
     assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_get_series_by_id_passes_language_param(sample_series_dto):
+    series_id = sample_series_dto.id
+    with patch(
+        "pecha_api.plans.series.public_series_view.get_series_detail",
+        return_value=sample_series_dto,
+    ) as mock_detail:
+        response = client.get(f"/series/{series_id}", params={"language": "bo"})
+
+        assert response.status_code == status.HTTP_200_OK
+        mock_detail.assert_called_once_with(series_id=series_id, language="bo")
 
 
 def test_get_cms_series_by_id_passes_language_param(sample_series_dto):


### PR DESCRIPTION
- Updated the `get_series` endpoint to accept an optional `language` query parameter for filtering plans by language.
- Modified the `get_series_detail` function to handle the new language parameter, allowing for more precise plan retrieval.
- Updated OpenAPI specifications to document the new language filtering feature.
- Added tests to ensure correct functionality of language filtering in series retrieval.