### PR TITLE
Add task and subtask completion functionality for daily sync

### DIFF
--- a/pecha_api/plans/users/plan_user_series_day_sync_service.py
+++ b/pecha_api/plans/users/plan_user_series_day_sync_service.py
@@ -5,11 +5,55 @@ from sqlalchemy.orm import Session
 
 from pecha_api.plans.cms.cms_plans_repository import get_plan_by_id
 from pecha_api.plans.items.plan_items_repository import get_plan_item_by_id
+from pecha_api.plans.tasks.plan_tasks_repository import get_tasks_by_plan_item_id
+from pecha_api.plans.tasks.sub_tasks.plan_sub_tasks_repository import get_sub_tasks_by_task_id
 from pecha_api.plans.users.plan_user_day_repository import save_user_day_completion_if_not_exists
 from pecha_api.plans.users.plan_user_series_day_sync_repository import (
     get_plan_items_by_plan_ids_and_day_number,
     get_sibling_plans_in_series_slot,
 )
+from pecha_api.plans.users.plan_user_task_repository import (
+    get_uncompleted_user_task_ids,
+    save_user_task_completions_bulk,
+)
+from pecha_api.plans.users.plan_users_models import UserSubTaskCompletion, UserTaskCompletion
+from pecha_api.plans.users.plan_users_subtasks_repository import (
+    get_uncompleted_user_sub_task_ids,
+    save_user_sub_task_completions_bulk,
+)
+
+
+def _complete_all_tasks_for_day(db: Session, user_id: UUID, day_id: UUID) -> None:
+    """Mark every task and subtask in a day as completed for the user."""
+    tasks = get_tasks_by_plan_item_id(db, day_id)
+    if not tasks:
+        return
+
+    task_ids = [task.id for task in tasks]
+    uncompleted_task_ids = get_uncompleted_user_task_ids(db, user_id, task_ids)
+    if uncompleted_task_ids:
+        save_user_task_completions_bulk(
+            db,
+            [UserTaskCompletion(user_id=user_id, task_id=task_id) for task_id in uncompleted_task_ids],
+        )
+
+    sub_task_ids = [
+        sub_task.id
+        for task in tasks
+        for sub_task in get_sub_tasks_by_task_id(db, task.id)
+    ]
+    if not sub_task_ids:
+        return
+
+    uncompleted_sub_task_ids = get_uncompleted_user_sub_task_ids(db, user_id, sub_task_ids)
+    if uncompleted_sub_task_ids:
+        save_user_sub_task_completions_bulk(
+            db,
+            [
+                UserSubTaskCompletion(user_id=user_id, sub_task_id=sub_task_id)
+                for sub_task_id in uncompleted_sub_task_ids
+            ],
+        )
 
 
 def sync_series_day_completion(db: Session, user_id: UUID, completed_day_id: UUID) -> List[UUID]:
@@ -44,6 +88,7 @@ def sync_series_day_completion(db: Session, user_id: UUID, completed_day_id: UUI
 
     synced_day_ids: List[UUID] = []
     for equivalent_day in equivalent_days:
+        _complete_all_tasks_for_day(db, user_id, equivalent_day.id)
         save_user_day_completion_if_not_exists(db, user_id, equivalent_day.id)
         synced_day_ids.append(equivalent_day.id)
 

--- a/pecha_api/plans/users/plan_user_task_repository.py
+++ b/pecha_api/plans/users/plan_user_task_repository.py
@@ -22,6 +22,17 @@ def save_user_task_completion(db: Session, user_task_completion: UserTaskComplet
     db.refresh(user_task_completion)
 
 
+def save_user_task_completions_bulk(db: Session, user_task_completions: List[UserTaskCompletion]) -> None:
+    if not user_task_completions:
+        return
+    try:
+        db.add_all(user_task_completions)
+        db.commit()
+    except Exception as e:
+        db.rollback()
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=ResponseError(error=BAD_REQUEST, message=str(e)).model_dump())
+
+
 def get_user_task_completions_by_user_id_and_task_ids(db: Session, user_id: UUID, task_ids: List[UUID]) -> List[UserTaskCompletion]:
     return db.query(UserTaskCompletion).filter(UserTaskCompletion.user_id == user_id, UserTaskCompletion.task_id.in_(task_ids)).all()
 

--- a/tests/plans/users/test_plan_user_series_day_sync_service.py
+++ b/tests/plans/users/test_plan_user_series_day_sync_service.py
@@ -65,7 +65,7 @@ def test_sync_series_day_completion_returns_empty_when_no_sibling_plans():
     assert result == []
 
 
-def test_sync_series_day_completion_marks_sibling_days_complete():
+def test_sync_series_day_completion_marks_sibling_days_and_tasks_complete():
     db_mock = MagicMock()
     user_id = uuid.uuid4()
     completed_day_id = uuid.uuid4()
@@ -90,6 +90,8 @@ def test_sync_series_day_completion_marks_sibling_days_complete():
         "pecha_api.plans.users.plan_user_series_day_sync_service.get_plan_items_by_plan_ids_and_day_number",
         return_value=[sibling_day],
     ) as mock_equivalent_days, patch(
+        "pecha_api.plans.users.plan_user_series_day_sync_service._complete_all_tasks_for_day",
+    ) as mock_complete_tasks, patch(
         "pecha_api.plans.users.plan_user_series_day_sync_service.save_user_day_completion_if_not_exists",
     ) as mock_save:
         result = sync_series_day_completion(db_mock, user_id, completed_day_id)
@@ -105,8 +107,52 @@ def test_sync_series_day_completion_marks_sibling_days_complete():
         plan_ids=[sibling_plan_id],
         day_number=3,
     )
+    mock_complete_tasks.assert_called_once_with(db_mock, user_id, sibling_day_id)
     mock_save.assert_called_once_with(db_mock, user_id, sibling_day_id)
     assert result == [sibling_day_id]
+
+
+def test_complete_all_tasks_for_day_marks_uncompleted_tasks_and_subtasks():
+    from pecha_api.plans.users.plan_user_series_day_sync_service import _complete_all_tasks_for_day
+
+    db_mock = MagicMock()
+    user_id = uuid.uuid4()
+    day_id = uuid.uuid4()
+    task_id = uuid.uuid4()
+    sub_task_id = uuid.uuid4()
+    task = SimpleNamespace(id=task_id)
+    sub_task = SimpleNamespace(id=sub_task_id)
+
+    with patch(
+        "pecha_api.plans.users.plan_user_series_day_sync_service.get_tasks_by_plan_item_id",
+        return_value=[task],
+    ), patch(
+        "pecha_api.plans.users.plan_user_series_day_sync_service.get_uncompleted_user_task_ids",
+        return_value=[task_id],
+    ), patch(
+        "pecha_api.plans.users.plan_user_series_day_sync_service.save_user_task_completions_bulk",
+    ) as mock_save_tasks, patch(
+        "pecha_api.plans.users.plan_user_series_day_sync_service.get_sub_tasks_by_task_id",
+        return_value=[sub_task],
+    ), patch(
+        "pecha_api.plans.users.plan_user_series_day_sync_service.get_uncompleted_user_sub_task_ids",
+        return_value=[sub_task_id],
+    ), patch(
+        "pecha_api.plans.users.plan_user_series_day_sync_service.save_user_sub_task_completions_bulk",
+    ) as mock_save_subtasks:
+        _complete_all_tasks_for_day(db_mock, user_id, day_id)
+
+    mock_save_tasks.assert_called_once()
+    saved_tasks = mock_save_tasks.call_args[0][1]
+    assert len(saved_tasks) == 1
+    assert saved_tasks[0].user_id == user_id
+    assert saved_tasks[0].task_id == task_id
+
+    mock_save_subtasks.assert_called_once()
+    saved_subtasks = mock_save_subtasks.call_args[0][1]
+    assert len(saved_subtasks) == 1
+    assert saved_subtasks[0].user_id == user_id
+    assert saved_subtasks[0].sub_task_id == sub_task_id
 
 
 def test_check_day_completion_runs_plan_completion_for_sibling_days():


### PR DESCRIPTION
- Implemented `_complete_all_tasks_for_day` to mark all tasks and subtasks as completed for a user on a given day.
- Enhanced `sync_series_day_completion` to call the new task completion function for equivalent days.
- Added bulk save methods for user task and subtask completions in the task repository.
- Updated tests to verify the new functionality for task and subtask completion during series day sync.