### PR TITLE
Add functionality to retrieve followed group details

### DIFF
--- a/pecha_api/plans/groups/groups_repository.py
+++ b/pecha_api/plans/groups/groups_repository.py
@@ -433,6 +433,20 @@ def get_following_group_ids_by_user(
     return [row[0] for row in rows]
 
 
+def is_user_following_group(
+    db: Session,
+    group_id: UUID,
+    user_id: UUID,
+) -> bool:
+    row = db.execute(
+        select(author_group_followers.c.group_id).where(
+            author_group_followers.c.group_id == group_id,
+            author_group_followers.c.user_id == user_id,
+        )
+    ).first()
+    return row is not None
+
+
 def get_followers_count_map(db: Session, group_ids: Sequence[UUID]) -> dict[UUID, int]:
     if not group_ids:
         return {}

--- a/pecha_api/plans/groups/groups_service.py
+++ b/pecha_api/plans/groups/groups_service.py
@@ -34,6 +34,7 @@ from pecha_api.plans.groups.groups_repository import (
     create_group_invite,
     get_followers_count_map,
     get_following_group_ids_by_user,
+    is_user_following_group,
     get_group_by_id,
     get_group_by_slug,
     get_groups_by_ids,
@@ -697,6 +698,27 @@ def unfollow_group(token: str, group_id: UUID) -> None:
     user = validate_and_extract_user_details(token=token)
     with SessionLocal() as db:
         remove_group_follow(db=db, group_id=group_id, user_id=user.id)
+
+
+def get_followed_group(
+    token: str,
+    group_id: UUID,
+    language: Optional[str] = None,
+) -> PublicAuthorGroupSummaryDTO:
+    user = validate_and_extract_user_details(token=token)
+    with SessionLocal() as db:
+        if not is_user_following_group(db=db, group_id=group_id, user_id=user.id):
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=GROUP_NOT_FOUND)
+        group = get_group_by_id(db=db, group_id=group_id)
+        if not group:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=GROUP_NOT_FOUND)
+        follower_count = get_followers_count_map(db=db, group_ids=[group_id]).get(group_id, 0)
+        return _group_to_summary(
+            group=group,
+            follower_count=follower_count,
+            public=True,
+            language=language,
+        )
 
 
 def list_followed_groups(token: str, skip: int, limit: int) -> PublicAuthorGroupListResponse:

--- a/pecha_api/plans/groups/groups_views.py
+++ b/pecha_api/plans/groups/groups_views.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Optional
+from typing import Annotated, Optional, Union
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Query
@@ -16,6 +16,7 @@ from pecha_api.plans.groups.groups_response_models import (
     GroupInviteListResponse,
     PublicAuthorGroupDetailDTO,
     PublicAuthorGroupListResponse,
+    PublicAuthorGroupSummaryDTO,
     ReplaceGroupSocialLinksRequest,
     ReplaceGroupTagsRequest,
     UpdateAuthorGroupRequest,
@@ -31,6 +32,7 @@ from pecha_api.plans.groups.groups_service import (
     get_author_group_detail,
     get_cms_group_detail,
     list_cms_groups,
+    get_followed_group,
     list_followed_groups,
     list_group_invites,
     list_my_pending_group_invites,
@@ -338,12 +340,24 @@ def delete_follow_group(
     return None
 
 
-@user_groups_router.get("", status_code=status.HTTP_200_OK, response_model=PublicAuthorGroupListResponse)
+@user_groups_router.get(
+    "",
+    status_code=status.HTTP_200_OK,
+    response_model=Union[PublicAuthorGroupListResponse, PublicAuthorGroupSummaryDTO],
+)
 def get_my_followed_groups(
     authentication_credential: Annotated[HTTPAuthorizationCredentials, Depends(oauth2_scheme)],
+    group_id: Annotated[Optional[UUID], Query(description="Return this group if the user is following it")] = None,
+    language: Annotated[Optional[str], Query(description="Filter group metadata by language (e.g. 'en', 'bo', 'zh')")] = None,
     skip: Annotated[int, Query(ge=0)] = 0,
     limit: Annotated[int, Query(ge=1, le=100)] = 20,
 ):
+    if group_id is not None:
+        return get_followed_group(
+            token=authentication_credential.credentials,
+            group_id=group_id,
+            language=language,
+        )
     return list_followed_groups(
         token=authentication_credential.credentials,
         skip=skip,

--- a/tests/plans/groups/test_groups_service.py
+++ b/tests/plans/groups/test_groups_service.py
@@ -33,6 +33,7 @@ from pecha_api.plans.groups.groups_service import (
     list_my_pending_group_invites,
     reject_group_invite_by_id,
     follow_group,
+    get_followed_group,
     get_author_group_detail,
     get_cms_group_detail,
     list_cms_groups,
@@ -587,6 +588,75 @@ def test_list_followed_groups():
         _session_local_context(mock_session)
         result = list_followed_groups(token="t", skip=0, limit=20)
     assert result.total == 1
+
+
+def test_get_followed_group_returns_group_when_following():
+    user = MagicMock()
+    user.id = uuid4()
+    group = _make_group()
+    meta = MagicMock()
+    meta.id = uuid4()
+    meta.title = "Followed Group"
+    meta.description = None
+    meta.language = "EN"
+    group.metadata_entries = [meta]
+
+    with patch("pecha_api.plans.groups.groups_service.SessionLocal") as mock_session, patch(
+        "pecha_api.plans.groups.groups_service.validate_and_extract_user_details",
+        return_value=user,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.is_user_following_group",
+        return_value=True,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_group_by_id",
+        return_value=group,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_followers_count_map",
+        return_value={group.id: 5},
+    ):
+        _session_local_context(mock_session)
+        result = get_followed_group(token="t", group_id=group.id)
+
+    assert result.id == group.id
+    assert result.follower_count == 5
+
+
+def test_get_followed_group_returns_404_when_not_following():
+    user = MagicMock()
+    user.id = uuid4()
+    with patch("pecha_api.plans.groups.groups_service.SessionLocal") as mock_session, patch(
+        "pecha_api.plans.groups.groups_service.validate_and_extract_user_details",
+        return_value=user,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.is_user_following_group",
+        return_value=False,
+    ):
+        _session_local_context(mock_session)
+        with pytest.raises(HTTPException) as exc:
+            get_followed_group(token="t", group_id=uuid4())
+    assert exc.value.status_code == status.HTTP_404_NOT_FOUND
+    assert exc.value.detail == GROUP_NOT_FOUND
+
+
+def test_get_followed_group_returns_404_when_group_missing():
+    user = MagicMock()
+    user.id = uuid4()
+    group_id = uuid4()
+    with patch("pecha_api.plans.groups.groups_service.SessionLocal") as mock_session, patch(
+        "pecha_api.plans.groups.groups_service.validate_and_extract_user_details",
+        return_value=user,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.is_user_following_group",
+        return_value=True,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_group_by_id",
+        return_value=None,
+    ):
+        _session_local_context(mock_session)
+        with pytest.raises(HTTPException) as exc:
+            get_followed_group(token="t", group_id=group_id)
+    assert exc.value.status_code == status.HTTP_404_NOT_FOUND
+    assert exc.value.detail == GROUP_NOT_FOUND
 
 
 def test_create_group_member_invite_creates_notification():

--- a/tests/plans/groups/test_groups_views.py
+++ b/tests/plans/groups/test_groups_views.py
@@ -363,3 +363,27 @@ def test_get_my_followed_groups():
         )
     assert response.status_code == status.HTTP_200_OK
     mock_service.assert_called_once_with(token="dummy", skip=0, limit=20)
+
+
+def test_get_my_followed_group_by_id():
+    group_id = uuid4()
+    group_summary = AuthorGroupSummaryDTO(
+        id=group_id,
+        slug="bodhichitta-authors",
+        is_public=True,
+        metadata=_metadata(),
+        tags=[],
+        follower_count=4,
+        member_count=2,
+    )
+    with patch(
+        "pecha_api.plans.groups.groups_views.get_followed_group",
+        return_value=group_summary,
+    ) as mock_service:
+        response = client.get(
+            f"/users/me/following/author/groups?group_id={group_id}&language=bo",
+            headers={"Authorization": "Bearer dummy"},
+        )
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["id"] == str(group_id)
+    mock_service.assert_called_once_with(token="dummy", group_id=group_id, language="bo")


### PR DESCRIPTION
- Introduced `is_user_following_group` to check if a user follows a specific group.
- Implemented `get_followed_group` to return group details if the user is following it, including follower count.
- Updated `get_my_followed_groups` endpoint to support fetching a specific followed group by ID.
- Enhanced tests to cover scenarios for retrieving followed group details, including cases for existing and non-existing groups.