### PR TITLE
Enhance plan retrieval by adding optional language filtering

### DIFF
--- a/pecha_api/plans/public/plan_repository.py
+++ b/pecha_api/plans/public/plan_repository.py
@@ -192,25 +192,41 @@ def get_all_unique_tags(db: Session, language: str = "EN") -> List[str]:
     return [row.tag for row in results]
 
 
-def get_next_plan_in_series(db: Session, series_id: UUID, current_display_order: Optional[int]) -> Optional[Plan]:
+def get_next_plan_in_series(
+    db: Session,
+    series_id: UUID,
+    current_display_order: Optional[int],
+    language: Optional[str] = None,
+) -> Optional[Plan]:
     if series_id is None or current_display_order is None:
         return None
-    
-    return db.query(Plan).filter(
+
+    query = db.query(Plan).filter(
         Plan.series_id == series_id,
         Plan.display_order > current_display_order,
         Plan.status == PlanStatus.PUBLISHED,
-        Plan.deleted_at.is_(None)
-    ).order_by(asc(Plan.display_order)).first()
+        Plan.deleted_at.is_(None),
+    )
+    if language:
+        query = query.filter(Plan.language == language.upper())
+    return query.order_by(asc(Plan.display_order)).first()
 
 
-def get_previous_plan_in_series(db: Session, series_id: UUID, current_display_order: Optional[int]) -> Optional[Plan]:
+def get_previous_plan_in_series(
+    db: Session,
+    series_id: UUID,
+    current_display_order: Optional[int],
+    language: Optional[str] = None,
+) -> Optional[Plan]:
     if series_id is None or current_display_order is None:
         return None
-    
-    return db.query(Plan).filter(
+
+    query = db.query(Plan).filter(
         Plan.series_id == series_id,
         Plan.display_order < current_display_order,
         Plan.status == PlanStatus.PUBLISHED,
-        Plan.deleted_at.is_(None)
-    ).order_by(desc(Plan.display_order)).first()
+        Plan.deleted_at.is_(None),
+    )
+    if language:
+        query = query.filter(Plan.language == language.upper())
+    return query.order_by(desc(Plan.display_order)).first()

--- a/pecha_api/plans/public/plan_repository.py
+++ b/pecha_api/plans/public/plan_repository.py
@@ -3,6 +3,7 @@ from sqlalchemy import and_, exists, func, desc, asc, or_, select
 from typing import Optional, Tuple, List
 from uuid import UUID
 from pecha_api.plans.plans_models import Plan
+from pecha_api.plans.series.series_model import Series
 from pecha_api.plans.groups.groups_models import author_group_plans, author_group_series
 from pecha_api.plans.tags.tag_model import Tag, plan_tags
 from pecha_api.plans.items.plan_items_models import PlanItem
@@ -151,6 +152,28 @@ def get_published_plan_by_id(db: Session, plan_id: UUID) -> Optional[Plan]:
             Plan.status == PlanStatus.PUBLISHED,
             Plan.deleted_at.is_(None)
         ).first()
+
+
+def get_published_plans_in_series(
+    db: Session,
+    series_id: UUID,
+    language: Optional[str] = None,
+) -> List[Plan]:
+    query = (
+        db.query(Plan)
+        .options(
+            selectinload(Plan.series).selectinload(Series.metadata_entries),
+        )
+        .filter(
+            Plan.series_id == series_id,
+            Plan.display_order.isnot(None),
+            Plan.status == PlanStatus.PUBLISHED,
+            Plan.deleted_at.is_(None),
+        )
+    )
+    if language:
+        query = query.filter(Plan.language == language.upper())
+    return query.order_by(asc(Plan.display_order)).all()
 
 
 def get_plan_items_by_plan_id(db: Session, plan_id: UUID) -> list[PlanItem]:

--- a/pecha_api/plans/public/plan_service.py
+++ b/pecha_api/plans/public/plan_service.py
@@ -14,7 +14,15 @@ from pecha_api.plans.items.plan_items_models import PlanItem
 from pecha_api.plans.plans_enums import ContentType, UserPlanStatus
 from pecha_api.plans.cms.cms_plans_repository import get_plan_by_id
 from pecha_api.uploads.S3_utils import generate_presigned_access_url
-from pecha_api.plans.public.plan_repository import (get_published_plans_from_db, get_published_plans_count, get_published_plan_by_id, get_all_unique_tags, get_next_plan_in_series, get_previous_plan_in_series)
+from pecha_api.plans.public.plan_repository import (
+    get_published_plans_from_db,
+    get_published_plans_count,
+    get_published_plan_by_id,
+    get_published_plans_in_series,
+    get_all_unique_tags,
+    get_next_plan_in_series,
+    get_previous_plan_in_series,
+)
 from pecha_api.plans.users.plan_users_progress_repository import get_plan_progress_by_user_id_and_plan_id, save_plan_progress
 from pecha_api.plans.users.plan_users_models import UserPlanProgress
 from pecha_api.routines.routines_repository import (
@@ -388,6 +396,83 @@ def _filter_series_metadata_by_language(metadata_entries, language: Optional[str
     ]
 
 
+def _to_plan_date(value) -> DateType:
+    if isinstance(value, dt):
+        return value.date()
+    return value
+
+
+def _resolve_plan_for_date_in_series(plans: List, reference_date: DateType):
+    sorted_plans = sorted(
+        plans,
+        key=lambda plan: (plan.display_order is None, plan.display_order or 0),
+    )
+    if not sorted_plans:
+        return None
+
+    for index, plan in enumerate(sorted_plans):
+        if not plan.start_date:
+            continue
+        plan_start = _to_plan_date(plan.start_date)
+        next_start = None
+        if index + 1 < len(sorted_plans) and sorted_plans[index + 1].start_date:
+            next_start = _to_plan_date(sorted_plans[index + 1].start_date)
+        if plan_start <= reference_date and (next_start is None or reference_date < next_start):
+            return plan
+
+    for plan in sorted_plans:
+        if plan.start_date:
+            return plan
+
+    return sorted_plans[0]
+
+
+def _resolve_daily_plan(
+    db,
+    plan_id: UUID,
+    requested_date: Optional[DateType],
+    language: Optional[str],
+):
+    entry_plan = get_published_plan_by_id(db=db, plan_id=plan_id)
+    if not entry_plan:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=ErrorConstants.PLAN_NOT_FOUND,
+        )
+
+    if not entry_plan.series_id:
+        return entry_plan
+
+    plan_language = language
+    if not plan_language:
+        plan_language = (
+            entry_plan.language.value
+            if hasattr(entry_plan.language, "value")
+            else str(entry_plan.language)
+        )
+
+    series_plans = get_published_plans_in_series(
+        db=db,
+        series_id=entry_plan.series_id,
+        language=plan_language,
+    )
+    if not series_plans:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=ErrorConstants.PLAN_NOT_FOUND,
+        )
+
+    today = dt.now(timezone.utc).date()
+    reference_date = requested_date if requested_date is not None else today
+    resolved_plan = _resolve_plan_for_date_in_series(series_plans, reference_date)
+    if not resolved_plan:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=ErrorConstants.PLAN_NOT_FOUND,
+        )
+    return resolved_plan
+
+
 async def get_plan_daily_content(
     plan_id: UUID,
     requested_date: Optional[DateType] = None,
@@ -395,21 +480,29 @@ async def get_plan_daily_content(
 ) -> DailyPlanResponse:
 
     with SessionLocal() as db:
-        plan = get_published_plan_by_id(db=db, plan_id=plan_id)
-        if not plan:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=ErrorConstants.PLAN_NOT_FOUND
+        plan = _resolve_daily_plan(
+            db=db,
+            plan_id=plan_id,
+            requested_date=requested_date,
+            language=language,
+        )
+
+        navigation_language = language
+        if not navigation_language:
+            navigation_language = (
+                plan.language.value
+                if hasattr(plan.language, "value")
+                else str(plan.language)
             )
 
         today = dt.now(timezone.utc).date()
 
         if plan.start_date:
-            start = plan.start_date.date() if isinstance(plan.start_date, dt) else plan.start_date
+            start = _to_plan_date(plan.start_date)
         else:
             start = today
 
-        total_days = db.query(PlanItem).filter(PlanItem.plan_id == plan_id).count()
+        total_days = db.query(PlanItem).filter(PlanItem.plan_id == plan.id).count()
         if total_days == 0:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
@@ -436,7 +529,7 @@ async def get_plan_daily_content(
             )
 
         plan_item = get_plan_day_with_tasks_and_subtasks(
-            db=db, plan_id=plan_id, day_number=day_number
+            db=db, plan_id=plan.id, day_number=day_number
         )
 
         plan_image = await get_image_url(image_url=plan.image_url)
@@ -446,7 +539,7 @@ async def get_plan_daily_content(
             series_image = await get_image_url(image_url=plan.series.image)
             metadata_entries = _filter_series_metadata_by_language(
                 getattr(plan.series, "metadata_entries", None) or [],
-                language=language,
+                language=navigation_language,
             )
             series_metadata = [
                 SeriesMetadataDTO(
@@ -482,7 +575,7 @@ async def get_plan_daily_content(
                     db=db,
                     series_id=plan.series_id,
                     current_display_order=plan.display_order,
-                    language=language,
+                    language=navigation_language,
                 )
                 if previous_plan:
                     previous_plan_id = previous_plan.id
@@ -492,7 +585,7 @@ async def get_plan_daily_content(
                     db=db,
                     series_id=plan.series_id,
                     current_display_order=plan.display_order,
-                    language=language,
+                    language=navigation_language,
                 )
                 if next_plan:
                     next_plan_id = next_plan.id

--- a/pecha_api/plans/public/plan_service.py
+++ b/pecha_api/plans/public/plan_service.py
@@ -372,7 +372,27 @@ def get_plan_day_details(plan_id: UUID, day_number: int) -> PlanDayDTO:
         return _build_plan_day_dto(plan_item)
 
 
-async def get_plan_daily_content(plan_id: UUID, requested_date: Optional[DateType] = None) -> DailyPlanResponse:
+def _filter_series_metadata_by_language(metadata_entries, language: Optional[str]):
+    if not language or not metadata_entries:
+        return metadata_entries or []
+    language_upper = language.upper()
+    return [
+        entry
+        for entry in metadata_entries
+        if (
+            entry.language.value
+            if hasattr(entry.language, "value")
+            else str(entry.language)
+        ).upper()
+        == language_upper
+    ]
+
+
+async def get_plan_daily_content(
+    plan_id: UUID,
+    requested_date: Optional[DateType] = None,
+    language: Optional[str] = None,
+) -> DailyPlanResponse:
 
     with SessionLocal() as db:
         plan = get_published_plan_by_id(db=db, plan_id=plan_id)
@@ -424,7 +444,10 @@ async def get_plan_daily_content(plan_id: UUID, requested_date: Optional[DateTyp
         series_dto = None
         if plan.series:
             series_image = await get_image_url(image_url=plan.series.image)
-            metadata_entries = getattr(plan.series, "metadata_entries", None) or []
+            metadata_entries = _filter_series_metadata_by_language(
+                getattr(plan.series, "metadata_entries", None) or [],
+                language=language,
+            )
             series_metadata = [
                 SeriesMetadataDTO(
                     id=entry.id,
@@ -455,12 +478,22 @@ async def get_plan_daily_content(plan_id: UUID, requested_date: Optional[DateTyp
 
         if plan.series_id and plan.display_order is not None:
             if previous_date is None:
-                previous_plan = get_previous_plan_in_series(db=db, series_id=plan.series_id, current_display_order=plan.display_order)
+                previous_plan = get_previous_plan_in_series(
+                    db=db,
+                    series_id=plan.series_id,
+                    current_display_order=plan.display_order,
+                    language=language,
+                )
                 if previous_plan:
                     previous_plan_id = previous_plan.id
 
             if next_date is None:
-                next_plan = get_next_plan_in_series(db=db, series_id=plan.series_id, current_display_order=plan.display_order)
+                next_plan = get_next_plan_in_series(
+                    db=db,
+                    series_id=plan.series_id,
+                    current_display_order=plan.display_order,
+                    language=language,
+                )
                 if next_plan:
                     next_plan_id = next_plan.id
 

--- a/pecha_api/plans/public/plan_views.py
+++ b/pecha_api/plans/public/plan_views.py
@@ -77,8 +77,12 @@ async def get_plan_daily(
         Optional[DateType],
         Query(description="Date in YYYY-MM-DD format. Defaults to today if not provided."),
     ] = None,
+    language: Annotated[
+        Optional[str],
+        Query(description="Filter series navigation and metadata by language (e.g. 'en', 'bo', 'zh')."),
+    ] = None,
 ):
-    return await get_plan_daily_content(plan_id=plan_id, requested_date=date)
+    return await get_plan_daily_content(plan_id=plan_id, requested_date=date, language=language)
 
 
 @public_plans_router.get("/{plan_id}/days", status_code=status.HTTP_200_OK, response_model=PlanDaysResponse)

--- a/tests/plans/public/test_plan_public_service.py
+++ b/tests/plans/public/test_plan_public_service.py
@@ -712,15 +712,22 @@ def _daily_content_mock_db_session(total_days: int):
     return mock_db
 
 
-def _daily_content_series_plan(plan_id, series_id, display_order: int):
+def _daily_content_series_plan(
+    plan_id,
+    series_id,
+    display_order: int,
+    start_date=None,
+    language_value: str = "EN",
+):
     mock_plan = MagicMock()
     mock_plan.id = plan_id
-    mock_plan.title = "Plan B"
+    mock_plan.title = f"Plan {display_order}"
     mock_plan.description = "Desc"
     mock_plan.image_url = None
     mock_plan.series_id = series_id
     mock_plan.display_order = display_order
-    mock_plan.start_date = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    mock_plan.start_date = start_date or datetime(2026, 5, 1, tzinfo=timezone.utc)
+    mock_plan.language = MagicMock(value=language_value)
     mock_series = MagicMock()
     mock_series.id = series_id
     metadata_entry = MagicMock()
@@ -748,20 +755,21 @@ async def test_get_plan_daily_content_first_day_sets_previous_plan_id_in_series(
 
     with patch("pecha_api.plans.public.plan_service.SessionLocal", return_value=mock_db), \
          patch("pecha_api.plans.public.plan_service.get_published_plan_by_id", return_value=mock_plan), \
+         patch("pecha_api.plans.public.plan_service.get_published_plans_in_series", return_value=[mock_plan]), \
          patch("pecha_api.plans.public.plan_service.get_plan_day_with_tasks_and_subtasks", return_value=mock_plan_item), \
          patch("pecha_api.plans.public.plan_service.get_previous_plan_in_series", return_value=mock_prev) as mock_prev_fn, \
          patch("pecha_api.plans.public.plan_service.get_next_plan_in_series") as mock_next_fn, \
          patch("pecha_api.plans.public.plan_service.get_image_url", new_callable=AsyncMock, return_value=None):
 
         result = await get_plan_daily_content(
-            plan_id=plan_id, requested_date=DateType(2026, 5, 1)
+            plan_id=plan_id, requested_date=DateType(2026, 5, 1), language="en"
         )
 
     assert isinstance(result, DailyPlanResponse)
     assert result.previous_plan_id == prev_plan_uuid
     assert result.next_plan_id is None
     mock_prev_fn.assert_called_once_with(
-        db=mock_db, series_id=series_id, current_display_order=2, language=None
+        db=mock_db, series_id=series_id, current_display_order=2, language="en"
     )
     mock_next_fn.assert_not_called()
 
@@ -780,22 +788,68 @@ async def test_get_plan_daily_content_last_day_sets_next_plan_id_in_series():
 
     with patch("pecha_api.plans.public.plan_service.SessionLocal", return_value=mock_db), \
          patch("pecha_api.plans.public.plan_service.get_published_plan_by_id", return_value=mock_plan), \
+         patch("pecha_api.plans.public.plan_service.get_published_plans_in_series", return_value=[mock_plan]), \
          patch("pecha_api.plans.public.plan_service.get_plan_day_with_tasks_and_subtasks", return_value=mock_plan_item), \
          patch("pecha_api.plans.public.plan_service.get_previous_plan_in_series") as mock_prev_fn, \
          patch("pecha_api.plans.public.plan_service.get_next_plan_in_series", return_value=mock_next) as mock_next_fn, \
          patch("pecha_api.plans.public.plan_service.get_image_url", new_callable=AsyncMock, return_value=None):
 
         result = await get_plan_daily_content(
-            plan_id=plan_id, requested_date=DateType(2026, 5, 3)
+            plan_id=plan_id, requested_date=DateType(2026, 5, 3), language="en"
         )
 
     assert isinstance(result, DailyPlanResponse)
     assert result.next_plan_id == next_plan_uuid
     assert result.previous_plan_id is None
     mock_next_fn.assert_called_once_with(
-        db=mock_db, series_id=series_id, current_display_order=2, language=None
+        db=mock_db, series_id=series_id, current_display_order=2, language="en"
     )
     mock_prev_fn.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_get_plan_daily_content_resolves_plan_by_date_in_series():
+    series_id = uuid4()
+    plan_one_id = uuid4()
+    plan_two_id = uuid4()
+    entry_plan = _daily_content_series_plan(
+        plan_two_id,
+        series_id,
+        display_order=2,
+        start_date=datetime(2026, 5, 10, tzinfo=timezone.utc),
+    )
+    active_plan = _daily_content_series_plan(
+        plan_one_id,
+        series_id,
+        display_order=1,
+        start_date=datetime(2026, 5, 1, tzinfo=timezone.utc),
+    )
+    mock_plan_item = MagicMock()
+    mock_plan_item.tasks = []
+    mock_db = _daily_content_mock_db_session(total_days=3)
+
+    with patch("pecha_api.plans.public.plan_service.SessionLocal", return_value=mock_db), \
+         patch("pecha_api.plans.public.plan_service.get_published_plan_by_id", return_value=entry_plan), \
+         patch(
+             "pecha_api.plans.public.plan_service.get_published_plans_in_series",
+             return_value=[active_plan, entry_plan],
+         ) as mock_series_plans, \
+         patch("pecha_api.plans.public.plan_service.get_plan_day_with_tasks_and_subtasks", return_value=mock_plan_item) as mock_day_fn, \
+         patch("pecha_api.plans.public.plan_service.get_next_plan_in_series", return_value=None), \
+         patch("pecha_api.plans.public.plan_service.get_previous_plan_in_series", return_value=None), \
+         patch("pecha_api.plans.public.plan_service.get_image_url", new_callable=AsyncMock, return_value=None):
+
+        result = await get_plan_daily_content(
+            plan_id=plan_two_id,
+            requested_date=DateType(2026, 5, 3),
+            language="en",
+        )
+
+    assert result.plan_id == plan_one_id
+    mock_series_plans.assert_called_once_with(
+        db=mock_db, series_id=series_id, language="en"
+    )
+    mock_day_fn.assert_called_once_with(db=mock_db, plan_id=plan_one_id, day_number=3)
+
 
 @pytest.mark.asyncio
 async def test_get_plan_daily_content_plan_not_found():

--- a/tests/plans/public/test_plan_public_service.py
+++ b/tests/plans/public/test_plan_public_service.py
@@ -1,5 +1,6 @@
 import pytest
 from uuid import uuid4
+from types import SimpleNamespace
 from unittest.mock import patch, MagicMock, Mock, AsyncMock
 from datetime import date as DateType, datetime, timezone
 from fastapi import HTTPException
@@ -16,6 +17,10 @@ from pecha_api.plans.public.plan_service import (
     auto_enroll_plan,
     is_user_enrolled_in_previous_plan,
     is_within_plan_date_range,
+    _to_plan_date,
+    _resolve_plan_for_date_in_series,
+    _resolve_daily_plan,
+    _filter_series_metadata_by_language,
 )
 from pecha_api.plans.public.plan_response_models import (
     PublicPlansResponse,
@@ -702,6 +707,138 @@ async def test_get_plan_days_plan_not_found():
         mock_get_plan.assert_called_once_with(db=db_session, plan_id=plan_id)
 
 
+def test_to_plan_date_from_datetime_and_date():
+    assert _to_plan_date(datetime(2026, 5, 1, tzinfo=timezone.utc)) == DateType(2026, 5, 1)
+    assert _to_plan_date(DateType(2026, 5, 2)) == DateType(2026, 5, 2)
+
+
+def test_resolve_plan_for_date_in_series_empty():
+    assert _resolve_plan_for_date_in_series([], DateType(2026, 5, 1)) is None
+
+
+def test_resolve_plan_for_date_in_series_picks_active_plan():
+    series_id = uuid4()
+    plan_one = _daily_content_series_plan(
+        uuid4(), series_id, 1, start_date=datetime(2026, 5, 1, tzinfo=timezone.utc)
+    )
+    plan_two = _daily_content_series_plan(
+        uuid4(), series_id, 2, start_date=datetime(2026, 5, 10, tzinfo=timezone.utc)
+    )
+
+    assert _resolve_plan_for_date_in_series(
+        [plan_two, plan_one], DateType(2026, 5, 5)
+    ).id == plan_one.id
+    assert _resolve_plan_for_date_in_series(
+        [plan_one, plan_two], DateType(2026, 5, 15)
+    ).id == plan_two.id
+
+
+def test_resolve_plan_for_date_in_series_before_first_start():
+    series_id = uuid4()
+    plan = _daily_content_series_plan(
+        uuid4(), series_id, 1, start_date=datetime(2026, 5, 10, tzinfo=timezone.utc)
+    )
+
+    assert _resolve_plan_for_date_in_series([plan], DateType(2026, 5, 1)).id == plan.id
+
+
+def test_resolve_plan_for_date_in_series_without_start_dates():
+    series_id = uuid4()
+    plan = _daily_content_series_plan(uuid4(), series_id, 1)
+    plan.start_date = None
+
+    assert _resolve_plan_for_date_in_series([plan], DateType(2026, 5, 1)).id == plan.id
+
+
+def test_filter_series_metadata_by_language():
+    entry_en = MagicMock()
+    entry_en.language = MagicMock(value="EN")
+    entry_bo = MagicMock()
+    entry_bo.language = "BO"
+
+    filtered = _filter_series_metadata_by_language([entry_en, entry_bo], "en")
+
+    assert filtered == [entry_en]
+
+
+def test_filter_series_metadata_without_language_returns_entries():
+    entry = MagicMock()
+    entries = [entry]
+
+    assert _filter_series_metadata_by_language(entries, None) == entries
+    assert _filter_series_metadata_by_language(None, "en") == []
+
+
+def test_resolve_daily_plan_returns_entry_when_not_in_series():
+    plan_id = uuid4()
+    mock_plan = MagicMock()
+    mock_plan.series_id = None
+    mock_db = MagicMock()
+
+    with patch(
+        "pecha_api.plans.public.plan_service.get_published_plan_by_id",
+        return_value=mock_plan,
+    ) as mock_get:
+        result = _resolve_daily_plan(db=mock_db, plan_id=plan_id, requested_date=None, language="en")
+
+    assert result is mock_plan
+    mock_get.assert_called_once_with(db=mock_db, plan_id=plan_id)
+
+
+def test_resolve_daily_plan_raises_when_entry_not_found():
+    mock_db = MagicMock()
+
+    with patch(
+        "pecha_api.plans.public.plan_service.get_published_plan_by_id",
+        return_value=None,
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            _resolve_daily_plan(db=mock_db, plan_id=uuid4(), requested_date=None, language="en")
+
+    assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_resolve_daily_plan_raises_when_no_language_plans_in_series():
+    series_id = uuid4()
+    entry_plan = MagicMock()
+    entry_plan.series_id = series_id
+    entry_plan.language = LanguageCode.EN
+    mock_db = MagicMock()
+
+    with patch(
+        "pecha_api.plans.public.plan_service.get_published_plan_by_id",
+        return_value=entry_plan,
+    ), patch(
+        "pecha_api.plans.public.plan_service.get_published_plans_in_series",
+        return_value=[],
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            _resolve_daily_plan(db=mock_db, plan_id=uuid4(), requested_date=None, language=None)
+
+    assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_resolve_daily_plan_uses_entry_language_when_omitted():
+    series_id = uuid4()
+    plan_id = uuid4()
+    entry_plan = _daily_content_series_plan(plan_id, series_id, 1)
+    mock_db = MagicMock()
+
+    with patch(
+        "pecha_api.plans.public.plan_service.get_published_plan_by_id",
+        return_value=entry_plan,
+    ), patch(
+        "pecha_api.plans.public.plan_service.get_published_plans_in_series",
+        return_value=[entry_plan],
+    ) as mock_series:
+        result = _resolve_daily_plan(
+            db=mock_db, plan_id=plan_id, requested_date=DateType(2026, 5, 1), language=None
+        )
+
+    assert result is entry_plan
+    mock_series.assert_called_once_with(db=mock_db, series_id=series_id, language="EN")
+
+
 def _daily_content_mock_db_session(total_days: int):
     mock_db = MagicMock()
     mock_db.__enter__ = Mock(return_value=mock_db)
@@ -861,6 +998,205 @@ async def test_get_plan_daily_content_plan_not_found():
 
         with pytest.raises(HTTPException) as exc_info:
             await get_plan_daily_content(plan_id=plan_id)
+
+    assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
+
+
+def _standalone_daily_plan(plan_id, *, start_date=None):
+    return SimpleNamespace(
+        id=plan_id,
+        title="Solo Plan",
+        description="Desc",
+        image_url=None,
+        series_id=None,
+        series=None,
+        display_order=None,
+        start_date=start_date,
+        language=SimpleNamespace(value="EN"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_plan_daily_content_standalone_plan_without_series():
+    plan_id = uuid4()
+    mock_plan = _standalone_daily_plan(
+        plan_id, start_date=datetime(2026, 5, 1, tzinfo=timezone.utc)
+    )
+    mock_plan_item = MagicMock()
+    mock_plan_item.tasks = []
+    mock_db = _daily_content_mock_db_session(total_days=2)
+
+    with patch("pecha_api.plans.public.plan_service.SessionLocal", return_value=mock_db), \
+         patch("pecha_api.plans.public.plan_service.get_published_plan_by_id", return_value=mock_plan), \
+         patch("pecha_api.plans.public.plan_service.get_plan_day_with_tasks_and_subtasks", return_value=mock_plan_item), \
+         patch("pecha_api.plans.public.plan_service.get_image_url", new_callable=AsyncMock, return_value=None):
+
+        result = await get_plan_daily_content(
+            plan_id=plan_id, requested_date=DateType(2026, 5, 2)
+        )
+
+    assert result.plan_id == plan_id
+    assert result.series is None
+    assert result.day_number == 2
+
+
+@pytest.mark.asyncio
+async def test_get_plan_daily_content_no_content_yet():
+    plan_id = uuid4()
+    mock_plan = _standalone_daily_plan(plan_id)
+    mock_db = _daily_content_mock_db_session(total_days=0)
+
+    with patch("pecha_api.plans.public.plan_service.SessionLocal", return_value=mock_db), \
+         patch("pecha_api.plans.public.plan_service.get_published_plan_by_id", return_value=mock_plan):
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_plan_daily_content(plan_id=plan_id)
+
+    assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
+    assert "no content yet" in exc_info.value.detail.lower()
+
+
+@pytest.mark.asyncio
+async def test_get_plan_daily_content_date_out_of_range():
+    plan_id = uuid4()
+    mock_plan = _standalone_daily_plan(
+        plan_id, start_date=datetime(2026, 5, 1, tzinfo=timezone.utc)
+    )
+    mock_db = _daily_content_mock_db_session(total_days=3)
+
+    with patch("pecha_api.plans.public.plan_service.SessionLocal", return_value=mock_db), \
+         patch("pecha_api.plans.public.plan_service.get_published_plan_by_id", return_value=mock_plan):
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_plan_daily_content(
+                plan_id=plan_id, requested_date=DateType(2026, 5, 10)
+            )
+
+    assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
+    assert "No content for date" in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_get_plan_daily_content_defaults_date_when_before_plan_window():
+    plan_id = uuid4()
+    mock_plan = _standalone_daily_plan(
+        plan_id, start_date=datetime(2099, 1, 1, tzinfo=timezone.utc)
+    )
+    mock_plan.title = "Future Plan"
+    mock_plan_item = MagicMock()
+    mock_plan_item.tasks = []
+    mock_db = _daily_content_mock_db_session(total_days=5)
+
+    with patch("pecha_api.plans.public.plan_service.SessionLocal", return_value=mock_db), \
+         patch("pecha_api.plans.public.plan_service.get_published_plan_by_id", return_value=mock_plan), \
+         patch("pecha_api.plans.public.plan_service.get_plan_day_with_tasks_and_subtasks", return_value=mock_plan_item), \
+         patch("pecha_api.plans.public.plan_service.get_image_url", new_callable=AsyncMock, return_value=None):
+
+        result = await get_plan_daily_content(plan_id=plan_id)
+
+    assert result.date == DateType(2099, 1, 1)
+    assert result.day_number == 1
+
+
+@pytest.mark.asyncio
+async def test_get_plan_daily_content_filters_series_metadata_by_navigation_language():
+    plan_id = uuid4()
+    series_id = uuid4()
+    mock_plan = _daily_content_series_plan(plan_id, series_id, display_order=1)
+    bo_entry = MagicMock()
+    bo_entry.id = uuid4()
+    bo_entry.title = "Tibetan"
+    bo_entry.description = None
+    bo_entry.language = MagicMock(value="BO")
+    mock_plan.series.metadata_entries = [
+        mock_plan.series.metadata_entries[0],
+        bo_entry,
+    ]
+    mock_plan_item = MagicMock()
+    mock_plan_item.tasks = []
+    mock_db = _daily_content_mock_db_session(total_days=1)
+
+    with patch("pecha_api.plans.public.plan_service.SessionLocal", return_value=mock_db), \
+         patch("pecha_api.plans.public.plan_service.get_published_plan_by_id", return_value=mock_plan), \
+         patch("pecha_api.plans.public.plan_service.get_published_plans_in_series", return_value=[mock_plan]), \
+         patch("pecha_api.plans.public.plan_service.get_plan_day_with_tasks_and_subtasks", return_value=mock_plan_item), \
+         patch("pecha_api.plans.public.plan_service.get_previous_plan_in_series", return_value=None), \
+         patch("pecha_api.plans.public.plan_service.get_next_plan_in_series", return_value=None), \
+         patch("pecha_api.plans.public.plan_service.get_image_url", new_callable=AsyncMock, return_value=None):
+
+        result = await get_plan_daily_content(
+            plan_id=plan_id, requested_date=DateType(2026, 5, 1), language="en"
+        )
+
+    assert result.series is not None
+    assert len(result.series.metadata) == 1
+    assert result.series.metadata[0].language == "EN"
+
+
+@pytest.mark.asyncio
+async def test_get_plan_daily_content_defaults_date_to_today_when_in_window():
+    from pecha_api.plans.public import plan_service
+
+    plan_id = uuid4()
+    mock_plan = _standalone_daily_plan(
+        plan_id, start_date=datetime(2026, 6, 1, tzinfo=timezone.utc)
+    )
+    mock_plan_item = MagicMock()
+    mock_plan_item.tasks = []
+    mock_db = _daily_content_mock_db_session(total_days=30)
+    today = plan_service.dt.now(timezone.utc).date()
+
+    with patch("pecha_api.plans.public.plan_service.SessionLocal", return_value=mock_db), \
+         patch("pecha_api.plans.public.plan_service.get_published_plan_by_id", return_value=mock_plan), \
+         patch("pecha_api.plans.public.plan_service.get_plan_day_with_tasks_and_subtasks", return_value=mock_plan_item), \
+         patch("pecha_api.plans.public.plan_service.get_image_url", new_callable=AsyncMock, return_value=None):
+
+        result = await get_plan_daily_content(plan_id=plan_id)
+
+    assert result.date == today
+    assert result.day_number == (today - DateType(2026, 6, 1)).days + 1
+
+
+@pytest.mark.asyncio
+async def test_get_plan_daily_content_without_start_date_uses_today():
+    from pecha_api.plans.public import plan_service
+
+    plan_id = uuid4()
+    mock_plan = _standalone_daily_plan(plan_id)
+    mock_plan.start_date = None
+    mock_plan_item = MagicMock()
+    mock_plan_item.tasks = []
+    mock_db = _daily_content_mock_db_session(total_days=1)
+    today = plan_service.dt.now(timezone.utc).date()
+
+    with patch("pecha_api.plans.public.plan_service.SessionLocal", return_value=mock_db), \
+         patch("pecha_api.plans.public.plan_service.get_published_plan_by_id", return_value=mock_plan), \
+         patch("pecha_api.plans.public.plan_service.get_plan_day_with_tasks_and_subtasks", return_value=mock_plan_item), \
+         patch("pecha_api.plans.public.plan_service.get_image_url", new_callable=AsyncMock, return_value=None):
+
+        result = await get_plan_daily_content(plan_id=plan_id)
+
+    assert result.date == today
+    assert result.day_number == 1
+
+
+def test_resolve_daily_plan_raises_when_date_resolution_fails():
+    series_id = uuid4()
+    entry_plan = _daily_content_series_plan(uuid4(), series_id, 1)
+    mock_db = MagicMock()
+
+    with patch(
+        "pecha_api.plans.public.plan_service.get_published_plan_by_id",
+        return_value=entry_plan,
+    ), patch(
+        "pecha_api.plans.public.plan_service.get_published_plans_in_series",
+        return_value=[entry_plan],
+    ), patch(
+        "pecha_api.plans.public.plan_service._resolve_plan_for_date_in_series",
+        return_value=None,
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            _resolve_daily_plan(db=mock_db, plan_id=entry_plan.id, requested_date=None, language="en")
 
     assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
 

--- a/tests/plans/public/test_plan_public_service.py
+++ b/tests/plans/public/test_plan_public_service.py
@@ -761,7 +761,7 @@ async def test_get_plan_daily_content_first_day_sets_previous_plan_id_in_series(
     assert result.previous_plan_id == prev_plan_uuid
     assert result.next_plan_id is None
     mock_prev_fn.assert_called_once_with(
-        db=mock_db, series_id=series_id, current_display_order=2
+        db=mock_db, series_id=series_id, current_display_order=2, language=None
     )
     mock_next_fn.assert_not_called()
 
@@ -793,7 +793,7 @@ async def test_get_plan_daily_content_last_day_sets_next_plan_id_in_series():
     assert result.next_plan_id == next_plan_uuid
     assert result.previous_plan_id is None
     mock_next_fn.assert_called_once_with(
-        db=mock_db, series_id=series_id, current_display_order=2
+        db=mock_db, series_id=series_id, current_display_order=2, language=None
     )
     mock_prev_fn.assert_not_called()
 

--- a/tests/plans/public/test_plan_public_views.py
+++ b/tests/plans/public/test_plan_public_views.py
@@ -1,12 +1,24 @@
 import pytest
 from uuid import uuid4
+from datetime import date as DateType
 from unittest.mock import patch, AsyncMock, MagicMock
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
 from starlette import status
 
 from pecha_api.app import api
-from pecha_api.plans.public.plan_response_models import PublicPlansResponse, PublicPlanDTO, AuthorDTO, PlanDayBasic, PlanDayDTO, TaskDTO, SubTaskDTO,PlanDaysResponse, TagsResponse
+from pecha_api.plans.public.plan_response_models import (
+    PublicPlansResponse,
+    PublicPlanDTO,
+    AuthorDTO,
+    PlanDayBasic,
+    PlanDayDTO,
+    TaskDTO,
+    SubTaskDTO,
+    PlanDaysResponse,
+    TagsResponse,
+    DailyPlanResponse,
+)
 from tests.plans.tag_test_helpers import make_tag_summaries
 from pecha_api.plans.plans_enums import PlanStatus, DifficultyLevel,ContentType
 from pecha_api.error_contants import ErrorConstants
@@ -314,6 +326,59 @@ async def test_get_plan_details_not_found():
         
         assert response.status_code == status.HTTP_404_NOT_FOUND
         assert ErrorConstants.PLAN_NOT_FOUND in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_get_plan_daily_success():
+    plan_id = uuid4()
+    daily_response = DailyPlanResponse(
+        plan_id=plan_id,
+        plan_title="Daily Plan",
+        plan_description="Desc",
+        date=DateType(2026, 5, 1),
+        day_number=1,
+        total_days=3,
+        start_date=DateType(2026, 5, 1),
+        end_date=DateType(2026, 5, 3),
+        tasks=[],
+    )
+
+    with patch(
+        "pecha_api.plans.public.plan_views.get_plan_daily_content",
+        new_callable=AsyncMock,
+        return_value=daily_response,
+    ) as mock_service:
+        response = client.get(
+            f"/api/v1/plans/{plan_id}/daily",
+            params={"date": "2026-05-01", "language": "en"},
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["plan_id"] == str(plan_id)
+    assert data["day_number"] == 1
+    mock_service.assert_called_once_with(
+        plan_id=plan_id,
+        requested_date=DateType(2026, 5, 1),
+        language="en",
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_plan_daily_not_found():
+    plan_id = uuid4()
+
+    with patch(
+        "pecha_api.plans.public.plan_views.get_plan_daily_content",
+        new_callable=AsyncMock,
+        side_effect=HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=ErrorConstants.PLAN_NOT_FOUND,
+        ),
+    ):
+        response = client.get(f"/api/v1/plans/{plan_id}/daily")
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- Updated `get_next_plan_in_series` and `get_previous_plan_in_series` functions to accept an optional `language` parameter for filtering plans by language.
- Introduced a new helper function `_filter_series_metadata_by_language` to filter metadata entries based on the specified language.
- Modified `get_plan_daily_content` and `get_plan_daily` to support the new language filtering feature.
- Updated tests to verify the correct functionality of language filtering in plan retrieval.