### PR TITLE
Refactor user relationships in models to include cascade delete behavior

### DIFF
--- a/pecha_api/plans/favorites/favorites_models.py
+++ b/pecha_api/plans/favorites/favorites_models.py
@@ -1,5 +1,5 @@
 from sqlalchemy import Column, DateTime, UUID, ForeignKey, Index
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import relationship, backref
 from uuid import uuid4
 from ...db.database import Base
 from _datetime import datetime
@@ -16,7 +16,7 @@ class Favorite(Base):
     created_at = Column(DateTime, default=datetime.now(_datetime.timezone.utc))
     updated_at = Column(DateTime, default=datetime.now(_datetime.timezone.utc))
 
-    user = relationship("Users", backref="favorites")
+    user = relationship("Users", backref=backref("favorites", cascade="all, delete-orphan"))
 
     __table_args__ = (
         Index("idx_favorites_user_plan", "user_id", "plan_id"),

--- a/pecha_api/plans/reviews/plan_reviews_models.py
+++ b/pecha_api/plans/reviews/plan_reviews_models.py
@@ -1,5 +1,5 @@
 from sqlalchemy import Column, Integer, DateTime, Boolean, Text, ForeignKey, Index, UniqueConstraint, UUID, CheckConstraint, text,String
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import relationship, backref
 from uuid import uuid4
 from ...db.database import Base
 from _datetime import datetime
@@ -27,7 +27,7 @@ class PlanReview(Base):
     deleted_at = Column(DateTime(timezone=True))
     deleted_by = Column(String(255))
 
-    user = relationship("Users", backref="reviews")
+    user = relationship("Users", backref=backref("reviews", cascade="all, delete-orphan"))
 
     __table_args__ = (
         UniqueConstraint("user_id", "plan_id", name="uq_plan_reviews_user_plan"),

--- a/pecha_api/plans/users/plan_users_models.py
+++ b/pecha_api/plans/users/plan_users_models.py
@@ -2,7 +2,7 @@ from sqlalchemy import Column, DateTime, Boolean, Integer, Index, UniqueConstrai
 from uuid import uuid4
 from _datetime import datetime
 import _datetime
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import relationship, backref
 
 from ...db.database import Base
 from ...plans.plans_enums import UserPlanStatusEnum, EnrollmentSourceEnum, SeriesStatusEnum
@@ -44,7 +44,7 @@ class UserPlanProgress(Base):
         default=lambda: datetime.now(_datetime.timezone.utc),
     )
 
-    user = relationship("Users", backref="plan_progress")
+    user = relationship("Users", backref=backref("plan_progress", cascade="all, delete-orphan"))
     series_enrollment = relationship("UserSeriesEnrollment", back_populates="plan_progress_records")
 
     __table_args__ = (
@@ -74,7 +74,7 @@ class UserTaskCompletion(Base):
         nullable=False,
     )
 
-    user = relationship("Users", backref="completed_tasks")
+    user = relationship("Users", backref=backref("completed_tasks", cascade="all, delete-orphan"))
     task = relationship("PlanTask", back_populates="user_task_completions")
 
     __table_args__ = (
@@ -101,7 +101,7 @@ class UserDayCompletion(Base):
         nullable=False,
     )
 
-    user = relationship("Users", backref="day_completions")
+    user = relationship("Users", backref=backref("day_completions", cascade="all, delete-orphan"))
     item = relationship("PlanItem", backref="user_day_completions")
 
     __table_args__ = (
@@ -127,7 +127,7 @@ class UserSubTaskCompletion(Base):
         nullable=False,
     )
 
-    user = relationship("Users", backref="sub_task_completions")
+    user = relationship("Users", backref=backref("sub_task_completions", cascade="all, delete-orphan"))
     sub_task = relationship("PlanSubTask", back_populates="user_sub_task_completions")
 
     __table_args__ = (
@@ -169,7 +169,7 @@ class UserSeriesEnrollment(Base):
     )
 
     # Relationships
-    user = relationship("Users", backref="series_enrollments")
+    user = relationship("Users", backref=backref("series_enrollments", cascade="all, delete-orphan"))
     series = relationship("Series", backref="user_enrollments")
     current_plan = relationship("Plan", foreign_keys=[current_plan_id])
     plan_progress_records = relationship("UserPlanProgress", back_populates="series_enrollment")


### PR DESCRIPTION
- Updated the relationship definitions in Favorite, PlanReview, UserPlanProgress, UserTaskCompletion, UserDayCompletion, UserSubTaskCompletion, and UserSeriesEnrollment models to use backref with cascade="all, delete-orphan". This ensures that related records are automatically deleted when the parent record is removed.