### PR TITLE
Enhance user plan retrieval by adding optional language filtering

### DIFF
--- a/pecha_api/plans/users/plan_user_series_repository.py
+++ b/pecha_api/plans/users/plan_user_series_repository.py
@@ -211,8 +211,9 @@ def get_paginated_plans_from_enrolled_series(
     user_id: UUID,
     status_filter: Optional[str] = None,
     series_id: Optional[UUID] = None,
+    language: Optional[str] = None,
     skip: int = 0,
-    limit: int = 20
+    limit: int = 20,
 ) -> Tuple[List[Plan], int]:
     from sqlalchemy.orm import selectinload
     from sqlalchemy import func, case, literal
@@ -237,7 +238,7 @@ def get_paginated_plans_from_enrolled_series(
     enrollment_subquery = enrollment_query.subquery()
     
     # Get all plans from enrolled series
-    all_plans_query = (
+    plans_query = (
         db.query(Plan)
         .join(enrollment_subquery, Plan.series_id == enrollment_subquery.c.series_id)
         .filter(Plan.deleted_at.is_(None))
@@ -246,8 +247,10 @@ def get_paginated_plans_from_enrolled_series(
             enrollment_subquery.c.series_id,
             asc(func.coalesce(Plan.display_order, 999))
         )
-        .all()
     )
+    if language:
+        plans_query = plans_query.filter(Plan.language == language.upper())
+    all_plans_query = plans_query.all()
     
     if not all_plans_query:
         return [], 0

--- a/pecha_api/plans/users/plan_users_service.py
+++ b/pecha_api/plans/users/plan_users_service.py
@@ -209,7 +209,14 @@ def auto_enroll_in_next_plan(db: SessionLocal, user_id: UUID, plan_id: UUID, ser
     return save_plan_progress(db, new_progress)
 
 
-async def get_user_enrolled_plans(token: str, status_filter: Optional[str] = None, series_id: Optional[UUID] = None, skip: int = 0, limit: int = 20) -> UserPlansResponse:
+async def get_user_enrolled_plans(
+    token: str,
+    status_filter: Optional[str] = None,
+    series_id: Optional[UUID] = None,
+    language: Optional[str] = None,
+    skip: int = 0,
+    limit: int = 20,
+) -> UserPlansResponse:
 
     from sqlalchemy import func
     from pecha_api.plans.items.plan_items_models import PlanItem
@@ -224,8 +231,9 @@ async def get_user_enrolled_plans(token: str, status_filter: Optional[str] = Non
             user_id=current_user.id,
             status_filter=normalized_status,
             series_id=series_id,
+            language=language,
             skip=skip,
-            limit=limit
+            limit=limit,
         )
         
         if not plans:

--- a/pecha_api/plans/users/plan_users_views.py
+++ b/pecha_api/plans/users/plan_users_views.py
@@ -49,11 +49,22 @@ async def get_user_plans(
     authentication_credential: Annotated[HTTPAuthorizationCredentials, Depends(oauth2_scheme)],
     status_filter: Optional[str] = Query(None, description="Filter by series enrollment status (ACTIVE, PAUSED, COMPLETED, CANCELLED)"),
     series_id: Optional[UUID] = Query(None, description="Filter by series ID to only get plans from that series"),
+    language: Annotated[
+        Optional[str],
+        Query(description="Filter by plan language (e.g. 'en', 'bo', 'zh')"),
+    ] = None,
     skip: int = Query(0, ge=0),
     limit: int = Query(20, ge=1, le=50)
 ):
 
-    return await get_user_enrolled_plans(token=authentication_credential.credentials, status_filter=status_filter, series_id=series_id, skip=skip, limit=limit)
+    return await get_user_enrolled_plans(
+        token=authentication_credential.credentials,
+        status_filter=status_filter,
+        series_id=series_id,
+        language=language,
+        skip=skip,
+        limit=limit,
+    )
 
 
 @user_progress_router.post("/plans", status_code=status.HTTP_204_NO_CONTENT)

--- a/tests/plans/users/test_plan_users_service.py
+++ b/tests/plans/users/test_plan_users_service.py
@@ -528,6 +528,58 @@ async def test_get_user_enrolled_plans_with_status_filter():
 
 
 @pytest.mark.asyncio
+async def test_get_user_enrolled_plans_with_language_filter():
+    from pecha_api.plans.users.plan_users_service import get_user_enrolled_plans
+    from datetime import datetime, timezone
+
+    user_id = uuid.uuid4()
+    plan_id = uuid.uuid4()
+    series_id = uuid.uuid4()
+    mock_user = SimpleNamespace(id=user_id)
+    progress = SimpleNamespace(started_at=datetime.now(timezone.utc))
+    plan = SimpleNamespace(
+        id=plan_id,
+        series_id=series_id,
+        title="Tibetan Plan",
+        description="Test",
+        language=SimpleNamespace(value="BO"),
+        difficulty_level=SimpleNamespace(value="BEGINNER"),
+        image_url=None,
+        tag_list=[],
+        start_date=None,
+        display_order=None,
+        created_at=datetime.now(timezone.utc),
+    )
+
+    db_mock, session_cm = _mock_session_with_db()
+    db_mock.query.return_value.filter.return_value.group_by.return_value.all.return_value = [
+        SimpleNamespace(plan_id=plan_id, total_days=10)
+    ]
+
+    with patch(
+        "pecha_api.plans.users.plan_users_service.validate_and_extract_user_details",
+        return_value=mock_user,
+    ), patch(
+        "pecha_api.plans.users.plan_users_service.SessionLocal",
+        return_value=session_cm,
+    ), patch(
+        "pecha_api.plans.users.plan_users_service.get_paginated_plans_from_enrolled_series",
+    ) as mock_repo, patch(
+        "pecha_api.plans.users.plan_users_service.get_plan_progress_by_user_id_and_plan_ids",
+        return_value={plan_id: progress},
+    ):
+        mock_repo.return_value = ([plan], 1)
+
+        result = await get_user_enrolled_plans(
+            token="token123", language="bo", skip=0, limit=20
+        )
+
+        assert mock_repo.call_args.kwargs["language"] == "bo"
+        assert result.total == 1
+        assert result.plans[0].language == "BO"
+
+
+@pytest.mark.asyncio
 async def test_get_user_enrolled_plans_with_pagination():
     from pecha_api.plans.users.plan_users_service import get_user_enrolled_plans
     from datetime import datetime, timezone

--- a/tests/plans/users/test_plan_users_views.py
+++ b/tests/plans/users/test_plan_users_views.py
@@ -462,6 +462,7 @@ def test_get_user_plans_success_default_pagination(authenticated_client):
         assert mock_get.call_count == 1
         assert mock_get.call_args.kwargs.get("token") == VALID_TOKEN
         assert mock_get.call_args.kwargs.get("status_filter") is None
+        assert mock_get.call_args.kwargs.get("language") is None
         assert mock_get.call_args.kwargs.get("skip") == 0
         assert mock_get.call_args.kwargs.get("limit") == 20
 
@@ -482,6 +483,21 @@ def test_get_user_plans_with_filters_and_pagination(authenticated_client):
         assert mock_get.call_args.kwargs.get("status_filter") == "active"
         assert mock_get.call_args.kwargs.get("skip") == 10
         assert mock_get.call_args.kwargs.get("limit") == 5
+
+
+def test_get_user_plans_with_language_filter(authenticated_client):
+    response_payload = {"plans": [], "skip": 0, "limit": 20, "total": 0}
+
+    with patch("pecha_api.plans.users.plan_users_views.get_user_enrolled_plans", new_callable=AsyncMock, return_value=response_payload) as mock_get:
+        response = authenticated_client.get(
+            "/users/me/plans?language=bo",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == response_payload
+        assert mock_get.call_count == 1
+        assert mock_get.call_args.kwargs.get("language") == "bo"
 
 
 def test_get_user_plan_progress_details_success(authenticated_client):


### PR DESCRIPTION
- Updated `get_user_enrolled_plans` and `get_paginated_plans_from_enrolled_series` functions to accept a `language` parameter for filtering plans by language.
- Modified related view and test files to support the new language filtering feature, ensuring comprehensive coverage and correct functionality.