### PR TITLE
Add functionality to save user day completion if not exists

### DIFF
--- a/pecha_api/plans/users/plan_user_day_repository.py
+++ b/pecha_api/plans/users/plan_user_day_repository.py
@@ -17,6 +17,19 @@ def save_user_day_completion(db: Session, user_day_completion: UserDayCompletion
         db.rollback()
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ResponseError(error=BAD_REQUEST, message=str(e.orig)).model_dump())
 
+
+def save_user_day_completion_if_not_exists(db: Session, user_id: UUID, day_id: UUID) -> bool:
+    """Insert day completion when missing. Returns True if a new row was created."""
+    if get_user_day_completion_by_user_id_and_day_id(db, user_id, day_id):
+        return False
+    try:
+        db.add(UserDayCompletion(user_id=user_id, day_id=day_id))
+        db.commit()
+        return True
+    except IntegrityError:
+        db.rollback()
+        return False
+
 def delete_user_day_completion(db: Session, user_id: UUID, day_id: UUID) -> None:
     try:
         db.query(UserDayCompletion).filter(UserDayCompletion.user_id == user_id, UserDayCompletion.day_id == day_id).delete()

--- a/pecha_api/plans/users/plan_user_series_day_sync_repository.py
+++ b/pecha_api/plans/users/plan_user_series_day_sync_repository.py
@@ -1,0 +1,48 @@
+from typing import List, Optional
+from uuid import UUID
+
+from sqlalchemy import and_
+from sqlalchemy.orm import Session
+
+from pecha_api.plans.items.plan_items_models import PlanItem
+from pecha_api.plans.plans_models import Plan
+
+
+def get_sibling_plans_in_series_slot(
+    db: Session,
+    *,
+    series_id: UUID,
+    display_order: int,
+    exclude_plan_id: UUID,
+) -> List[Plan]:
+    """Plans in the same series slot (display_order) as the source plan, excluding the source."""
+    return (
+        db.query(Plan)
+        .filter(
+            Plan.series_id == series_id,
+            Plan.display_order == display_order,
+            Plan.id != exclude_plan_id,
+            Plan.deleted_at.is_(None),
+        )
+        .all()
+    )
+
+
+def get_plan_items_by_plan_ids_and_day_number(
+    db: Session,
+    *,
+    plan_ids: List[UUID],
+    day_number: int,
+) -> List[PlanItem]:
+    if not plan_ids:
+        return []
+    return (
+        db.query(PlanItem)
+        .filter(
+            and_(
+                PlanItem.plan_id.in_(plan_ids),
+                PlanItem.day_number == day_number,
+            )
+        )
+        .all()
+    )

--- a/pecha_api/plans/users/plan_user_series_day_sync_service.py
+++ b/pecha_api/plans/users/plan_user_series_day_sync_service.py
@@ -1,0 +1,50 @@
+from typing import List
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from pecha_api.plans.cms.cms_plans_repository import get_plan_by_id
+from pecha_api.plans.items.plan_items_repository import get_plan_item_by_id
+from pecha_api.plans.users.plan_user_day_repository import save_user_day_completion_if_not_exists
+from pecha_api.plans.users.plan_user_series_day_sync_repository import (
+    get_plan_items_by_plan_ids_and_day_number,
+    get_sibling_plans_in_series_slot,
+)
+
+
+def sync_series_day_completion(db: Session, user_id: UUID, completed_day_id: UUID) -> List[UUID]:
+    """
+    Mirror day completion to sibling language plans in the same series slot.
+
+    Sibling plans share series_id and display_order; equivalent days share day_number.
+    Returns day_ids of sibling plans that have a matching day (for plan-completion checks).
+    """
+    day_item = get_plan_item_by_id(db, completed_day_id)
+    if not day_item:
+        return []
+
+    plan = get_plan_by_id(db, day_item.plan_id)
+    if not plan or not plan.series_id or plan.display_order is None:
+        return []
+
+    sibling_plans = get_sibling_plans_in_series_slot(
+        db,
+        series_id=plan.series_id,
+        display_order=plan.display_order,
+        exclude_plan_id=plan.id,
+    )
+    if not sibling_plans:
+        return []
+
+    equivalent_days = get_plan_items_by_plan_ids_and_day_number(
+        db,
+        plan_ids=[sibling.id for sibling in sibling_plans],
+        day_number=day_item.day_number,
+    )
+
+    synced_day_ids: List[UUID] = []
+    for equivalent_day in equivalent_days:
+        save_user_day_completion_if_not_exists(db, user_id, equivalent_day.id)
+        synced_day_ids.append(equivalent_day.id)
+
+    return synced_day_ids

--- a/pecha_api/plans/users/plan_users_service.py
+++ b/pecha_api/plans/users/plan_users_service.py
@@ -64,6 +64,7 @@ from pecha_api.plans.response_message import (
 )
 from pecha_api.plans.tasks.plan_tasks_models import PlanTask
 from pecha_api.plans.users.plan_user_day_repository import get_completed_day_ids_by_user_id_and_day_ids, save_user_day_completion, delete_user_day_completion, get_user_day_completion_by_user_id_and_day_id
+from pecha_api.plans.users.plan_user_series_day_sync_service import sync_series_day_completion
 from pecha_api.plans.users.plan_users_subtasks_repository import (
     save_user_sub_task_completions, 
     get_user_subtask_completions_by_user_id_and_sub_task_ids, 
@@ -470,9 +471,12 @@ def check_day_completion(db:SessionLocal(), user_id: UUID, day_id: UUID) -> None
     
     if len(uncompleted_task_ids) == 0:
         save_user_day_completion(db=db, user_day_completion=UserDayCompletion(user_id=user_id, day_id=day_id))
-        
-        # Check if plan is now completed
+
+        sibling_day_ids = sync_series_day_completion(db=db, user_id=user_id, completed_day_id=day_id)
+
         check_plan_completion(db, user_id, day_id)
+        for sibling_day_id in sibling_day_ids:
+            check_plan_completion(db, user_id, sibling_day_id)
     else:
         return
 

--- a/tests/plans/users/test_plan_user_series_day_sync_service.py
+++ b/tests/plans/users/test_plan_user_series_day_sync_service.py
@@ -1,0 +1,119 @@
+import uuid
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from pecha_api.plans.users.plan_user_series_day_sync_service import sync_series_day_completion
+
+
+def test_sync_series_day_completion_returns_empty_when_day_not_found():
+    db_mock = MagicMock()
+    with patch(
+        "pecha_api.plans.users.plan_user_series_day_sync_service.get_plan_item_by_id",
+        return_value=None,
+    ):
+        result = sync_series_day_completion(db_mock, uuid.uuid4(), uuid.uuid4())
+    assert result == []
+
+
+def test_sync_series_day_completion_returns_empty_when_plan_not_in_series():
+    db_mock = MagicMock()
+    day_id = uuid.uuid4()
+    plan_id = uuid.uuid4()
+    with patch(
+        "pecha_api.plans.users.plan_user_series_day_sync_service.get_plan_item_by_id",
+        return_value=SimpleNamespace(id=day_id, plan_id=plan_id, day_number=1),
+    ), patch(
+        "pecha_api.plans.users.plan_user_series_day_sync_service.get_plan_by_id",
+        return_value=SimpleNamespace(id=plan_id, series_id=None, display_order=1),
+    ):
+        result = sync_series_day_completion(db_mock, uuid.uuid4(), day_id)
+    assert result == []
+
+
+def test_sync_series_day_completion_returns_empty_when_display_order_missing():
+    db_mock = MagicMock()
+    day_id = uuid.uuid4()
+    plan_id = uuid.uuid4()
+    series_id = uuid.uuid4()
+    with patch(
+        "pecha_api.plans.users.plan_user_series_day_sync_service.get_plan_item_by_id",
+        return_value=SimpleNamespace(id=day_id, plan_id=plan_id, day_number=2),
+    ), patch(
+        "pecha_api.plans.users.plan_user_series_day_sync_service.get_plan_by_id",
+        return_value=SimpleNamespace(id=plan_id, series_id=series_id, display_order=None),
+    ):
+        result = sync_series_day_completion(db_mock, uuid.uuid4(), day_id)
+    assert result == []
+
+
+def test_sync_series_day_completion_marks_sibling_days_complete():
+    db_mock = MagicMock()
+    user_id = uuid.uuid4()
+    completed_day_id = uuid.uuid4()
+    plan_id = uuid.uuid4()
+    series_id = uuid.uuid4()
+    sibling_plan_id = uuid.uuid4()
+    sibling_day_id = uuid.uuid4()
+
+    sibling_plan = SimpleNamespace(id=sibling_plan_id)
+    sibling_day = SimpleNamespace(id=sibling_day_id)
+
+    with patch(
+        "pecha_api.plans.users.plan_user_series_day_sync_service.get_plan_item_by_id",
+        return_value=SimpleNamespace(id=completed_day_id, plan_id=plan_id, day_number=3),
+    ), patch(
+        "pecha_api.plans.users.plan_user_series_day_sync_service.get_plan_by_id",
+        return_value=SimpleNamespace(id=plan_id, series_id=series_id, display_order=1),
+    ), patch(
+        "pecha_api.plans.users.plan_user_series_day_sync_service.get_sibling_plans_in_series_slot",
+        return_value=[sibling_plan],
+    ) as mock_siblings, patch(
+        "pecha_api.plans.users.plan_user_series_day_sync_service.get_plan_items_by_plan_ids_and_day_number",
+        return_value=[sibling_day],
+    ) as mock_equivalent_days, patch(
+        "pecha_api.plans.users.plan_user_series_day_sync_service.save_user_day_completion_if_not_exists",
+    ) as mock_save:
+        result = sync_series_day_completion(db_mock, user_id, completed_day_id)
+
+    mock_siblings.assert_called_once_with(
+        db_mock,
+        series_id=series_id,
+        display_order=1,
+        exclude_plan_id=plan_id,
+    )
+    mock_equivalent_days.assert_called_once_with(
+        db_mock,
+        plan_ids=[sibling_plan_id],
+        day_number=3,
+    )
+    mock_save.assert_called_once_with(db_mock, user_id, sibling_day_id)
+    assert result == [sibling_day_id]
+
+
+def test_check_day_completion_runs_plan_completion_for_sibling_days():
+    from pecha_api.plans.users.plan_users_service import check_day_completion
+
+    user_id = uuid.uuid4()
+    day_id = uuid.uuid4()
+    sibling_day_id = uuid.uuid4()
+    db_mock = MagicMock()
+
+    with patch(
+        "pecha_api.plans.users.plan_users_service.get_tasks_by_plan_item_id",
+        return_value=[SimpleNamespace(id=uuid.uuid4())],
+    ), patch(
+        "pecha_api.plans.users.plan_users_service.get_uncompleted_user_task_ids",
+        return_value=[],
+    ), patch(
+        "pecha_api.plans.users.plan_users_service.save_user_day_completion",
+    ), patch(
+        "pecha_api.plans.users.plan_users_service.sync_series_day_completion",
+        return_value=[sibling_day_id],
+    ), patch(
+        "pecha_api.plans.users.plan_users_service.check_plan_completion",
+    ) as mock_plan_completion:
+        check_day_completion(db=db_mock, user_id=user_id, day_id=day_id)
+
+    assert mock_plan_completion.call_count == 2
+    mock_plan_completion.assert_any_call(db_mock, user_id, day_id)
+    mock_plan_completion.assert_any_call(db_mock, user_id, sibling_day_id)

--- a/tests/plans/users/test_plan_users_service.py
+++ b/tests/plans/users/test_plan_users_service.py
@@ -1222,13 +1222,20 @@ def test_check_day_completion_marks_day_complete_when_all_done():
         side_effect=lambda user_id, day_id: SimpleNamespace(user_id=user_id, day_id=day_id),
     ), patch(
         "pecha_api.plans.users.plan_users_service.save_user_day_completion",
-    ) as mock_save:
+    ) as mock_save, patch(
+        "pecha_api.plans.users.plan_users_service.sync_series_day_completion",
+        return_value=[],
+    ) as mock_sync, patch(
+        "pecha_api.plans.users.plan_users_service.check_plan_completion",
+    ) as mock_plan_completion:
         check_day_completion(db=db_mock, user_id=user_id, day_id=day_id)
 
         assert mock_save.call_count == 1
         udc = mock_save.call_args.kwargs["user_day_completion"]
         assert udc.user_id == user_id
         assert udc.day_id == day_id
+        mock_sync.assert_called_once_with(db=db_mock, user_id=user_id, completed_day_id=day_id)
+        mock_plan_completion.assert_called_once_with(db_mock, user_id, day_id)
 
 
 def test_check_day_completion_does_nothing_when_remaining_tasks():


### PR DESCRIPTION
- Introduced `save_user_day_completion_if_not_exists` method to handle day completion insertion only when it doesn't already exist.
- Updated `check_day_completion` to utilize `sync_series_day_completion` for handling sibling day completions.
- Enhanced tests to cover the new functionality and ensure correct behavior of day completion logic.