### PR TITLE
Refactor plan enrollment logic by removing unenrollment functionality

### DIFF
--- a/pecha_api/routines/routines_service.py
+++ b/pecha_api/routines/routines_service.py
@@ -15,7 +15,6 @@ from pecha_api.texts.texts_models import Text
 from pecha_api.plans.users.plan_users_models import UserPlanProgress
 from pecha_api.plans.plans_enums import UserPlanStatus
 from pecha_api.plans.users.plan_users_progress_repository import (
-    delete_user_plan_progress,
     get_plan_progress_by_user_id_and_plan_ids,
 )
 
@@ -191,32 +190,15 @@ def _enroll_plans(db, user_id: UUID, plan_ids: List[UUID]) -> None:
         db.rollback()
 
 
-def _unenroll_plans(db, user_id: UUID, plan_ids: List[UUID]) -> None:
-    if not plan_ids:
-        return
-
-    for plan_id in plan_ids:
-        try:
-            delete_user_plan_progress(db=db, user_id=user_id, plan_id=plan_id)
-        except HTTPException as e:
-            if e.status_code == status.HTTP_404_NOT_FOUND:
-                continue
-            raise
-
-
-def _sync_plan_enrollments_on_update(
+def _enroll_new_plans_on_update(
     db, user_id: UUID, time_block_id: UUID, new_sessions: List
 ) -> None:
     old_plan_ids = set(
         get_plan_source_ids_by_time_block_id(db=db, time_block_id=time_block_id)
     )
     new_plan_ids = set(_extract_plan_ids(new_sessions))
-
     added_plans = list(new_plan_ids - old_plan_ids)
-    removed_plans = list(old_plan_ids - new_plan_ids)
-
     _enroll_plans(db=db, user_id=user_id, plan_ids=added_plans)
-    _unenroll_plans(db=db, user_id=user_id, plan_ids=removed_plans)
 
 
 def _validate_and_sync_update(
@@ -247,7 +229,7 @@ def _validate_and_sync_update(
         sessions=request.sessions,
     )
 
-    _sync_plan_enrollments_on_update(
+    _enroll_new_plans_on_update(
         db=db,
         user_id=user_id,
         time_block_id=time_block_id,
@@ -600,13 +582,6 @@ def delete_time_block(token: str, routine_id: UUID, time_block_id: UUID) -> None
                 ).model_dump(),
             )
 
-        # Auto-unenroll plans before soft delete
-        plan_ids = get_plan_source_ids_by_time_block_id(
-            db=db, time_block_id=time_block_id
-        )
-        _unenroll_plans(db=db, user_id=current_user.id, plan_ids=plan_ids)
-
-        # Soft delete
         soft_delete_time_block(db=db, time_block=time_block)
 
 

--- a/tests/plans/users/test_plan_users_service.py
+++ b/tests/plans/users/test_plan_users_service.py
@@ -479,7 +479,7 @@ async def test_get_user_enrolled_plans_success():
 async def test_get_user_enrolled_plans_includes_group_info():
     from datetime import datetime, timezone
     from pecha_api.plans.users.plan_users_service import get_user_enrolled_plans
-    from pecha_api.plans.groups.groups_response_models import AuthorGroupSummaryDTO, GroupMetadataDTO
+    from pecha_api.plans.groups.group_summary_models import AuthorGroupSummaryDTO, GroupMetadataDTO
 
     user_id = uuid.uuid4()
     plan_id = uuid.uuid4()

--- a/tests/routines/test_routines_service.py
+++ b/tests/routines/test_routines_service.py
@@ -16,6 +16,7 @@ from pecha_api.routines.routines_service import (
     _resolve_recitation_sessions,
     _resolve_timer_sessions,
     _resolve_sessions,
+    _enroll_new_plans_on_update,
     build_session_models,
     group_sessions_by_block,
     build_time_block_dto,
@@ -963,6 +964,67 @@ async def test_add_time_block_duplicate_time():
             )
         assert exc_info.value.status_code == 409
         assert exc_info.value.detail["message"] == TIME_ALREADY_EXISTS
+
+
+def test_enroll_new_plans_on_update_does_not_unenroll_removed_plans():
+    user_id = uuid.uuid4()
+    time_block_id = uuid.uuid4()
+    kept_plan_id = uuid.uuid4()
+    removed_plan_id = uuid.uuid4()
+    added_plan_id = uuid.uuid4()
+
+    new_sessions = [
+        SimpleNamespace(session_type=SessionType.PLAN, source_id=kept_plan_id),
+        SimpleNamespace(session_type=SessionType.PLAN, source_id=added_plan_id),
+    ]
+
+    db_mock = MagicMock()
+
+    with patch(
+        "pecha_api.routines.routines_service.get_plan_source_ids_by_time_block_id",
+        return_value=[kept_plan_id, removed_plan_id],
+    ), patch(
+        "pecha_api.routines.routines_service._enroll_plans",
+    ) as mock_enroll_plans:
+        _enroll_new_plans_on_update(
+            db=db_mock,
+            user_id=user_id,
+            time_block_id=time_block_id,
+            new_sessions=new_sessions,
+        )
+
+        mock_enroll_plans.assert_called_once_with(
+            db=db_mock, user_id=user_id, plan_ids=[added_plan_id]
+        )
+
+
+def test_delete_time_block_does_not_delete_plan_progress():
+    user_id = uuid.uuid4()
+    routine_id = uuid.uuid4()
+    time_block_id = uuid.uuid4()
+
+    _, session_cm = _mock_session_with_db()
+
+    with patch(
+        "pecha_api.routines.routines_service.validate_and_extract_user_details",
+        return_value=SimpleNamespace(id=user_id),
+    ), patch(
+        "pecha_api.routines.routines_service.SessionLocal",
+        return_value=session_cm,
+    ), patch(
+        "pecha_api.routines.routines_service.get_routine_by_id_and_user",
+        return_value=SimpleNamespace(id=routine_id, user_id=user_id),
+    ), patch(
+        "pecha_api.routines.routines_service.get_time_block_by_id_and_routine",
+        return_value=SimpleNamespace(id=time_block_id, routine_id=routine_id),
+    ), patch(
+        "pecha_api.routines.routines_service.soft_delete_time_block",
+    ) as mock_soft_delete:
+        delete_time_block(
+            token="token123", routine_id=routine_id, time_block_id=time_block_id
+        )
+
+        mock_soft_delete.assert_called_once()
 
 
 def test_delete_time_block_success():


### PR DESCRIPTION
- Removed the _unenroll_plans function and its calls from the routines_service.py.
- Renamed _sync_plan_enrollments_on_update to _enroll_new_plans_on_update to better reflect its purpose.
- Updated related tests to ensure that removed plans are not unenrolled during updates.