### PR TITLE
Enhance metadata handling by adding 'sub_title' field across models a…

### DIFF
--- a/migrations/versions/020fc79d15bf_merge_platform_roles_and_timer_session_.py
+++ b/migrations/versions/020fc79d15bf_merge_platform_roles_and_timer_session_.py
@@ -1,0 +1,23 @@
+"""merge platform roles and timer session heads
+
+Revision ID: 020fc79d15bf
+Revises: a1b2c3d4e5f7, c5e7a9b1d3f2
+Create Date: 2026-06-05 16:19:55.465424
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "020fc79d15bf"
+down_revision: Union[str, Sequence[str], None] = ("a1b2c3d4e5f7", "c5e7a9b1d3f2")
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/migrations/versions/e8f9a0b1c2d3_add_sub_title_to_series_and_group_metadata.py
+++ b/migrations/versions/e8f9a0b1c2d3_add_sub_title_to_series_and_group_metadata.py
@@ -1,0 +1,31 @@
+"""add sub_title to series and group metadata
+
+Revision ID: e8f9a0b1c2d3
+Revises: 020fc79d15bf
+Create Date: 2026-06-05 12:00:00.000000
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "e8f9a0b1c2d3"
+down_revision: Union[str, Sequence[str], None] = "020fc79d15bf"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "series_metadata",
+        sa.Column("sub_title", sa.String(length=255), nullable=True),
+    )
+    op.add_column(
+        "author_group_metadata",
+        sa.Column("sub_title", sa.String(length=255), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("author_group_metadata", "sub_title")
+    op.drop_column("series_metadata", "sub_title")

--- a/pecha_api/plans/dashboard/dashboard_repository.py
+++ b/pecha_api/plans/dashboard/dashboard_repository.py
@@ -23,6 +23,8 @@ _SERIES_METADATA_JSON = (
                         SeriesMetadata.id,
                         "title",
                         SeriesMetadata.title,
+                        "sub_title",
+                        SeriesMetadata.sub_title,
                         "description",
                         SeriesMetadata.description,
                         "language",
@@ -98,7 +100,10 @@ def _apply_series_filters(
             exists(
                 select(literal(1)).where(
                     SeriesMetadata.series_id == Series.id,
-                    SeriesMetadata.title.ilike(f"%{search}%"),
+                    or_(
+                        SeriesMetadata.title.ilike(f"%{search}%"),
+                        SeriesMetadata.sub_title.ilike(f"%{search}%"),
+                    ),
                 )
             )
         )

--- a/pecha_api/plans/dashboard/dashboard_response_models.py
+++ b/pecha_api/plans/dashboard/dashboard_response_models.py
@@ -1,12 +1,16 @@
 from datetime import datetime
-from typing import List, Literal, Optional
+from typing import List, Literal, Optional, Union
 from uuid import UUID
 
 from pydantic import BaseModel, Field, model_serializer
 
 from pecha_api.plans.media.media_response_models import ImageUrlModel
 from pecha_api.plans.plans_enums import PlanStatus
-from pecha_api.plans.series.series_response_models import SeriesMetadataDTO, SeriesPlanDTO
+from pecha_api.plans.series.series_response_models import (
+    SeriesMetadataDTO,
+    SeriesMetadataResponse,
+    SeriesPlanDTO,
+)
 
 DashboardTab = Literal["all", "series", "plans"]
 DashboardItemType = Literal["series", "plan"]
@@ -16,7 +20,7 @@ class DashboardItemDTO(BaseModel):
     id: UUID
     type: DashboardItemType
     title: Optional[str] = None
-    metadata: Optional[List[SeriesMetadataDTO]] = None
+    metadata: Optional[SeriesMetadataResponse] = None
     plans: Optional[List[SeriesPlanDTO]] = None
     author_id: Optional[UUID] = None
     image: Optional[ImageUrlModel] = None

--- a/pecha_api/plans/dashboard/dashboard_service.py
+++ b/pecha_api/plans/dashboard/dashboard_service.py
@@ -28,6 +28,7 @@ from pecha_api.plans.plans_enums import PlanStatus
 from pecha_api.plans.series.series_repository import get_series_with_plans_by_ids
 from pecha_api.plans.series.series_response_models import SeriesMetadataDTO
 from pecha_api.plans.series.series_service import _get_sorted_active_plans, _plan_to_dto
+from pecha_api.plans.shared.metadata_utils import format_metadata_response
 def _parse_languages(item_type: str, languages_raw: Optional[str]) -> List[str]:
     if not languages_raw:
         return []
@@ -42,17 +43,27 @@ def _to_plan_status(status_value) -> PlanStatus:
     return PlanStatus(status_value)
 
 
-def _parse_metadata(raw) -> List[SeriesMetadataDTO]:
+def _parse_metadata(raw, language: Optional[str] = None):
     if raw is None:
-        return []
-    if isinstance(raw, str):
-        raw = json.loads(raw)
-    if not raw:
-        return []
-    return [SeriesMetadataDTO(**item) for item in raw]
+        metadata_list: List[SeriesMetadataDTO] = []
+    elif isinstance(raw, str):
+        parsed = json.loads(raw)
+        metadata_list = [SeriesMetadataDTO(**item) for item in parsed] if parsed else []
+    elif not raw:
+        metadata_list = []
+    else:
+        metadata_list = [SeriesMetadataDTO(**item) for item in raw]
+
+    if language:
+        language_upper = language.upper()
+        metadata_list = [
+            item for item in metadata_list
+            if item.language.upper() == language_upper
+        ]
+    return format_metadata_response(metadata_list, language=language)
 
 
-def _row_to_dto(row) -> DashboardItemDTO:
+def _row_to_dto(row, language: Optional[str] = None) -> DashboardItemDTO:
     item_type = row.item_type
     common = dict(
         id=row.id,
@@ -72,7 +83,7 @@ def _row_to_dto(row) -> DashboardItemDTO:
     if item_type == "series":
         return DashboardItemDTO(
             **common,
-            metadata=_parse_metadata(row.metadata_json),
+            metadata=_parse_metadata(row.metadata_json, language=language),
             author_id=row.author_id,
         )
     return DashboardItemDTO(
@@ -142,7 +153,7 @@ def get_dashboard_items_list(
             group_ids=group_ids,
         )
 
-    items = [_row_to_dto(row) for row in rows]
+    items = [_row_to_dto(row, language=language) for row in rows]
     return DashboardItemsResponse(
         items=items,
         pagination=DashboardPaginationDTO(
@@ -154,8 +165,8 @@ def get_dashboard_items_list(
     )
 
 
-def _row_to_public_dto(row) -> DashboardItemDTO:
-    return _row_to_dto(row).model_copy(update={"author_id": None})
+def _row_to_public_dto(row, language: Optional[str] = None) -> DashboardItemDTO:
+    return _row_to_dto(row, language=language).model_copy(update={"author_id": None})
 
 
 def _published_plans_by_series(db_session, series_ids: List[UUID]) -> dict:
@@ -191,7 +202,7 @@ def get_practice_items_list(
             featured=featured,
         )
 
-        items = [_row_to_public_dto(row) for row in rows]
+        items = [_row_to_public_dto(row, language=language) for row in rows]
         series_ids = [item.id for item in items if item.type == "series"]
         plans_by_series = _published_plans_by_series(db_session, series_ids)
 

--- a/pecha_api/plans/groups/groups_models.py
+++ b/pecha_api/plans/groups/groups_models.py
@@ -165,6 +165,7 @@ class AuthorGroupMetadata(Base):
     )
     language = Column(String(10), nullable=False)
     title = Column(String(255), nullable=False)
+    sub_title = Column(String(255), nullable=True)
     description = Column(Text, nullable=True)
 
     group = relationship("AuthorGroup", back_populates="metadata_entries")

--- a/pecha_api/plans/groups/groups_repository.py
+++ b/pecha_api/plans/groups/groups_repository.py
@@ -165,6 +165,7 @@ def get_groups_paginated(
                     AuthorGroupMetadata.group_id == AuthorGroup.id,
                     or_(
                         AuthorGroupMetadata.title.ilike(f"%{search}%"),
+                        AuthorGroupMetadata.sub_title.ilike(f"%{search}%"),
                         AuthorGroupMetadata.description.ilike(f"%{search}%"),
                     ),
                 )

--- a/pecha_api/plans/groups/groups_response_models.py
+++ b/pecha_api/plans/groups/groups_response_models.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import List, Optional
+from typing import List, Optional, Union
 from uuid import UUID
 
 from pydantic import BaseModel, field_validator
@@ -13,6 +13,7 @@ from pecha_api.plans.tags.tag_response_models import TagSummaryDTO
 
 class GroupMetadataInput(BaseModel):
     title: str
+    sub_title: Optional[str] = None
     description: Optional[str] = None
     language: LanguageCode
 
@@ -20,8 +21,12 @@ class GroupMetadataInput(BaseModel):
 class GroupMetadataDTO(BaseModel):
     id: UUID
     title: str
+    sub_title: Optional[str] = None
     description: Optional[str] = None
     language: str
+
+
+GroupMetadataResponse = Union[GroupMetadataDTO, List[GroupMetadataDTO], None]
 
 
 class GroupSocialLinkInput(BaseModel):
@@ -47,7 +52,7 @@ class AuthorGroupSummaryDTO(BaseModel):
     id: UUID
     slug: str
     is_public: bool
-    metadata: List[GroupMetadataDTO]
+    metadata: GroupMetadataResponse = []
     tags: List[TagSummaryDTO] = []
     follower_count: int = 0
     member_count: int = 0
@@ -61,7 +66,7 @@ class AuthorGroupDetailDTO(BaseModel):
     banner_key: Optional[str] = None
     avatar_url: Optional[str] = None
     banner_url: Optional[str] = None
-    metadata: List[GroupMetadataDTO]
+    metadata: GroupMetadataResponse = []
     members: List[AuthorGroupMemberDTO] = []
     tags: List[TagSummaryDTO] = []
     social_links: List[GroupSocialLinkDTO] = []

--- a/pecha_api/plans/groups/groups_service.py
+++ b/pecha_api/plans/groups/groups_service.py
@@ -62,6 +62,7 @@ from pecha_api.plans.groups.groups_repository import (
 from pecha_api.plans.series.series_repository import get_active_plan_count_map_by_series_ids
 from pecha_api.plans.series.series_response_models import SeriesListItemDTO
 from pecha_api.plans.series.series_service import _series_to_list_item_dto
+from pecha_api.plans.shared.metadata_utils import format_metadata_response
 from pecha_api.plans.groups.groups_response_models import (
     AuthorGroupDetailDTO,
     AuthorGroupListResponse,
@@ -109,16 +110,34 @@ def _generate_group_asset_url(asset_key: Optional[str]) -> Optional[str]:
     )
 
 
-def _metadata_to_dtos(metadata_entries) -> List[GroupMetadataDTO]:
+def _optional_metadata_str(value) -> Optional[str]:
+    return value if isinstance(value, str) else None
+
+
+def _metadata_to_dtos(metadata_entries, language: Optional[str] = None) -> List[GroupMetadataDTO]:
+    if language:
+        language_upper = language.upper()
+        metadata_entries = [
+            item for item in metadata_entries
+            if _language_value(item.language).upper() == language_upper
+        ]
     return [
         GroupMetadataDTO(
             id=item.id,
             title=item.title,
+            sub_title=_optional_metadata_str(getattr(item, "sub_title", None)),
             description=item.description,
-            language=item.language,
+            language=_language_value(item.language),
         )
         for item in sorted(metadata_entries, key=lambda value: value.language)
     ]
+
+
+def _metadata_response(metadata_entries, language: Optional[str] = None):
+    return format_metadata_response(
+        _metadata_to_dtos(metadata_entries, language=language),
+        language=language,
+    )
 
 
 def _members_to_dtos(members) -> List[AuthorGroupMemberDTO]:
@@ -329,12 +348,16 @@ def _plans_to_dtos(db: Session, plan_list: List[Plan], group_id: UUID) -> List[P
     ]
 
 
-def _group_to_summary(group: AuthorGroup, follower_count: int = 0) -> AuthorGroupSummaryDTO:
+def _group_to_summary(
+    group: AuthorGroup,
+    follower_count: int = 0,
+    language: Optional[str] = None,
+) -> AuthorGroupSummaryDTO:
     return AuthorGroupSummaryDTO(
         id=group.id,
         slug=group.slug,
         is_public=group.is_public,
-        metadata=_metadata_to_dtos(group.metadata_entries),
+        metadata=_metadata_response(group.metadata_entries, language=language),
         tags=tags_to_summary_dtos(group.tags),
         follower_count=follower_count,
         member_count=len(group.members),
@@ -345,6 +368,7 @@ def _group_to_detail(
     group: AuthorGroup,
     follower_count: int = 0,
     db: Optional[Session] = None,
+    language: Optional[str] = None,
 ) -> AuthorGroupDetailDTO:
     if db is not None:
         group_series = get_series_by_group_id(db=db, group_id=group.id)
@@ -363,7 +387,7 @@ def _group_to_detail(
         banner_key=group.banner_key,
         avatar_url=_generate_group_asset_url(group.avatar_key),
         banner_url=_generate_group_asset_url(group.banner_key),
-        metadata=_metadata_to_dtos(group.metadata_entries),
+        metadata=_metadata_response(group.metadata_entries, language=language),
         members=_members_to_dtos(group.members),
         tags=tags_to_summary_dtos(group.tags),
         social_links=_social_links_to_dtos(group.social_links),
@@ -385,6 +409,7 @@ def create_author_group(token: str, request: CreateAuthorGroupRequest) -> Author
             AuthorGroupMetadata(
                 language=item.language.value,
                 title=item.title,
+                sub_title=item.sub_title,
                 description=item.description,
             )
             for item in request.metadata
@@ -438,6 +463,7 @@ def update_author_group(token: str, group_id: UUID, request: UpdateAuthorGroupRe
                 AuthorGroupMetadata(
                     language=item.language.value,
                     title=item.title,
+                    sub_title=item.sub_title,
                     description=item.description,
                 )
                 for item in request.metadata
@@ -496,7 +522,14 @@ def list_public_groups(
         group_ids = [group.id for group in groups]
         follower_count_map = get_followers_count_map(db=db, group_ids=group_ids)
         return AuthorGroupListResponse(
-            groups=[_group_to_summary(group=item, follower_count=follower_count_map.get(item.id, 0)) for item in groups],
+            groups=[
+                _group_to_summary(
+                    group=item,
+                    follower_count=follower_count_map.get(item.id, 0),
+                    language=language,
+                )
+                for item in groups
+            ],
             skip=skip,
             limit=limit,
             total=total,
@@ -533,7 +566,14 @@ def list_cms_groups(
         ids = [group.id for group in groups]
         follower_count_map = get_followers_count_map(db=db, group_ids=ids)
         return AuthorGroupListResponse(
-            groups=[_group_to_summary(group=item, follower_count=follower_count_map.get(item.id, 0)) for item in groups],
+            groups=[
+                _group_to_summary(
+                    group=item,
+                    follower_count=follower_count_map.get(item.id, 0),
+                    language=language,
+                )
+                for item in groups
+            ],
             skip=skip,
             limit=limit,
             total=total,

--- a/pecha_api/plans/public/plan_response_models.py
+++ b/pecha_api/plans/public/plan_response_models.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, ConfigDict
-from typing import Optional, List
+from typing import Optional, List, Union
 from pecha_api.plans.plans_enums import DifficultyLevel, PlanStatus,ContentType
 from uuid import UUID
 from datetime import datetime, date as DateType
@@ -100,13 +100,17 @@ class PlansRepositoryResponse(BaseModel):
 class SeriesMetadataDTO(BaseModel):
     id: UUID
     title: str
+    sub_title: Optional[str] = None
     description: Optional[str] = None
     language: str
 
 
+SeriesMetadataResponse = Union[SeriesMetadataDTO, List[SeriesMetadataDTO], None]
+
+
 class SeriesDTO(BaseModel):
     id: UUID
-    metadata: List[SeriesMetadataDTO] = []
+    metadata: SeriesMetadataResponse = []
     image: Optional[ImageUrlModel] = None
 
 class DailyPlanResponse(BaseModel):

--- a/pecha_api/plans/public/plan_service.py
+++ b/pecha_api/plans/public/plan_service.py
@@ -34,6 +34,7 @@ from pecha_api.plans.groups.groups_repository import get_group_id_for_plan, get_
 from pecha_api.plans.tags.tag_helpers import tags_to_summary_dtos
 from pecha_api.plans.tags.tag_repository import get_published_tags_for_language, get_all_tags_paginated
 from pecha_api.plans.tags.tag_response_models import PublicTagsListResponse
+from pecha_api.plans.shared.metadata_utils import format_metadata_response
 
 logger = logging.getLogger(__name__)
 
@@ -537,14 +538,17 @@ async def get_plan_daily_content(
         series_dto = None
         if plan.series:
             series_image = await get_image_url(image_url=plan.series.image)
-            metadata_entries = _filter_series_metadata_by_language(
-                getattr(plan.series, "metadata_entries", None) or [],
-                language=navigation_language,
-            )
+            metadata_entries = getattr(plan.series, "metadata_entries", None) or []
+            if language:
+                metadata_entries = _filter_series_metadata_by_language(
+                    metadata_entries,
+                    language=language,
+                )
             series_metadata = [
                 SeriesMetadataDTO(
                     id=entry.id,
                     title=entry.title,
+                    sub_title=entry.sub_title if isinstance(entry.sub_title, str) else None,
                     description=entry.description,
                     language=entry.language.value
                     if hasattr(entry.language, "value")
@@ -559,7 +563,7 @@ async def get_plan_daily_content(
             ]
             series_dto = SeriesDTO(
                 id=plan.series.id,
-                metadata=series_metadata,
+                metadata=format_metadata_response(series_metadata, language=language),
                 image=series_image,
             )
 

--- a/pecha_api/plans/series/series_metadata_model.py
+++ b/pecha_api/plans/series/series_metadata_model.py
@@ -12,6 +12,7 @@ class SeriesMetadata(Base):
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
     title = Column(String(255), nullable=False)
+    sub_title = Column(String(255), nullable=True)
     description = Column(Text, nullable=True)
     language = Column(LanguageCodeEnum, nullable=False)
     series_id = Column(

--- a/pecha_api/plans/series/series_repository.py
+++ b/pecha_api/plans/series/series_repository.py
@@ -99,6 +99,7 @@ def _persist_metadata_entries(
             SeriesMetadata(
                 series_id=series_id,
                 title=entry.title,
+                sub_title=entry.sub_title,
                 description=entry.description,
                 language=entry.language,
             )
@@ -256,6 +257,7 @@ def get_series_paginated(
                     SeriesMetadata.series_id == Series.id,
                     or_(
                         SeriesMetadata.title.ilike(f"%{search}%"),
+                        SeriesMetadata.sub_title.ilike(f"%{search}%"),
                         SeriesMetadata.description.ilike(f"%{search}%"),
                     ),
                 )

--- a/pecha_api/plans/series/series_response_models.py
+++ b/pecha_api/plans/series/series_response_models.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, field_validator
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 from uuid import UUID
 from datetime import datetime
 
@@ -25,12 +25,17 @@ def _validate_plan_language_keys(v):
 class SeriesMetadataDTO(BaseModel):
     id: UUID
     title: str
+    sub_title: Optional[str] = None
     description: Optional[str] = None
     language: str
 
 
+SeriesMetadataResponse = Union[SeriesMetadataDTO, List[SeriesMetadataDTO], None]
+
+
 class SeriesMetadataInput(BaseModel):
     title: str
+    sub_title: Optional[str] = None
     description: Optional[str] = None
     language: LanguageCode
 
@@ -83,7 +88,7 @@ class SeriesPlanDTO(BaseModel):
 
 class SeriesListItemDTO(BaseModel):
     id: UUID
-    metadata: List[SeriesMetadataDTO] = []
+    metadata: SeriesMetadataResponse = []
     image: Optional[ImageUrlModel] = None
     image_key: Optional[str] = None
     author_id: UUID
@@ -95,7 +100,7 @@ class SeriesListItemDTO(BaseModel):
 
 class SeriesDTO(BaseModel):
     id: UUID
-    metadata: List[SeriesMetadataDTO] = []
+    metadata: SeriesMetadataResponse = []
     image: Optional[ImageUrlModel] = None
     image_key: Optional[str] = None
     author_id: UUID

--- a/pecha_api/plans/series/series_service.py
+++ b/pecha_api/plans/series/series_service.py
@@ -7,6 +7,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from pecha_api.db.database import SessionLocal
+from pecha_api.plans.shared.metadata_utils import format_metadata_response
 from pecha_api.plans.plans_enums import PlanStatus
 from pecha_api.plans.series.series_model import Series
 from pecha_api.plans.groups.groups_repository import (
@@ -66,6 +67,10 @@ def _language_value(language) -> str:
     return str(language)
 
 
+def _optional_metadata_str(value) -> Optional[str]:
+    return value if isinstance(value, str) else None
+
+
 def _metadata_to_dtos(entries, language: Optional[str] = None) -> List[SeriesMetadataDTO]:
     if not entries:
         return []
@@ -80,12 +85,20 @@ def _metadata_to_dtos(entries, language: Optional[str] = None) -> List[SeriesMet
             SeriesMetadataDTO(
                 id=entry.id,
                 title=entry.title,
+                sub_title=_optional_metadata_str(getattr(entry, "sub_title", None)),
                 description=entry.description,
                 language=_language_value(entry.language),
             )
             for entry in entries
         ],
         key=lambda metadata_dto: metadata_dto.language,
+    )
+
+
+def _metadata_response(entries, language: Optional[str] = None):
+    return format_metadata_response(
+        _metadata_to_dtos(entries, language=language),
+        language=language,
     )
 
 
@@ -177,7 +190,7 @@ def _series_to_list_item_dto(
 ) -> SeriesListItemDTO:
     return SeriesListItemDTO(
         id=row.id,
-        metadata=_metadata_to_dtos(row.metadata_entries, language=language),
+        metadata=_metadata_response(row.metadata_entries, language=language),
         image=get_image_url(image_url=row.image),
         image_key=row.image,
         author_id=row.author_id,
@@ -214,7 +227,7 @@ def _series_to_dto(
 
     return SeriesDTO(
         id=row.id,
-        metadata=_metadata_to_dtos(row.metadata_entries, language=metadata_language),
+        metadata=_metadata_response(row.metadata_entries, language=metadata_language),
         image=get_image_url(image_url=row.image),
         image_key=row.image,
         author_id=row.author_id,

--- a/pecha_api/plans/shared/metadata_utils.py
+++ b/pecha_api/plans/shared/metadata_utils.py
@@ -1,0 +1,12 @@
+from typing import List, Optional, TypeVar, Union
+
+T = TypeVar("T")
+
+
+def format_metadata_response(
+    metadata_list: List[T],
+    language: Optional[str],
+) -> Union[T, List[T], None]:
+    if language:
+        return metadata_list[0] if metadata_list else None
+    return metadata_list

--- a/spec/series-openapi-spec.yaml
+++ b/spec/series-openapi-spec.yaml
@@ -484,6 +484,9 @@ components:
       properties:
         title:
           type: string
+        sub_title:
+          type: string
+          nullable: true
         description:
           type: string
           nullable: true
@@ -502,6 +505,9 @@ components:
           format: uuid
         title:
           type: string
+        sub_title:
+          type: string
+          nullable: true
         description:
           type: string
           nullable: true

--- a/tests/plans/public/test_plan_public_service.py
+++ b/tests/plans/public/test_plan_public_service.py
@@ -1139,8 +1139,7 @@ async def test_get_plan_daily_content_filters_series_metadata_by_navigation_lang
         )
 
     assert result.series is not None
-    assert len(result.series.metadata) == 1
-    assert result.series.metadata[0].language == "EN"
+    assert result.series.metadata.language == "EN"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
…nd repositories

- Introduced 'sub_title' field in SeriesMetadata and AuthorGroupMetadata models.
- Updated filtering logic in repositories to include 'sub_title' in search queries.
- Modified response models to accommodate 'sub_title' in DTOs and responses.
- Adjusted service methods to handle 'sub_title' during metadata processing and response formatting.
- Updated OpenAPI specifications to reflect the new 'sub_title' field.