### PR TITLE
Refactor duplicate plan handling in routines

### DIFF
--- a/pecha_api/routines/response_message.py
+++ b/pecha_api/routines/response_message.py
@@ -1,7 +1,7 @@
 ROUTINE_ALREADY_EXISTS = "Routine already exists for this user"
 INVALID_TIME_FORMAT = "Time must be in HH:MM 24-hour format (00:00 to 23:59)"
 SESSIONS_REQUIRED = "At least one session is required"
-DUPLICATE_PLAN = "A plan can only appear once across the entire routine"
+DUPLICATE_PLAN = "A plan can only appear once in a time block"
 DUPLICATE_RECITATION_COLLECTION = "A recitation collection can only appear once across the entire routine"
 ROUTINE_NOT_FOUND = "Routine not found"
 ROUTINE_FORBIDDEN = "Routine does not belong to this user"

--- a/pecha_api/routines/routines_repository.py
+++ b/pecha_api/routines/routines_repository.py
@@ -46,37 +46,6 @@ def get_routine_by_id_and_user(
     )
 
 
-def get_existing_plan_source_ids(db: Session, routine_id: UUID) -> List[UUID]:
-    sessions = (
-        db.query(RoutineSession.source_id)
-        .join(RoutineTimeBlock, RoutineSession.time_block_id == RoutineTimeBlock.id)
-        .filter(
-            RoutineTimeBlock.routine_id == routine_id,
-            RoutineTimeBlock.deleted_at.is_(None),
-            RoutineSession.session_type == SessionType.PLAN,
-        )
-        .all()
-    )
-    return [s.source_id for s in sessions]
-
-
-def get_existing_plan_source_ids_in_routine(
-    db: Session, routine_id: UUID, exclude_time_block_id: Optional[UUID] = None
-) -> List[UUID]:
-    query = (
-        db.query(RoutineSession.source_id)
-        .join(RoutineTimeBlock, RoutineSession.time_block_id == RoutineTimeBlock.id)
-        .filter(
-            RoutineTimeBlock.routine_id == routine_id,
-            RoutineTimeBlock.deleted_at.is_(None),
-            RoutineSession.session_type == SessionType.PLAN,
-        )
-    )
-    if exclude_time_block_id:
-        query = query.filter(RoutineTimeBlock.id != exclude_time_block_id)
-    return [row[0] for row in query.all()]
-
-
 def time_block_exists_for_routine(db: Session, routine_id: UUID, time: str) -> bool:
     return (
         db.query(RoutineTimeBlock)

--- a/pecha_api/routines/routines_service.py
+++ b/pecha_api/routines/routines_service.py
@@ -24,8 +24,6 @@ from .routines_enums import SessionType
 from .routines_repository import (
     get_routine_by_user_id,
     get_routine_by_id_and_user,
-    get_existing_plan_source_ids,
-    get_existing_plan_source_ids_in_routine,
     get_existing_collection_source_ids,
     get_existing_collection_source_ids_in_routine,
     get_collection_source_ids_by_time_block_id,
@@ -128,36 +126,6 @@ def _validate_time_block_request(request: CreateTimeBlockRequest) -> None:
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail=ResponseError(
                 error=BAD_REQUEST, message=DUPLICATE_RECITATION_COLLECTION
-            ).model_dump(),
-        )
-
-
-def _check_duplicate_plans(db, routine_id: UUID, sessions: List) -> None:
-    existing_plan_ids = get_existing_plan_source_ids(db=db, routine_id=routine_id)
-    new_plan_ids = [s.source_id for s in sessions if s.session_type == SessionType.PLAN]
-    overlap = set(new_plan_ids) & set(existing_plan_ids)
-    if overlap:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=ResponseError(
-                error=BAD_REQUEST, message=DUPLICATE_PLAN
-            ).model_dump(),
-        )
-
-
-def _check_duplicate_plans_on_update(
-    db, routine_id: UUID, time_block_id: UUID, sessions: List
-) -> None:
-    existing_plan_ids = get_existing_plan_source_ids_in_routine(
-        db=db, routine_id=routine_id, exclude_time_block_id=time_block_id
-    )
-    new_plan_ids = [s.source_id for s in sessions if s.session_type == SessionType.PLAN]
-    overlap = set(new_plan_ids) & set(existing_plan_ids)
-    if overlap:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=ResponseError(
-                error=BAD_REQUEST, message=DUPLICATE_PLAN
             ).model_dump(),
         )
 
@@ -271,13 +239,6 @@ def _validate_and_sync_update(
                 error=BAD_REQUEST, message=TIME_BLOCK_TIME_CONFLICT
             ).model_dump(),
         )
-
-    _check_duplicate_plans_on_update(
-        db=db,
-        routine_id=routine_id,
-        time_block_id=time_block_id,
-        sessions=request.sessions,
-    )
 
     _check_duplicate_collections_on_update(
         db=db,
@@ -645,7 +606,6 @@ async def add_time_block_to_routine(
                 ).model_dump(),
             )
 
-        _check_duplicate_plans(db=db, routine_id=routine_id, sessions=request.sessions)
         _check_duplicate_collections(db=db, routine_id=routine_id, sessions=request.sessions)
         _check_duplicate_time(db=db, routine_id=routine_id, time=request.time)
 

--- a/tests/routines/test_routines_service.py
+++ b/tests/routines/test_routines_service.py
@@ -946,9 +946,11 @@ async def test_add_time_block_duplicate_time():
 
 
 @pytest.mark.asyncio
-async def test_add_time_block_duplicate_plan_across_routine():
+async def test_add_time_block_allows_same_plan_in_different_time_block():
     user_id = uuid.uuid4()
     routine_id = uuid.uuid4()
+    time_block_id = uuid.uuid4()
+    session_id = uuid.uuid4()
     existing_plan_id = uuid.uuid4()
 
     request = CreateTimeBlockRequest(
@@ -965,6 +967,26 @@ async def test_add_time_block_duplicate_plan_across_routine():
 
     _, session_cm = _mock_session_with_db()
 
+    saved_time_block = SimpleNamespace(
+        id=time_block_id,
+        time="08:00",
+        time_int=800,
+        notification_enabled=True,
+    )
+    saved_session = SimpleNamespace(
+        id=session_id,
+        session_type=SessionType.PLAN,
+        source_id=existing_plan_id,
+        display_order=0,
+    )
+    mock_plan = SimpleNamespace(
+        id=existing_plan_id,
+        title="Morning Plan",
+        language=SimpleNamespace(value="EN"),
+        image_url="https://example.com/morning.jpg",
+        start_date=None,
+    )
+
     with patch(
         "pecha_api.routines.routines_service.validate_and_extract_user_details",
         return_value=SimpleNamespace(id=user_id),
@@ -975,15 +997,31 @@ async def test_add_time_block_duplicate_plan_across_routine():
         "pecha_api.routines.routines_service.get_routine_by_id_and_user",
         return_value=SimpleNamespace(id=routine_id, user_id=user_id),
     ), patch(
-        "pecha_api.routines.routines_service.get_existing_plan_source_ids",
-        return_value=[existing_plan_id],
+        "pecha_api.routines.routines_service.time_block_exists_for_routine",
+        return_value=False,
+    ), patch(
+        "pecha_api.routines.routines_service.RoutineTimeBlock",
+        return_value=MagicMock(),
+    ), patch(
+        "pecha_api.routines.routines_service.save_time_block",
+        return_value=saved_time_block,
+    ), patch(
+        "pecha_api.routines.routines_service.RoutineSession",
+        return_value=MagicMock(),
+    ), patch(
+        "pecha_api.routines.routines_service.save_sessions",
+        return_value=[saved_session],
+    ), patch(
+        "pecha_api.routines.routines_service.get_plans_by_ids",
+        return_value=[mock_plan],
     ):
-        with pytest.raises(HTTPException) as exc_info:
-            await add_time_block_to_routine(
-                token="token123", routine_id=routine_id, request=request
-            )
-        assert exc_info.value.status_code == 422
-        assert exc_info.value.detail["message"] == DUPLICATE_PLAN
+        result = await add_time_block_to_routine(
+            token="token123", routine_id=routine_id, request=request
+        )
+
+        assert result.id == time_block_id
+        assert len(result.sessions) == 1
+        assert result.sessions[0].source_id == existing_plan_id
 
 
 @pytest.mark.asyncio
@@ -1016,8 +1054,8 @@ async def test_add_time_block_duplicate_collection_across_routine():
         "pecha_api.routines.routines_service.get_routine_by_id_and_user",
         return_value=SimpleNamespace(id=routine_id, user_id=user_id),
     ), patch(
-        "pecha_api.routines.routines_service.get_existing_plan_source_ids",
-        return_value=[],
+        "pecha_api.routines.routines_service.time_block_exists_for_routine",
+        return_value=False,
     ), patch(
         "pecha_api.routines.routines_service.get_existing_collection_source_ids",
         return_value=[existing_collection_id],
@@ -1445,10 +1483,11 @@ async def test_update_time_block_service_time_conflict():
 
 
 @pytest.mark.asyncio
-async def test_update_time_block_service_duplicate_plan_across_routine():
+async def test_update_time_block_service_allows_same_plan_in_different_time_block():
     user_id = uuid.uuid4()
     routine_id = uuid.uuid4()
     time_block_id = uuid.uuid4()
+    session_id = uuid.uuid4()
     existing_plan_id = uuid.uuid4()
 
     request = UpdateTimeBlockRequest(
@@ -1465,6 +1504,33 @@ async def test_update_time_block_service_duplicate_plan_across_routine():
 
     _, session_cm = _mock_session_with_db()
 
+    saved_time_block = SimpleNamespace(
+        id=time_block_id,
+        time="14:00",
+        time_int=1400,
+        notification_enabled=True,
+    )
+    mock_time_block = SimpleNamespace(
+        id=time_block_id,
+        routine_id=routine_id,
+        time="12:00",
+        time_int=1200,
+        notification_enabled=True,
+    )
+    saved_session = SimpleNamespace(
+        id=session_id,
+        session_type=SessionType.PLAN,
+        source_id=existing_plan_id,
+        display_order=0,
+    )
+    mock_plan = SimpleNamespace(
+        id=existing_plan_id,
+        title="Updated Plan",
+        language=SimpleNamespace(value="EN"),
+        image_url="https://example.com/updated.jpg",
+        start_date=None,
+    )
+
     with patch(
         "pecha_api.routines.routines_service.validate_and_extract_user_details",
         return_value=SimpleNamespace(id=user_id),
@@ -1476,23 +1542,35 @@ async def test_update_time_block_service_duplicate_plan_across_routine():
         return_value=SimpleNamespace(id=routine_id, user_id=user_id),
     ), patch(
         "pecha_api.routines.routines_service.get_time_block_by_id_and_routine",
-        return_value=SimpleNamespace(id=time_block_id, routine_id=routine_id),
+        return_value=mock_time_block,
     ), patch(
         "pecha_api.routines.routines_service.get_time_block_by_routine_and_time",
         return_value=None,
     ), patch(
-        "pecha_api.routines.routines_service.get_existing_plan_source_ids_in_routine",
-        return_value=[existing_plan_id],
+        "pecha_api.routines.routines_service.delete_sessions_by_time_block_id",
+    ), patch(
+        "pecha_api.routines.routines_service.update_time_block_repo",
+        return_value=saved_time_block,
+    ), patch(
+        "pecha_api.routines.routines_service.build_session_models",
+        return_value=[MagicMock()],
+    ), patch(
+        "pecha_api.routines.routines_service.save_sessions",
+        return_value=[saved_session],
+    ), patch(
+        "pecha_api.routines.routines_service.get_plans_by_ids",
+        return_value=[mock_plan],
     ):
-        with pytest.raises(HTTPException) as exc_info:
-            await update_time_block_service(
-                token="token123",
-                routine_id=routine_id,
-                time_block_id=time_block_id,
-                request=request,
-            )
-        assert exc_info.value.status_code == 422
-        assert exc_info.value.detail["message"] == DUPLICATE_PLAN
+        result = await update_time_block_service(
+            token="token123",
+            routine_id=routine_id,
+            time_block_id=time_block_id,
+            request=request,
+        )
+
+        assert result.id == time_block_id
+        assert len(result.sessions) == 1
+        assert result.sessions[0].source_id == existing_plan_id
 
 
 @pytest.mark.asyncio
@@ -1531,9 +1609,6 @@ async def test_update_time_block_service_duplicate_collection_across_routine():
     ), patch(
         "pecha_api.routines.routines_service.get_time_block_by_routine_and_time",
         return_value=None,
-    ), patch(
-        "pecha_api.routines.routines_service.get_existing_plan_source_ids_in_routine",
-        return_value=[],
     ), patch(
         "pecha_api.routines.routines_service.get_existing_collection_source_ids_in_routine",
         return_value=[existing_collection_id],


### PR DESCRIPTION
- Updated the error message for duplicate plans to clarify that a plan can only appear once in a time block.
- Removed unused functions for retrieving existing plan source IDs from the routines repository and service.
- Adjusted tests to reflect the new logic allowing the same plan in different time blocks, ensuring proper validation and error handling.