### PR TITLE
Implement caching for text and segment retrieval functions

### DIFF
--- a/pecha_api/texts/segments/segments_cache_service.py
+++ b/pecha_api/texts/segments/segments_cache_service.py
@@ -44,8 +44,8 @@ async def set_segment_info_by_id_cache(segment_id: str = None, cache_type: Cache
     cache_time_out = config.get_int("CACHE_TEXT_TIMEOUT")
     await set_cache(hash_key=hashed_key, value=data, cache_time_out=cache_time_out)
 
-async def get_segment_root_mapping_by_id_cache(segment_id: str = None) -> SegmentRootMappingResponse:
-    payload = [segment_id]
+async def get_segment_root_mapping_by_id_cache(segment_id: str = None, cache_type: CacheType = None) -> SegmentRootMappingResponse:
+    payload = [segment_id, cache_type]
     hashed_key: str = Utils.generate_hash_key(payload = payload)
     cache_data: SegmentRootMappingResponse = await get_cache_data(hash_key = hashed_key)
     if cache_data and isinstance(cache_data, dict):
@@ -58,8 +58,8 @@ async def set_segment_root_mapping_by_id_cache(segment_id: str = None, cache_typ
     cache_time_out = config.get_int("CACHE_TEXT_TIMEOUT")
     await set_cache(hash_key=hashed_key, value=data, cache_time_out=cache_time_out)
 
-async def get_segment_translations_by_id_cache(segment_id: str = None) -> SegmentTranslationsResponse:
-    payload = [segment_id]
+async def get_segment_translations_by_id_cache(segment_id: str = None, cache_type: CacheType = None) -> SegmentTranslationsResponse:
+    payload = [segment_id, cache_type]
     hashed_key: str = Utils.generate_hash_key(payload = payload)
     cache_data: SegmentTranslationsResponse = await get_cache_data(hash_key = hashed_key)
     if cache_data and isinstance(cache_data, dict):
@@ -72,8 +72,8 @@ async def set_segment_translations_by_id_cache(segment_id: str = None, cache_typ
     cache_time_out = config.get_int("CACHE_TEXT_TIMEOUT")
     await set_cache(hash_key=hashed_key, value=data, cache_time_out=cache_time_out)
 
-async def get_segment_commentaries_by_id_cache(segment_id: str = None) -> SegmentCommentariesResponse:
-    payload = [segment_id]
+async def get_segment_commentaries_by_id_cache(segment_id: str = None, cache_type: CacheType = None) -> SegmentCommentariesResponse:
+    payload = [segment_id, cache_type]
     hashed_key: str = Utils.generate_hash_key(payload = payload)
     cache_data: SegmentCommentariesResponse = await get_cache_data(hash_key = hashed_key)
     if cache_data and isinstance(cache_data, dict):

--- a/pecha_api/texts/segments/segments_service.py
+++ b/pecha_api/texts/segments/segments_service.py
@@ -45,6 +45,10 @@ from .segments_cache_service import (
     get_segment_info_by_id_cache,
     get_segment_root_mapping_by_id_cache,
     set_segment_root_mapping_by_id_cache,
+    get_segment_translations_by_id_cache,
+    set_segment_translations_by_id_cache,
+    get_segment_commentaries_by_id_cache,
+    set_segment_commentaries_by_id_cache,
     get_segments_details_by_ids_cache,
     set_segments_details_by_ids_cache,
     delete_segments_details_by_ids_cache
@@ -119,6 +123,13 @@ async def get_translations_by_segment_id(segment_id: str) -> SegmentTranslations
     is_valid_segment = await SegmentUtils.validate_segment_exists(segment_id=segment_id)
     if not is_valid_segment:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ErrorConstants.SEGMENT_NOT_FOUND_MESSAGE)
+
+    cache_data = await get_segment_translations_by_id_cache(
+        segment_id=segment_id, cache_type=CacheType.SEGMENT_TRANSLATIONS
+    )
+    if cache_data:
+        return cache_data
+
     parent_segment = await get_segment_by_id(segment_id=segment_id)
     mapped_segments = await get_related_mapped_segments(parent_segment_id=segment_id)
     translations = await SegmentUtils.filter_segment_mapping_by_type_or_text_id(segments=mapped_segments, type="version")
@@ -129,7 +140,10 @@ async def get_translations_by_segment_id(segment_id: str) -> SegmentTranslations
         ),
         translations=translations
     )
-    
+
+    await set_segment_translations_by_id_cache(
+        segment_id=segment_id, cache_type=CacheType.SEGMENT_TRANSLATIONS, data=response
+    )
     return response
 
 async def get_commentaries_by_segment_id(
@@ -139,6 +153,13 @@ async def get_commentaries_by_segment_id(
     is_valid_segment = await SegmentUtils.validate_segment_exists(segment_id=segment_id)
     if not is_valid_segment:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ErrorConstants.SEGMENT_NOT_FOUND_MESSAGE)
+
+    cache_data = await get_segment_commentaries_by_id_cache(
+        segment_id=segment_id, cache_type=CacheType.SEGMENT_COMMENTARIES
+    )
+    if cache_data:
+        return cache_data
+
     parent_segment = await get_segment_by_id(segment_id=segment_id)
     mapped_segments = await get_related_mapped_segments(parent_segment_id=segment_id)
     commentaries = await SegmentUtils.filter_segment_mapping_by_type_or_text_id(segments=mapped_segments, type="commentary")
@@ -149,7 +170,10 @@ async def get_commentaries_by_segment_id(
         ),
         commentaries=commentaries
     )
-    
+
+    await set_segment_commentaries_by_id_cache(
+        segment_id=segment_id, cache_type=CacheType.SEGMENT_COMMENTARIES, data=response
+    )
     return response
 
 async def get_info_by_segment_id(segment_id: str) -> SegmentInfoResponse:
@@ -192,6 +216,13 @@ async def get_root_text_mapping_by_segment_id(segment_id: str) -> SegmentRootMap
     is_valid_segment = await SegmentUtils.validate_segment_exists(segment_id=segment_id)
     if not is_valid_segment:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ErrorConstants.SEGMENT_NOT_FOUND_MESSAGE)
+
+    cache_data = await get_segment_root_mapping_by_id_cache(
+        segment_id=segment_id, cache_type=CacheType.SEGMENT_ROOT_TEXT
+    )
+    if cache_data:
+        return cache_data
+
     parent_segment = await get_segment_by_id(segment_id=segment_id)
     parent_text = await TextUtils.get_text_details_by_id(text_id=parent_segment.text_id)
     mapped_segments = await get_related_mapped_segments(parent_segment_id=segment_id)
@@ -202,6 +233,10 @@ async def get_root_text_mapping_by_segment_id(segment_id: str) -> SegmentRootMap
             content=parent_segment.content
         ),
         segment_root_mapping=segment_root_mapping
+    )
+
+    await set_segment_root_mapping_by_id_cache(
+        segment_id=segment_id, cache_type=CacheType.SEGMENT_ROOT_TEXT, data=response
     )
     return response
 async def fetch_segments_by_text_id(text_id: str) -> List[SegmentDTO]:

--- a/pecha_api/texts/texts_service.py
+++ b/pecha_api/texts/texts_service.py
@@ -264,6 +264,12 @@ async def get_table_of_contents_by_text_id(text_id: str, language: str = None, s
     
     if language is None:
         language = get("DEFAULT_LANGUAGE")
+
+    cached_data: TableOfContentResponse = await get_table_of_contents_by_text_id_cache(
+        text_id=text_id, language=language, skip=skip, limit=limit, cache_type=CacheType.TEXT_TABLE_OF_CONTENTS
+    )
+    if cached_data is not None:
+        return cached_data
     
     is_valid_text: bool = await TextUtils.validate_text_exists(text_id=text_id)
     if not is_valid_text:
@@ -290,7 +296,11 @@ async def get_table_of_contents_by_text_id(text_id: str, language: str = None, s
             for content in table_of_contents
         ]
     )
-    
+
+    await set_table_of_contents_by_text_id_cache(
+        text_id=text_id, language=language, skip=skip, limit=limit,
+        data=response, cache_type=CacheType.TEXT_TABLE_OF_CONTENTS
+    )
     return response
 
 def _get_paginated_sections(sections: List[Section], skip: int, limit: int) -> List[Section]:
@@ -396,15 +406,15 @@ async def get_text_versions_by_group_id(text_id: str, language: str, skip: int, 
     if language is None:
         language = get("DEFAULT_LANGUAGE")
     
-    # cached_data: TextVersionResponse = await get_text_versions_by_group_id_cache(
-    #     text_id = text_id,
-    #     language = language,
-    #     skip = skip,
-    #     limit = limit,
-    #     cache_type = CacheType.TEXT_VERSIONS
-    # )
-    # if cached_data is not None:
-    #     return cached_data
+    cached_data: TextVersionResponse = await get_text_versions_by_group_id_cache(
+        text_id=text_id,
+        language=language,
+        skip=skip,
+        limit=limit,
+        cache_type=CacheType.TEXT_VERSIONS
+    )
+    if cached_data is not None:
+        return cached_data
 
     root_text = await TextUtils.get_text_detail_by_id(text_id=text_id)
     group_id = root_text.group_id

--- a/tests/plans/audio/test_tts_service.py
+++ b/tests/plans/audio/test_tts_service.py
@@ -115,6 +115,16 @@ def test_generate_tts_audio_routes_en_to_gemini(mock_get, mock_client_cls):
     mock_client.models.generate_content.assert_called_once()
 
 
+@patch("pecha_api.plans.audio.tts_service.get", return_value=None)
+def test_generate_tts_audio_raises_when_gemini_key_missing(mock_get):
+    with pytest.raises(RuntimeError, match="GEMINI_API_KEY is not configured"):
+        generate_tts_audio(
+            content="Hello world",
+            audio_type=PlanAudioType.RECITATION,
+            language="en",
+        )
+
+
 @patch("google.genai.Client")
 @patch("pecha_api.plans.audio.tts_service.get", return_value="test-api-key")
 def test_generate_tts_audio_raises_when_no_candidates(mock_get, mock_client_cls):

--- a/tests/plans/audio/test_tts_test_views.py
+++ b/tests/plans/audio/test_tts_test_views.py
@@ -50,3 +50,20 @@ def test_preview_tts_returns_400_for_validation_error(mock_generate):
 
     assert response.status_code == 400
     assert "Unsupported language" in response.json()["detail"]
+
+
+@patch(
+    "pecha_api.plans.audio.tts_test_views.generate_tts_audio",
+    side_effect=RuntimeError("GEMINI_API_KEY is not configured"),
+)
+def test_preview_tts_returns_502_for_runtime_error(mock_generate):
+    response = client.post(
+        "/preview",
+        json={
+            "text": "Hello",
+            "language": "en",
+        },
+    )
+
+    assert response.status_code == 502
+    assert "GEMINI_API_KEY" in response.json()["detail"]

--- a/tests/plans/image_upload/test_media_views.py
+++ b/tests/plans/image_upload/test_media_views.py
@@ -1,4 +1,5 @@
 import io
+import uuid
 import pytest
 from unittest.mock import patch, MagicMock, AsyncMock
 from fastapi.testclient import TestClient
@@ -7,13 +8,19 @@ from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from fastapi import UploadFile, HTTPException
 from starlette import status
 
-from pecha_api.plans.media.media_response_models import PlanUploadResponse, ImageUrlModel, TextImageUploadResponse
+from pecha_api.plans.media.media_response_models import (
+    PlanUploadResponse,
+    ImageUrlModel,
+    TextImageUploadResponse,
+    PlanDayAudioUploadResponse,
+)
 from pecha_api.plans.response_message import (
     IMAGE_UPLOAD_SUCCESS,
+    AUDIO_UPLOAD_SUCCESS,
     INVALID_FILE_FORMAT,
     FILE_TOO_LARGE,
     UNEXPECTED_ERROR_UPLOAD,
-    AUTHOR_NOT_FOUND
+    AUTHOR_NOT_FOUND,
 )
 
 
@@ -147,6 +154,20 @@ def mock_text_upload_service():
 
 
 @pytest.fixture
+def mock_day_audio_upload_service():
+    """Mock the day audio upload service with success response"""
+    with patch("pecha_api.plans.media.media_views.upload_plan_day_audio") as mock_func:
+        mock_func.return_value = PlanDayAudioUploadResponse(
+            plan_item_id="day-item-123",
+            audio_key="audio/day.mp3",
+            audio_url="https://audio.example.com/day.mp3",
+            duration_ms=120000,
+            message=AUDIO_UPLOAD_SUCCESS,
+        )
+        yield mock_func
+
+
+@pytest.fixture
 def media_app():
     """Create a minimal FastAPI app including only the media router."""
     from pecha_api.plans.media import media_views
@@ -265,6 +286,75 @@ class TestMediaUploadSuccess:
         response = authenticated_client.post("/cms/media/upload", files=files, headers=headers, params=params)
         
         assert response.status_code == status.HTTP_201_CREATED
+
+
+class TestDayAudioUploadSuccess:
+    """Test cases for successful day audio upload scenarios"""
+
+    def test_upload_day_audio_success(self, authenticated_client, mock_day_audio_upload_service):
+        day_id = str(uuid.uuid4())
+        files = [("file", ("day.mp3", b"fake_audio_content", "audio/mpeg"))]
+        headers = {"Authorization": f"Bearer {VALID_TOKEN}"}
+        data = {"duration_ms": "120000"}
+
+        response = authenticated_client.post(
+            "/cms/media/upload/day-audio",
+            files=files,
+            headers=headers,
+            params={"day_id": day_id},
+            data=data,
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        response_data = response.json()
+        assert response_data["message"] == AUDIO_UPLOAD_SUCCESS
+        assert response_data["audio_key"] == "audio/day.mp3"
+        assert response_data["audio_url"] == "https://audio.example.com/day.mp3"
+        assert response_data["duration_ms"] == 120000
+        mock_day_audio_upload_service.assert_called_once()
+
+    def test_upload_day_audio_without_duration(self, authenticated_client, mock_day_audio_upload_service):
+        day_id = str(uuid.uuid4())
+        files = [("file", ("day.mp3", b"fake_audio_content", "audio/mpeg"))]
+        headers = {"Authorization": f"Bearer {VALID_TOKEN}"}
+
+        response = authenticated_client.post(
+            "/cms/media/upload/day-audio",
+            files=files,
+            headers=headers,
+            params={"day_id": day_id},
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        mock_day_audio_upload_service.assert_called_once()
+
+
+class TestDayAudioUploadValidation:
+    """Test cases for day audio upload validation"""
+
+    def test_upload_day_audio_missing_day_id(self, authenticated_client):
+        files = [("file", ("day.mp3", b"fake_audio_content", "audio/mpeg"))]
+        headers = {"Authorization": f"Bearer {VALID_TOKEN}"}
+
+        response = authenticated_client.post(
+            "/cms/media/upload/day-audio",
+            files=files,
+            headers=headers,
+        )
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+    def test_upload_day_audio_missing_file(self, authenticated_client):
+        day_id = str(uuid.uuid4())
+        headers = {"Authorization": f"Bearer {VALID_TOKEN}"}
+
+        response = authenticated_client.post(
+            "/cms/media/upload/day-audio",
+            headers=headers,
+            params={"day_id": day_id},
+        )
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
 
 class TestTextMediaUploadSuccess:

--- a/tests/segments/test_segments_service.py
+++ b/tests/segments/test_segments_service.py
@@ -96,6 +96,87 @@ async def test_get_translations_by_segment_id_segment_not_found():
         assert excinfo.value.status_code == 404
         assert excinfo.value.detail == ErrorConstants.SEGMENT_NOT_FOUND_MESSAGE
 
+
+@pytest.mark.asyncio
+async def test_get_translations_by_segment_id_cache_hit():
+    segment_id = "efb26a06-f373-450b-ba57-e7a8d4dd5b64"
+    cached_response = SegmentTranslationsResponse(
+        parent_segment=ParentSegment(segment_id=segment_id, content="cached content"),
+        translations=[],
+    )
+
+    with patch(
+        "pecha_api.texts.segments.segments_service.SegmentUtils.validate_segment_exists",
+        new_callable=AsyncMock,
+        return_value=True,
+    ), patch(
+        "pecha_api.texts.segments.segments_service.get_segment_translations_by_id_cache",
+        new_callable=AsyncMock,
+        return_value=cached_response,
+    ) as mock_get_cache, patch(
+        "pecha_api.texts.segments.segments_service.get_segment_by_id",
+        new_callable=AsyncMock,
+    ) as mock_get_segment:
+        response = await get_translations_by_segment_id(segment_id=segment_id)
+
+        assert response == cached_response
+        mock_get_cache.assert_awaited_once()
+        mock_get_segment.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_translations_by_segment_id_cache_miss_sets_cache():
+    segment_id = "efb26a06-f373-450b-ba57-e7a8d4dd5b64"
+    segment = SegmentDTO(
+        id=segment_id,
+        text_id=segment_id,
+        content="parent content",
+        mapping=[],
+        type=SegmentType.SOURCE,
+    )
+    translations = [
+        SegmentTranslation(
+            segment_id=f"{segment_id}_1",
+            text_id=segment_id,
+            title="Title 1",
+            source="source 1",
+            language="en",
+            content="translation content",
+        )
+    ]
+
+    with patch(
+        "pecha_api.texts.segments.segments_service.SegmentUtils.validate_segment_exists",
+        new_callable=AsyncMock,
+        return_value=True,
+    ), patch(
+        "pecha_api.texts.segments.segments_service.get_segment_translations_by_id_cache",
+        new_callable=AsyncMock,
+        return_value=None,
+    ), patch(
+        "pecha_api.texts.segments.segments_service.get_segment_by_id",
+        new_callable=AsyncMock,
+        return_value=segment,
+    ), patch(
+        "pecha_api.texts.segments.segments_service.get_related_mapped_segments",
+        new_callable=AsyncMock,
+        return_value=translations,
+    ), patch(
+        "pecha_api.texts.segments.segments_service.SegmentUtils.filter_segment_mapping_by_type_or_text_id",
+        new_callable=AsyncMock,
+        return_value=translations,
+    ), patch(
+        "pecha_api.texts.segments.segments_service.set_segment_translations_by_id_cache",
+        new_callable=AsyncMock,
+    ) as mock_set_cache:
+        response = await get_translations_by_segment_id(segment_id=segment_id)
+
+        assert response.parent_segment.segment_id == segment_id
+        assert response.translations == translations
+        mock_set_cache.assert_awaited_once()
+        assert mock_set_cache.await_args.kwargs["segment_id"] == segment_id
+
+
 @pytest.mark.asyncio
 async def test_create_new_segment():
     """
@@ -362,6 +443,83 @@ async def test_get_commentaries_by_segment_id_not_found():
             await get_commentaries_by_segment_id(segment_id=segment_id)
         assert exc_info.value.status_code == 404
         assert exc_info.value.detail == ErrorConstants.SEGMENT_NOT_FOUND_MESSAGE
+
+
+@pytest.mark.asyncio
+async def test_get_commentaries_by_segment_id_cache_hit():
+    segment_id = "efb26a06-f373-450b-ba57-e7a8d4dd5b64"
+    cached_response = SegmentCommentariesResponse(
+        parent_segment=ParentSegment(segment_id=segment_id, content="cached content"),
+        commentaries=[],
+    )
+
+    with patch(
+        "pecha_api.texts.segments.segments_service.SegmentUtils.validate_segment_exists",
+        new_callable=AsyncMock,
+        return_value=True,
+    ), patch(
+        "pecha_api.texts.segments.segments_service.get_segment_commentaries_by_id_cache",
+        new_callable=AsyncMock,
+        return_value=cached_response,
+    ) as mock_get_cache, patch(
+        "pecha_api.texts.segments.segments_service.get_segment_by_id",
+        new_callable=AsyncMock,
+    ) as mock_get_segment:
+        response = await get_commentaries_by_segment_id(segment_id=segment_id)
+
+        assert response == cached_response
+        mock_get_cache.assert_awaited_once()
+        mock_get_segment.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_commentaries_by_segment_id_cache_miss_sets_cache():
+    parent_segment_id = "efb26a06-f373-450b-ba57-e7a8d4dd5b64"
+    repo_parent_segment = type("Segment", (), {
+        "id": parent_segment_id,
+        "content": "parent_segment_content",
+    })()
+    filtered_commentaries = [
+        SegmentCommentry(
+            text_id="text_id_1",
+            title="title_1",
+            segments=[
+                MappedSegmentDTO(segment_id="id_1", content="content_1"),
+            ],
+            language="en",
+            count=1,
+        )
+    ]
+
+    with patch(
+        "pecha_api.texts.segments.segments_service.SegmentUtils.validate_segment_exists",
+        new_callable=AsyncMock,
+        return_value=True,
+    ), patch(
+        "pecha_api.texts.segments.segments_service.get_segment_commentaries_by_id_cache",
+        new_callable=AsyncMock,
+        return_value=None,
+    ), patch(
+        "pecha_api.texts.segments.segments_service.get_segment_by_id",
+        new_callable=AsyncMock,
+        return_value=repo_parent_segment,
+    ), patch(
+        "pecha_api.texts.segments.segments_service.get_related_mapped_segments",
+        new_callable=AsyncMock,
+        return_value=[],
+    ), patch(
+        "pecha_api.texts.segments.segments_service.SegmentUtils.filter_segment_mapping_by_type_or_text_id",
+        new_callable=AsyncMock,
+        return_value=filtered_commentaries,
+    ), patch(
+        "pecha_api.texts.segments.segments_service.set_segment_commentaries_by_id_cache",
+        new_callable=AsyncMock,
+    ) as mock_set_cache:
+        response = await get_commentaries_by_segment_id(segment_id=parent_segment_id)
+
+        assert response.commentaries == filtered_commentaries
+        mock_set_cache.assert_awaited_once()
+        assert mock_set_cache.await_args.kwargs["segment_id"] == parent_segment_id
 
 @pytest.mark.asyncio
 async def test_get_infos_by_segment_id_success():

--- a/tests/texts/test_texts_service.py
+++ b/tests/texts/test_texts_service.py
@@ -989,7 +989,9 @@ async def test_get_text_details_by_text_id_with_text_id_content_id_segment_id_su
         ]
     )
 
-    with patch("pecha_api.texts.texts_service._validate_text_detail_request", new_callable=AsyncMock, return_value=True), \
+    with patch("pecha_api.texts.texts_service.get_text_details_cache", new_callable=AsyncMock, return_value=None), \
+        patch("pecha_api.texts.texts_service.set_text_details_cache", new_callable=AsyncMock, return_value=None), \
+        patch("pecha_api.texts.texts_service._validate_text_detail_request", new_callable=AsyncMock, return_value=True), \
         patch("pecha_api.texts.texts_service.TextUtils.get_text_detail_by_id", new_callable=AsyncMock, return_value=mock_text_detail), \
         patch("pecha_api.texts.texts_service.get_table_of_content_by_content_id", new_callable=AsyncMock, return_value=mock_table_of_content), \
         patch("pecha_api.texts.texts_service.SegmentUtils.get_mapped_segment_content_for_table_of_content", new_callable=AsyncMock, return_value=mock_mapped_table_of_content):
@@ -1096,7 +1098,9 @@ async def test_get_text_details_by_text_id_with_text_id_content_id_segment_id_pr
         ]
     )
 
-    with patch("pecha_api.texts.texts_service._validate_text_detail_request", new_callable=AsyncMock, return_value=True), \
+    with patch("pecha_api.texts.texts_service.get_text_details_cache", new_callable=AsyncMock, return_value=None), \
+        patch("pecha_api.texts.texts_service.set_text_details_cache", new_callable=AsyncMock, return_value=None), \
+        patch("pecha_api.texts.texts_service._validate_text_detail_request", new_callable=AsyncMock, return_value=True), \
         patch("pecha_api.texts.texts_service.TextUtils.get_text_detail_by_id", new_callable=AsyncMock, return_value=mock_text_detail), \
         patch("pecha_api.texts.texts_service.get_table_of_content_by_content_id", new_callable=AsyncMock, return_value=mock_table_of_content), \
         patch("pecha_api.texts.texts_service.SegmentUtils.get_mapped_segment_content_for_table_of_content", new_callable=AsyncMock, return_value=mock_mapped_table_of_content):
@@ -1197,7 +1201,9 @@ async def test_get_text_details_by_text_id_with_segment_id_only_success():
         ]
     )
 
-    with patch("pecha_api.texts.texts_service._validate_text_detail_request", new_callable=AsyncMock, return_value=True), \
+    with patch("pecha_api.texts.texts_service.get_text_details_cache", new_callable=AsyncMock, return_value=None), \
+        patch("pecha_api.texts.texts_service.set_text_details_cache", new_callable=AsyncMock, return_value=None), \
+        patch("pecha_api.texts.texts_service._validate_text_detail_request", new_callable=AsyncMock, return_value=True), \
         patch("pecha_api.texts.texts_service.TextUtils.get_text_detail_by_id", new_callable=AsyncMock, return_value=mock_text_detail), \
         patch("pecha_api.texts.texts_service.find_table_of_content_with_segment", new_callable=AsyncMock, return_value=mock_table_of_contents[0]), \
         patch("pecha_api.texts.texts_service.SegmentUtils.get_mapped_segment_content_for_table_of_content", new_callable=AsyncMock, return_value=mock_mapped_table_of_contents):
@@ -1334,7 +1340,9 @@ async def test_get_text_details_by_text_id_with_content_id_only_success():
         ]
     )
 
-    with patch("pecha_api.texts.texts_service._validate_text_detail_request", new_callable=AsyncMock, return_value=True), \
+    with patch("pecha_api.texts.texts_service.get_text_details_cache", new_callable=AsyncMock, return_value=None), \
+        patch("pecha_api.texts.texts_service.set_text_details_cache", new_callable=AsyncMock, return_value=None), \
+        patch("pecha_api.texts.texts_service._validate_text_detail_request", new_callable=AsyncMock, return_value=True), \
         patch("pecha_api.texts.texts_service.TextUtils.get_text_detail_by_id", new_callable=AsyncMock, return_value=mock_text_detail), \
         patch(
             "pecha_api.texts.texts_service.get_first_segment_table_of_content",
@@ -1369,7 +1377,186 @@ async def test_get_text_details_by_text_id_with_content_id_only_success():
         assert len(section.segments) + len(section.sections[0].segments) == 2
         assert section.segments[0].segment_id == "segment_id_1"
         assert response.pagination_direction == PaginationDirection.NEXT
-    
+
+
+@pytest.mark.asyncio
+async def test_get_text_details_by_text_id_cache_hit():
+    text_id = "text_id_1"
+    content_id = "content_id_1"
+    cached_response = DetailTableOfContentResponse(
+        text_detail=TextDTO(
+            id=text_id,
+            title="cached title",
+            language="bo",
+            group_id="group_id_1",
+            type="version",
+            is_published=False,
+            created_date="created_date",
+            updated_date="updated_date",
+            published_date="published_date",
+            published_by="published_by",
+            categories=[],
+            views=0,
+        ),
+        content=DetailTableOfContent(
+            id=content_id,
+            text_id=text_id,
+            sections=[],
+        ),
+        size=2,
+        pagination_direction=PaginationDirection.NEXT,
+        current_segment_position=1,
+        total_segments=3,
+    )
+
+    with patch(
+        "pecha_api.texts.texts_service.get_text_details_cache",
+        new_callable=AsyncMock,
+        return_value=cached_response,
+    ) as mock_get_cache, patch(
+        "pecha_api.texts.texts_service._validate_text_detail_request",
+        new_callable=AsyncMock,
+    ) as mock_validate:
+        response = await get_text_details_by_text_id(
+            text_id=text_id,
+            text_details_request=TextDetailsRequest(
+                content_id=content_id,
+                segment_id="segment_id_1",
+                size=2,
+                direction=PaginationDirection.NEXT,
+            ),
+        )
+
+        assert response == cached_response
+        mock_get_cache.assert_awaited_once()
+        mock_validate.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_text_details_by_text_id_cache_miss_sets_cache():
+    text_id = "text_id_1"
+    content_id = "content_id_1"
+    mock_text_detail = TextDTO(
+        id=text_id,
+        title="text_title",
+        language="bo",
+        group_id="group_id_1",
+        type="version",
+        is_published=False,
+        created_date="created_date",
+        updated_date="updated_date",
+        published_date="published_date",
+        published_by="published_by",
+        categories=[],
+        views=0,
+    )
+    mock_table_of_content = TableOfContent(
+        id=content_id,
+        text_id=text_id,
+        type=TableOfContentType.TEXT,
+        sections=[
+            Section(
+                id="section_id_1",
+                title="section_title",
+                section_number=1,
+                parent_id="parent_id_1",
+                segments=[
+                    TextSegment(segment_id="segment_id_1", segment_number=1),
+                ],
+                sections=[],
+                created_date="created_date",
+                updated_date="updated_date",
+                published_date="published_date",
+            )
+        ],
+    )
+    mock_mapped_table_of_content = DetailTableOfContent(
+        id=content_id,
+        text_id=text_id,
+        sections=[
+            DetailSection(
+                id="section_id_1",
+                title="section_title",
+                section_number=1,
+                parent_id="parent_id_1",
+                segments=[
+                    DetailTextSegment(
+                        segment_id="segment_id_1",
+                        segment_number=1,
+                        content="segment_content_1",
+                        translation=None,
+                    )
+                ],
+                sections=[],
+                created_date="created_date",
+                updated_date="updated_date",
+                published_date="published_date",
+            )
+        ],
+    )
+
+    with patch("pecha_api.texts.texts_service.get_text_details_cache", new_callable=AsyncMock, return_value=None), \
+        patch("pecha_api.texts.texts_service.set_text_details_cache", new_callable=AsyncMock) as mock_set_cache, \
+        patch("pecha_api.texts.texts_service._validate_text_detail_request", new_callable=AsyncMock, return_value=True), \
+        patch("pecha_api.texts.texts_service.TextUtils.get_text_detail_by_id", new_callable=AsyncMock, return_value=mock_text_detail), \
+        patch("pecha_api.texts.texts_service.get_table_of_content_by_content_id", new_callable=AsyncMock, return_value=mock_table_of_content), \
+        patch("pecha_api.texts.texts_service.SegmentUtils.get_mapped_segment_content_for_table_of_content", new_callable=AsyncMock, return_value=mock_mapped_table_of_content):
+        await get_text_details_by_text_id(
+            text_id=text_id,
+            text_details_request=TextDetailsRequest(
+                content_id=content_id,
+                segment_id="segment_id_1",
+                size=1,
+                direction=PaginationDirection.NEXT,
+            ),
+        )
+
+        mock_set_cache.assert_awaited_once()
+        assert mock_set_cache.await_args.kwargs["text_id"] == text_id
+        assert mock_set_cache.await_args.kwargs["content_id"] == content_id
+        assert mock_set_cache.await_args.kwargs["skip"] == "segment_id_1"
+
+
+@pytest.mark.asyncio
+async def test_get_table_of_contents_by_text_id_cache_hit():
+    text_id = "text_id_1"
+    cached_response = TableOfContentResponse(
+        text_detail=TextDTO(
+            id=text_id,
+            title="cached title",
+            language="en",
+            group_id="group_id_1",
+            type="version",
+            is_published=True,
+            created_date="created_date",
+            updated_date="updated_date",
+            published_date="published_date",
+            published_by="published_by",
+            categories=[],
+            views=0,
+        ),
+        contents=[],
+    )
+
+    with patch(
+        "pecha_api.texts.texts_service.get_table_of_contents_by_text_id_cache",
+        new_callable=AsyncMock,
+        return_value=cached_response,
+    ) as mock_get_cache, patch(
+        "pecha_api.texts.texts_service.TextUtils.validate_text_exists",
+        new_callable=AsyncMock,
+    ) as mock_validate:
+        response = await get_table_of_contents_by_text_id(
+            text_id=text_id,
+            language="en",
+            skip=0,
+            limit=10,
+        )
+
+        assert response == cached_response
+        mock_get_cache.assert_awaited_once()
+        mock_validate.assert_not_awaited()
+
 
 @pytest.mark.asyncio
 async def test_get_table_of_content_by_sheet_id_success():

--- a/tests/texts/test_texts_service.py
+++ b/tests/texts/test_texts_service.py
@@ -584,8 +584,8 @@ async def test_get_table_of_contents_by_text_id_success():
     ]
 
     with patch("pecha_api.texts.texts_service.TextUtils.validate_text_exists", new_callable=AsyncMock, return_value=True), \
-        patch("pecha_api.texts.texts_service.get_table_of_contents_by_text_id_cache", new_callable=MagicMock, return_value=None),\
-        patch("pecha_api.texts.texts_service.set_table_of_contents_by_text_id_cache", new_callable=MagicMock, return_value=None),\
+        patch("pecha_api.texts.texts_service.get_table_of_contents_by_text_id_cache", new_callable=AsyncMock, return_value=None),\
+        patch("pecha_api.texts.texts_service.set_table_of_contents_by_text_id_cache", new_callable=AsyncMock, return_value=None),\
         patch("pecha_api.texts.texts_service.TextUtils.get_text_detail_by_id", new_callable=AsyncMock, return_value=mock_text_detail), \
         patch("pecha_api.texts.texts_service.get_texts_by_group_id", new_callable=AsyncMock, return_value=mock_group_texts), \
         patch("pecha_api.texts.texts_service.get_contents_by_id", new_callable=AsyncMock, return_value=table_of_contents):
@@ -690,8 +690,8 @@ async def test_get_table_of_contents_by_text_id_success_language_is_none():
     ]
 
     with patch("pecha_api.texts.texts_service.TextUtils.validate_text_exists", new_callable=AsyncMock, return_value=True), \
-        patch("pecha_api.texts.texts_service.get_table_of_contents_by_text_id_cache", new_callable=MagicMock, return_value=None),\
-        patch("pecha_api.texts.texts_service.set_table_of_contents_by_text_id_cache", new_callable=MagicMock, return_value=None),\
+        patch("pecha_api.texts.texts_service.get_table_of_contents_by_text_id_cache", new_callable=AsyncMock, return_value=None),\
+        patch("pecha_api.texts.texts_service.set_table_of_contents_by_text_id_cache", new_callable=AsyncMock, return_value=None),\
         patch("pecha_api.texts.texts_service.TextUtils.get_text_detail_by_id", new_callable=AsyncMock, return_value=mock_text_detail), \
         patch("pecha_api.texts.texts_service.get_texts_by_group_id", new_callable=AsyncMock, return_value=mock_group_texts), \
         patch("pecha_api.texts.texts_service.get_contents_by_id", new_callable=AsyncMock, return_value=table_of_contents):
@@ -779,8 +779,8 @@ async def test_get_table_of_contents_by_text_id_root_text_is_none():
     ]
 
     with patch("pecha_api.texts.texts_service.TextUtils.validate_text_exists", new_callable=AsyncMock, return_value=True), \
-        patch("pecha_api.texts.texts_service.get_table_of_contents_by_text_id_cache", new_callable=MagicMock, return_value=None),\
-        patch("pecha_api.texts.texts_service.set_table_of_contents_by_text_id_cache", new_callable=MagicMock, return_value=None),\
+        patch("pecha_api.texts.texts_service.get_table_of_contents_by_text_id_cache", new_callable=AsyncMock, return_value=None),\
+        patch("pecha_api.texts.texts_service.set_table_of_contents_by_text_id_cache", new_callable=AsyncMock, return_value=None),\
         patch("pecha_api.texts.texts_service.TextUtils.get_text_detail_by_id", new_callable=AsyncMock, return_value=mock_text_detail), \
         patch("pecha_api.texts.texts_service.get_texts_by_group_id", new_callable=AsyncMock, return_value=mock_group_texts), \
         patch("pecha_api.texts.texts_service.get_contents_by_id", new_callable=AsyncMock, return_value=table_of_contents), \


### PR DESCRIPTION
- Added caching logic to `get_table_of_contents_by_text_id` and `get_text_versions_by_group_id` in `texts_service.py` to improve performance.
- Updated segment caching functions in `segments_cache_service.py` to accept cache type as a parameter.
- Enhanced `get_translations_by_segment_id` and `get_commentaries_by_segment_id` in `segments_service.py` to utilize caching.
- Modified tests in `test_texts_service.py` to use AsyncMock for caching functions.