### PR TITLE
Refactor duplicate plan validation in routines

### DIFF
--- a/pecha_api/routines/response_message.py
+++ b/pecha_api/routines/response_message.py
@@ -1,7 +1,7 @@
 ROUTINE_ALREADY_EXISTS = "Routine already exists for this user"
 INVALID_TIME_FORMAT = "Time must be in HH:MM 24-hour format (00:00 to 23:59)"
 SESSIONS_REQUIRED = "At least one session is required"
-DUPLICATE_PLAN = "A plan can only appear once across the entire routine"
+DUPLICATE_PLAN = "A plan can only appear once in a time block"
 ROUTINE_NOT_FOUND = "Routine not found"
 ROUTINE_FORBIDDEN = "Routine does not belong to this user"
 TIME_ALREADY_EXISTS = "A time block with this time already exists in the routine"

--- a/pecha_api/routines/routines_repository.py
+++ b/pecha_api/routines/routines_repository.py
@@ -46,20 +46,6 @@ def get_routine_by_id_and_user(
     )
 
 
-def get_existing_plan_source_ids(db: Session, routine_id: UUID) -> List[UUID]:
-    sessions = (
-        db.query(RoutineSession.source_id)
-        .join(RoutineTimeBlock, RoutineSession.time_block_id == RoutineTimeBlock.id)
-        .filter(
-            RoutineTimeBlock.routine_id == routine_id,
-            RoutineTimeBlock.deleted_at.is_(None),
-            RoutineSession.session_type == SessionType.PLAN,
-        )
-        .all()
-    )
-    return [s.source_id for s in sessions]
-
-
 def time_block_exists_for_routine(db: Session, routine_id: UUID, time: str) -> bool:
     return (
         db.query(RoutineTimeBlock)
@@ -158,21 +144,6 @@ def get_time_block_by_id(db: Session, time_block_id: UUID) -> Optional[RoutineTi
         )
         .first()
     )
-
-
-def get_existing_plan_source_ids_in_routine(db: Session, routine_id: UUID, exclude_time_block_id: Optional[UUID] = None) -> List[UUID]:
-    query = (
-        db.query(RoutineSession.source_id)
-        .join(RoutineTimeBlock, RoutineSession.time_block_id == RoutineTimeBlock.id)
-        .filter(
-            RoutineTimeBlock.routine_id == routine_id,
-            RoutineTimeBlock.deleted_at.is_(None),
-            RoutineSession.session_type == SessionType.PLAN,
-        )
-    )
-    if exclude_time_block_id:
-        query = query.filter(RoutineTimeBlock.id != exclude_time_block_id)
-    return [row[0] for row in query.all()]
 
 
 def get_time_block_by_routine_and_time(db: Session, routine_id: UUID, time: str, exclude_time_block_id: Optional[UUID] = None) -> Optional[RoutineTimeBlock]:

--- a/pecha_api/routines/routines_service.py
+++ b/pecha_api/routines/routines_service.py
@@ -23,8 +23,6 @@ from .routines_enums import SessionType
 from .routines_repository import (
     get_routine_by_user_id,
     get_routine_by_id_and_user,
-    get_existing_plan_source_ids,
-    get_existing_plan_source_ids_in_routine,
     time_block_exists_for_routine,
     get_time_block_by_id_and_routine,
     get_plan_source_ids_by_time_block_id,
@@ -99,43 +97,12 @@ def _validate_time_block_request(request: CreateTimeBlockRequest) -> None:
                 ).model_dump(),
             )
 
-    # Duplicate plan source_ids within the request
     plan_source_ids = [
         session.source_id
         for session in request.sessions
         if session.session_type == SessionType.PLAN
     ]
     if len(plan_source_ids) != len(set(plan_source_ids)):
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=ResponseError(
-                error=BAD_REQUEST, message=DUPLICATE_PLAN
-            ).model_dump(),
-        )
-
-
-def _check_duplicate_plans(db, routine_id: UUID, sessions: List) -> None:
-    existing_plan_ids = get_existing_plan_source_ids(db=db, routine_id=routine_id)
-    new_plan_ids = [s.source_id for s in sessions if s.session_type == SessionType.PLAN]
-    overlap = set(new_plan_ids) & set(existing_plan_ids)
-    if overlap:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=ResponseError(
-                error=BAD_REQUEST, message=DUPLICATE_PLAN
-            ).model_dump(),
-        )
-
-
-def _check_duplicate_plans_on_update(
-    db, routine_id: UUID, time_block_id: UUID, sessions: List
-) -> None:
-    existing_plan_ids = get_existing_plan_source_ids_in_routine(
-        db=db, routine_id=routine_id, exclude_time_block_id=time_block_id
-    )
-    new_plan_ids = [s.source_id for s in sessions if s.session_type == SessionType.PLAN]
-    overlap = set(new_plan_ids) & set(existing_plan_ids)
-    if overlap:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail=ResponseError(
@@ -221,13 +188,6 @@ def _validate_and_sync_update(
                 error=BAD_REQUEST, message=TIME_BLOCK_TIME_CONFLICT
             ).model_dump(),
         )
-
-    _check_duplicate_plans_on_update(
-        db=db,
-        routine_id=routine_id,
-        time_block_id=time_block_id,
-        sessions=request.sessions,
-    )
 
     _enroll_new_plans_on_update(
         db=db,
@@ -521,7 +481,6 @@ async def add_time_block_to_routine(
                 ).model_dump(),
             )
 
-        _check_duplicate_plans(db=db, routine_id=routine_id, sessions=request.sessions)
         _check_duplicate_time(db=db, routine_id=routine_id, time=request.time)
 
         # Save time block

--- a/tests/routines/test_routines_service.py
+++ b/tests/routines/test_routines_service.py
@@ -779,9 +779,6 @@ async def test_add_time_block_success():
         "pecha_api.routines.routines_service.get_routine_by_id_and_user",
         return_value=SimpleNamespace(id=routine_id, user_id=user_id),
     ), patch(
-        "pecha_api.routines.routines_service.get_existing_plan_source_ids",
-        return_value=[],
-    ), patch(
         "pecha_api.routines.routines_service.time_block_exists_for_routine",
         return_value=False,
     ), patch(
@@ -883,47 +880,6 @@ async def test_add_time_block_forbidden():
 
 
 @pytest.mark.asyncio
-async def test_add_time_block_duplicate_plan_across_routine():
-    user_id = uuid.uuid4()
-    routine_id = uuid.uuid4()
-    existing_plan_id = uuid.uuid4()
-
-    request = CreateTimeBlockRequest(
-        time="08:00",
-        time_int=800,
-        sessions=[
-            SessionRequest(
-                session_type=SessionType.PLAN,
-                source_id=existing_plan_id,
-                display_order=0,
-            )
-        ],
-    )
-
-    _, session_cm = _mock_session_with_db()
-
-    with patch(
-        "pecha_api.routines.routines_service.validate_and_extract_user_details",
-        return_value=SimpleNamespace(id=user_id),
-    ), patch(
-        "pecha_api.routines.routines_service.SessionLocal",
-        return_value=session_cm,
-    ), patch(
-        "pecha_api.routines.routines_service.get_routine_by_id_and_user",
-        return_value=SimpleNamespace(id=routine_id, user_id=user_id),
-    ), patch(
-        "pecha_api.routines.routines_service.get_existing_plan_source_ids",
-        return_value=[existing_plan_id],
-    ):
-        with pytest.raises(HTTPException) as exc_info:
-            await add_time_block_to_routine(
-                token="token123", routine_id=routine_id, request=request
-            )
-        assert exc_info.value.status_code == 422
-        assert exc_info.value.detail["message"] == DUPLICATE_PLAN
-
-
-@pytest.mark.asyncio
 async def test_add_time_block_duplicate_time():
     user_id = uuid.uuid4()
     routine_id = uuid.uuid4()
@@ -951,9 +907,6 @@ async def test_add_time_block_duplicate_time():
     ), patch(
         "pecha_api.routines.routines_service.get_routine_by_id_and_user",
         return_value=SimpleNamespace(id=routine_id, user_id=user_id),
-    ), patch(
-        "pecha_api.routines.routines_service.get_existing_plan_source_ids",
-        return_value=[],
     ), patch(
         "pecha_api.routines.routines_service.time_block_exists_for_routine",
         return_value=True,
@@ -1378,59 +1331,6 @@ async def test_update_time_block_service_time_conflict():
             )
         assert exc_info.value.status_code == 409
         assert exc_info.value.detail["message"] == TIME_BLOCK_TIME_CONFLICT
-
-
-@pytest.mark.asyncio
-async def test_update_time_block_duplicate_plan_across_routine():
-    user_id = uuid.uuid4()
-    routine_id = uuid.uuid4()
-    time_block_id = uuid.uuid4()
-    existing_plan_id = uuid.uuid4()
-
-    request = UpdateTimeBlockRequest(
-        time="14:00",
-        time_int=1400,
-        sessions=[
-            SessionRequest(
-                session_type=SessionType.PLAN,
-                source_id=existing_plan_id,
-                display_order=0,
-            )
-        ],
-    )
-
-    _, session_cm = _mock_session_with_db()
-
-    with patch(
-        "pecha_api.routines.routines_service.validate_and_extract_user_details",
-        return_value=SimpleNamespace(id=user_id),
-    ), patch(
-        "pecha_api.routines.routines_service.SessionLocal",
-        return_value=session_cm,
-    ), patch(
-        "pecha_api.routines.routines_service.get_routine_by_id_and_user",
-        return_value=SimpleNamespace(id=routine_id, user_id=user_id),
-    ), patch(
-        "pecha_api.routines.routines_service.get_time_block_by_id_and_routine",
-        return_value=SimpleNamespace(
-            id=time_block_id, routine_id=routine_id, time="12:00", time_int=1200
-        ),
-    ), patch(
-        "pecha_api.routines.routines_service.get_time_block_by_routine_and_time",
-        return_value=None,
-    ), patch(
-        "pecha_api.routines.routines_service.get_existing_plan_source_ids_in_routine",
-        return_value=[existing_plan_id],
-    ):
-        with pytest.raises(HTTPException) as exc_info:
-            await update_time_block_service(
-                token="token123",
-                routine_id=routine_id,
-                time_block_id=time_block_id,
-                request=request,
-            )
-        assert exc_info.value.status_code == 422
-        assert exc_info.value.detail["message"] == DUPLICATE_PLAN
 
 
 # ============================================================================

--- a/tests/routines/test_routines_views.py
+++ b/tests/routines/test_routines_views.py
@@ -299,49 +299,6 @@ def test_create_routine_invalid_time(authenticated_client):
         )
 
 
-def test_create_routine_duplicate_plan(authenticated_client):
-    duplicate_source_id = uuid.uuid4()
-
-    with patch(
-        "pecha_api.routines.routines_views.create_routine_with_time_block",
-        new_callable=AsyncMock,
-    ) as mock_create:
-        mock_create.side_effect = HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail={
-                "error": "Bad request",
-                "message": "A plan can only appear once across the entire routine",
-            },
-        )
-
-        response = authenticated_client.post(
-            "/routines",
-            json={
-                "time": "12:00",
-                "time_int": 1200,
-                "sessions": [
-                    {
-                        "session_type": "PLAN",
-                        "source_id": str(duplicate_source_id),
-                        "display_order": 0,
-                    },
-                    {
-                        "session_type": "PLAN",
-                        "source_id": str(duplicate_source_id),
-                        "display_order": 1,
-                    },
-                ],
-            },
-            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
-        )
-
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
-        assert (
-            response.json()["detail"]["message"]
-            == "A plan can only appear once across the entire routine"
-        )
-
-
 def test_create_time_block_success(authenticated_client):
     routine_id = uuid.uuid4()
     time_block_id = uuid.uuid4()
@@ -501,38 +458,6 @@ def test_create_time_block_duplicate_time(authenticated_client):
             response.json()["detail"]["message"]
             == "A time block with this time already exists in the routine"
         )
-
-
-def test_create_time_block_duplicate_plan(authenticated_client):
-    with patch(
-        "pecha_api.routines.routines_views.add_time_block_to_routine",
-        new_callable=AsyncMock,
-    ) as mock_add:
-        mock_add.side_effect = HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail={
-                "error": "Bad request",
-                "message": "A plan can only appear once across the entire routine",
-            },
-        )
-
-        response = authenticated_client.post(
-            f"/routines/{uuid.uuid4()}/time-blocks",
-            json={
-                "time": "08:00",
-                "time_int": 800,
-                "sessions": [
-                    {
-                        "session_type": "PLAN",
-                        "source_id": str(uuid.uuid4()),
-                        "display_order": 0,
-                    }
-                ],
-            },
-            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
-        )
-
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
 
 def test_delete_time_block_success(authenticated_client):
@@ -804,39 +729,6 @@ def test_update_time_block_time_conflict(authenticated_client):
 
         assert response.status_code == status.HTTP_409_CONFLICT
         assert response.json()["detail"]["message"] == "Time block with this time already exists"
-
-
-def test_update_time_block_duplicate_plan(authenticated_client):
-    routine_id = uuid.uuid4()
-    time_block_id = uuid.uuid4()
-
-    with patch(
-        "pecha_api.routines.routines_views.update_time_block_service",
-        new_callable=AsyncMock,
-    ) as mock_update:
-        mock_update.side_effect = HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail={"error": "Bad request", "message": "A plan can only appear once across the entire routine"},
-        )
-
-        response = authenticated_client.put(
-            f"/routines/{routine_id}/time-blocks/{time_block_id}",
-            json={
-                "time": "14:00",
-                "time_int": 1400,
-                "sessions": [
-                    {
-                        "session_type": "PLAN",
-                        "source_id": str(uuid.uuid4()),
-                        "display_order": 0,
-                    }
-                ],
-            },
-            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
-        )
-
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
-        assert response.json()["detail"]["message"] == "A plan can only appear once across the entire routine"
 
 
 def test_update_time_block_empty_sessions(authenticated_client):


### PR DESCRIPTION
- Updated the error message for duplicate plans to specify that a plan can only appear once in a time block.
- Removed unused functions related to checking existing plan source IDs from the routines repository and service.
- Adjusted tests to remove references to the removed functions and ensure they align with the updated validation logic.