### PR TITLE
Add subtask audio upload and deletion endpoints

### DIFF
--- a/pecha_api/plans/audio/plan_subtask_audio_service.py
+++ b/pecha_api/plans/audio/plan_subtask_audio_service.py
@@ -1,0 +1,129 @@
+import os
+import uuid
+from typing import Optional
+from uuid import UUID
+
+from fastapi import HTTPException, UploadFile
+from starlette import status
+
+from pecha_api.config import get
+from pecha_api.db.database import SessionLocal
+from pecha_api.plans.audio.plan_day_audio_service import _validate_audio_file
+from pecha_api.plans.auth.plan_auth_models import ResponseError
+from pecha_api.plans.authors.plan_authors_service import validate_cms_author_details
+from pecha_api.plans.cms.cms_plans_repository import get_plan_by_id
+from pecha_api.plans.items.plan_items_repository import get_plan_item_by_id
+from pecha_api.plans.media.media_response_models import SubTaskAudioUploadResponse
+from pecha_api.plans.response_message import (
+    BAD_REQUEST,
+    PLAN_DAY_NOT_FOUND,
+    PLAN_NOT_FOUND,
+    SUB_TASK_NOT_FOUND,
+    SUBTASK_AUDIO_UPLOAD_SUCCESS,
+    TASK_NOT_FOUND,
+)
+from pecha_api.plans.shared.permissions import require_can_edit_content
+from pecha_api.plans.tasks.plan_tasks_repository import get_task_by_id
+from pecha_api.plans.tasks.sub_tasks.plan_sub_tasks_models import PlanSubTask
+from pecha_api.plans.tasks.sub_tasks.plan_sub_tasks_repository import get_sub_task_by_subtask_id
+from pecha_api.uploads.S3_utils import delete_file, generate_presigned_access_url, upload_file
+
+
+def _get_author_sub_task(db, sub_task_id: UUID, current_author) -> PlanSubTask:
+    subtask = get_sub_task_by_subtask_id(db=db, id=sub_task_id)
+    if not subtask:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=ResponseError(error=BAD_REQUEST, message=SUB_TASK_NOT_FOUND).model_dump(),
+        )
+
+    task = get_task_by_id(db=db, task_id=subtask.task_id)
+    if not task:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=ResponseError(error=BAD_REQUEST, message=TASK_NOT_FOUND).model_dump(),
+        )
+
+    plan_item = get_plan_item_by_id(db=db, day_id=task.plan_item_id)
+    if not plan_item:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=ResponseError(error=BAD_REQUEST, message=PLAN_DAY_NOT_FOUND).model_dump(),
+        )
+
+    plan = get_plan_by_id(db=db, plan_id=plan_item.plan_id)
+    if not plan:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=ResponseError(error=BAD_REQUEST, message=PLAN_NOT_FOUND).model_dump(),
+        )
+
+    require_can_edit_content(
+        db=db,
+        group_id=plan.group_id,
+        author=current_author,
+        content_status=plan.status,
+    )
+    return subtask
+
+
+def upload_plan_subtask_audio(
+    token: str,
+    sub_task_id: UUID,
+    file: UploadFile,
+    duration_ms: Optional[int] = None,
+) -> SubTaskAudioUploadResponse:
+    _validate_audio_file(file)
+    file_extension = os.path.splitext(file.filename.lower())[1] if file.filename else ""
+
+    with SessionLocal() as db:
+        current_author = validate_cms_author_details(token=token)
+        subtask = _get_author_sub_task(db=db, sub_task_id=sub_task_id, current_author=current_author)
+
+        unique_id = str(uuid.uuid4())
+        s3_key = f"audio/plan_subtasks/{subtask.task_id}/{sub_task_id}/{unique_id}{file_extension}"
+
+        file.file.seek(0)
+        upload_file(
+            bucket_name=get("AWS_BUCKET_NAME"),
+            s3_key=s3_key,
+            file=file,
+        )
+
+        if subtask.audio_url:
+            delete_file(subtask.audio_url)
+
+        subtask.audio_url = s3_key
+        subtask.duration = str(duration_ms) if duration_ms is not None else None
+        subtask.updated_by = current_author.email
+        db.commit()
+
+        task_id_str = str(subtask.task_id)
+        sub_task_id_str = str(sub_task_id)
+        audio_key = s3_key
+        stored_duration_ms = duration_ms
+
+    audio_url = generate_presigned_access_url(
+        bucket_name=get("AWS_BUCKET_NAME"),
+        s3_key=audio_key,
+    )
+    return SubTaskAudioUploadResponse(
+        sub_task_id=sub_task_id_str,
+        task_id=task_id_str,
+        audio_key=audio_key,
+        audio_url=audio_url,
+        duration_ms=stored_duration_ms,
+        message=SUBTASK_AUDIO_UPLOAD_SUCCESS,
+    )
+
+
+def delete_plan_subtask_audio(token: str, sub_task_id: UUID) -> None:
+    with SessionLocal() as db:
+        current_author = validate_cms_author_details(token=token)
+        subtask = _get_author_sub_task(db=db, sub_task_id=sub_task_id, current_author=current_author)
+        if subtask.audio_url:
+            delete_file(subtask.audio_url)
+        subtask.audio_url = None
+        subtask.duration = None
+        subtask.updated_by = current_author.email
+        db.commit()

--- a/pecha_api/plans/media/media_response_models.py
+++ b/pecha_api/plans/media/media_response_models.py
@@ -32,6 +32,15 @@ class PlanDayAudioUploadResponse(BaseModel):
     message: str
 
 
+class SubTaskAudioUploadResponse(BaseModel):
+    sub_task_id: str
+    task_id: str
+    audio_key: str
+    audio_url: str
+    duration_ms: Optional[int] = None
+    message: str
+
+
 class Error(BaseModel):
     error: str
     message: str

--- a/pecha_api/plans/media/media_views.py
+++ b/pecha_api/plans/media/media_views.py
@@ -2,8 +2,9 @@ from fastapi import APIRouter, UploadFile, File, status, Depends, Query, Form
 from uuid import UUID
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from .media_services import upload_plan_image, upload_series_image, upload_text_image
-from .media_response_models import PlanUploadResponse, TextImageUploadResponse, PlanDayAudioUploadResponse
+from .media_response_models import PlanUploadResponse, TextImageUploadResponse, PlanDayAudioUploadResponse, SubTaskAudioUploadResponse
 from pecha_api.plans.audio.plan_day_audio_service import upload_plan_day_audio
+from pecha_api.plans.audio.plan_subtask_audio_service import upload_plan_subtask_audio
 from typing import Annotated, Optional
 
 oauth2_scheme = HTTPBearer()
@@ -47,6 +48,21 @@ async def upload_day_audio(
     return upload_plan_day_audio(
         token=authentication_credential.credentials,
         day_id=day_id,
+        file=file,
+        duration_ms=duration_ms,
+    )
+
+
+@media_router.post("/upload/subtask-audio", status_code=status.HTTP_201_CREATED)
+async def upload_subtask_audio(
+    authentication_credential: Annotated[HTTPAuthorizationCredentials, Depends(oauth2_scheme)],
+    sub_task_id: UUID = Query(...),
+    duration_ms: Optional[int] = Form(None),
+    file: UploadFile = File(...),
+) -> SubTaskAudioUploadResponse:
+    return upload_plan_subtask_audio(
+        token=authentication_credential.credentials,
+        sub_task_id=sub_task_id,
         file=file,
         duration_ms=duration_ms,
     )

--- a/pecha_api/plans/response_message.py
+++ b/pecha_api/plans/response_message.py
@@ -20,6 +20,7 @@ EMAIL_VERIFICATION_PENDING_STATUS = "EMAIL VERIFICATION PENDING"
 
 IMAGE_UPLOAD_SUCCESS = "Image uploaded successfully"
 AUDIO_UPLOAD_SUCCESS = "Day audio uploaded successfully"
+SUBTASK_AUDIO_UPLOAD_SUCCESS = "Sub task audio uploaded successfully"
 AUDIO_ASSIGN_SUCCESS = "Day audio assigned successfully"
 AUDIO_KEY_NOT_FOUND = "Audio not found or you do not have access to this audio key"
 INVALID_AUDIO_FILE_FORMAT = "Invalid audio format. Allowed: MP3, M4A, WAV, AAC, OGG"

--- a/pecha_api/plans/tasks/sub_tasks/plan_sub_tasks_views.py
+++ b/pecha_api/plans/tasks/sub_tasks/plan_sub_tasks_views.py
@@ -6,6 +6,7 @@ from starlette import status
 
 from pecha_api.plans.tasks.sub_tasks.plan_sub_tasks_response_model import (SubTaskRequest, SubTaskResponse, UpdateSubTaskRequest, SubTaskOrderRequest, SubTaskOrderResponse)
 from pecha_api.plans.tasks.sub_tasks.plan_sub_tasks_services import (create_new_sub_tasks, update_sub_task_by_task_id, change_subtask_order_service)
+from pecha_api.plans.audio.plan_subtask_audio_service import delete_plan_subtask_audio
 
 sub_tasks_router = APIRouter(
     prefix="/cms/sub-tasks",
@@ -44,4 +45,15 @@ async def change_subtask_order(
         token=authentication_credential.credentials,
         task_id=task_id,
         update_subtask_order=update_subtask_order_request,
+    )
+
+
+@sub_tasks_router.delete("/{sub_task_id}/audio", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_subtask_audio(
+    sub_task_id: UUID,
+    authentication_credential: Annotated[HTTPAuthorizationCredentials, Depends(oauth2_scheme)],
+):
+    return delete_plan_subtask_audio(
+        token=authentication_credential.credentials,
+        sub_task_id=sub_task_id,
     )

--- a/tests/plans/audio/test_plan_subtask_audio_service.py
+++ b/tests/plans/audio/test_plan_subtask_audio_service.py
@@ -1,0 +1,149 @@
+import io
+import pytest
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+from fastapi import HTTPException, UploadFile
+
+from pecha_api.plans.platform_enums import PlatformRole
+from pecha_api.plans.audio.plan_subtask_audio_service import (
+    delete_plan_subtask_audio,
+    upload_plan_subtask_audio,
+)
+
+
+@patch("pecha_api.plans.audio.plan_subtask_audio_service.generate_presigned_access_url", return_value="https://audio.url")
+@patch("pecha_api.plans.audio.plan_subtask_audio_service.delete_file")
+@patch("pecha_api.plans.audio.plan_subtask_audio_service.upload_file", return_value="audio/key.mp3")
+@patch("pecha_api.plans.audio.plan_subtask_audio_service._get_author_sub_task")
+@patch("pecha_api.plans.audio.plan_subtask_audio_service.validate_cms_author_details")
+@patch("pecha_api.plans.audio.plan_subtask_audio_service.SessionLocal")
+def test_upload_plan_subtask_audio_success(
+    mock_session,
+    mock_validate,
+    mock_get_subtask,
+    mock_upload,
+    mock_delete_file,
+    mock_presign,
+):
+    sub_task_id = uuid4()
+    task_id = uuid4()
+
+    author = MagicMock()
+    author.email = "author@test.com"
+    author.platform_role = PlatformRole.SUPER_ADMIN
+    mock_validate.return_value = author
+
+    subtask = MagicMock()
+    subtask.task_id = task_id
+    subtask.audio_url = "audio/plan_subtasks/old.mp3"
+    mock_get_subtask.return_value = subtask
+
+    mock_db = MagicMock()
+    mock_session.return_value.__enter__ = MagicMock(return_value=mock_db)
+    mock_session.return_value.__exit__ = MagicMock(return_value=False)
+
+    file = MagicMock(spec=UploadFile)
+    file.filename = "subtask.mp3"
+    file.content_type = "audio/mpeg"
+    file.size = 1024
+    file.file = io.BytesIO(b"audio")
+
+    response = upload_plan_subtask_audio(
+        token="token",
+        sub_task_id=sub_task_id,
+        file=file,
+        duration_ms=45000,
+    )
+
+    mock_delete_file.assert_called_once_with("audio/plan_subtasks/old.mp3")
+    mock_upload.assert_called_once()
+    mock_db.commit.assert_called_once()
+    assert response.sub_task_id == str(sub_task_id)
+    assert response.task_id == str(task_id)
+    assert response.audio_url == "https://audio.url"
+    assert response.duration_ms == 45000
+    assert response.message == "Sub task audio uploaded successfully"
+
+
+@patch("pecha_api.plans.audio.plan_subtask_audio_service.delete_file")
+@patch("pecha_api.plans.audio.plan_subtask_audio_service._get_author_sub_task")
+@patch("pecha_api.plans.audio.plan_subtask_audio_service.validate_cms_author_details")
+@patch("pecha_api.plans.audio.plan_subtask_audio_service.SessionLocal")
+def test_delete_plan_subtask_audio_success(
+    mock_session,
+    mock_validate,
+    mock_get_subtask,
+    mock_delete_file,
+):
+    sub_task_id = uuid4()
+
+    author = MagicMock()
+    author.email = "author@test.com"
+    mock_validate.return_value = author
+
+    subtask = MagicMock()
+    subtask.audio_url = "audio/plan_subtasks/task/sub.mp3"
+    mock_get_subtask.return_value = subtask
+
+    mock_db = MagicMock()
+    mock_session.return_value.__enter__ = MagicMock(return_value=mock_db)
+    mock_session.return_value.__exit__ = MagicMock(return_value=False)
+
+    delete_plan_subtask_audio(token="token", sub_task_id=sub_task_id)
+
+    mock_delete_file.assert_called_once_with("audio/plan_subtasks/task/sub.mp3")
+    assert subtask.audio_url is None
+    assert subtask.duration is None
+    mock_db.commit.assert_called_once()
+
+
+@patch("pecha_api.plans.audio.plan_subtask_audio_service._get_author_sub_task")
+@patch("pecha_api.plans.audio.plan_subtask_audio_service.validate_cms_author_details")
+@patch("pecha_api.plans.audio.plan_subtask_audio_service.SessionLocal")
+def test_delete_plan_subtask_audio_without_existing_audio(
+    mock_session,
+    mock_validate,
+    mock_get_subtask,
+):
+    mock_validate.return_value = MagicMock(email="author@test.com")
+
+    subtask = MagicMock()
+    subtask.audio_url = None
+    mock_get_subtask.return_value = subtask
+
+    mock_db = MagicMock()
+    mock_session.return_value.__enter__ = MagicMock(return_value=mock_db)
+    mock_session.return_value.__exit__ = MagicMock(return_value=False)
+
+    delete_plan_subtask_audio(token="token", sub_task_id=uuid4())
+
+    assert subtask.audio_url is None
+    assert subtask.duration is None
+    mock_db.commit.assert_called_once()
+
+
+@patch("pecha_api.plans.audio.plan_subtask_audio_service._get_author_sub_task")
+@patch("pecha_api.plans.audio.plan_subtask_audio_service.validate_cms_author_details")
+@patch("pecha_api.plans.audio.plan_subtask_audio_service.SessionLocal")
+def test_upload_plan_subtask_audio_not_found(
+    mock_session,
+    mock_validate,
+    mock_get_subtask,
+):
+    mock_validate.return_value = MagicMock(email="author@test.com")
+    mock_get_subtask.side_effect = HTTPException(status_code=404, detail={"error": "bad", "message": "Sub task not found"})
+    mock_session.return_value.__enter__ = MagicMock(return_value=MagicMock())
+    mock_session.return_value.__exit__ = MagicMock(return_value=False)
+
+    file = MagicMock(spec=UploadFile)
+    file.filename = "subtask.mp3"
+    file.size = 1024
+    file.file = io.BytesIO(b"audio")
+
+    with pytest.raises(HTTPException) as exc:
+        upload_plan_subtask_audio(
+            token="token",
+            sub_task_id=uuid4(),
+            file=file,
+        )
+    assert exc.value.status_code == 404

--- a/tests/plans/audio/test_tts_service.py
+++ b/tests/plans/audio/test_tts_service.py
@@ -116,6 +116,39 @@ def test_generate_tts_audio_routes_en_to_gemini(mock_get, mock_client_cls):
 
 
 @patch("google.genai.Client")
+@patch("pecha_api.plans.audio.tts_service.get", return_value=None)
+def test_generate_tts_audio_raises_when_api_key_missing(mock_get, mock_client_cls):
+    with pytest.raises(RuntimeError, match="GEMINI_API_KEY is not configured"):
+        generate_tts_audio(
+            content="Hello world",
+            audio_type=PlanAudioType.RECITATION,
+            language="en",
+        )
+    mock_client_cls.assert_not_called()
+
+
+@patch("google.genai.Client")
+@patch("pecha_api.plans.audio.tts_service.get", return_value="test-api-key")
+def test_generate_tts_audio_raises_when_no_inline_data(mock_get, mock_client_cls):
+    inline_data = MagicMock(data=None, mime_type="audio/L16;rate=24000")
+    part = MagicMock(inline_data=inline_data)
+    content = MagicMock(parts=[part])
+    candidate = MagicMock(content=content)
+    response = MagicMock(candidates=[candidate])
+
+    mock_client = MagicMock()
+    mock_client.models.generate_content.return_value = response
+    mock_client_cls.return_value = mock_client
+
+    with pytest.raises(RuntimeError, match="no audio data"):
+        generate_tts_audio(
+            content="Hello world",
+            audio_type=PlanAudioType.RECITATION,
+            language="en",
+        )
+
+
+@patch("google.genai.Client")
 @patch("pecha_api.plans.audio.tts_service.get", return_value="test-api-key")
 def test_generate_tts_audio_raises_when_no_candidates(mock_get, mock_client_cls):
     mock_client = MagicMock()

--- a/tests/plans/audio/test_tts_service.py
+++ b/tests/plans/audio/test_tts_service.py
@@ -1,4 +1,3 @@
-import struct
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -10,6 +9,28 @@ from pecha_api.plans.audio.tts_service import (
     generate_tts_audio,
 )
 from pecha_api.plans.plans_enums import PlanAudioType
+
+_EN_RECITATION = {
+    "content": "Hello world",
+    "audio_type": PlanAudioType.RECITATION,
+    "language": "en",
+}
+
+
+def _configure_gemini_client(mock_client_cls, response):
+    mock_client = MagicMock()
+    mock_client.models.generate_content.return_value = response
+    mock_client_cls.return_value = mock_client
+    return mock_client
+
+
+def _build_gemini_audio_response(*, audio_data=b"\x00\x01\x02\x03", inline_data=None):
+    if inline_data is None:
+        inline_data = MagicMock(data=audio_data, mime_type="audio/L16;rate=24000")
+    part = MagicMock(inline_data=inline_data)
+    content = MagicMock(parts=[part])
+    candidate = MagicMock(content=content)
+    return MagicMock(candidates=[candidate])
 
 
 def test_normalize_language():
@@ -94,36 +115,19 @@ def test_generate_tts_audio_passes_voice_name_to_monlam(mock_monlam):
 @patch("pecha_api.plans.audio.tts_service.get", return_value="test-api-key")
 def test_generate_tts_audio_routes_en_to_gemini(mock_get, mock_client_cls):
     audio_data = b"\x00\x01\x02\x03"
-    inline_data = MagicMock(data=audio_data, mime_type="audio/L16;rate=24000")
-    part = MagicMock(inline_data=inline_data)
-    content = MagicMock(parts=[part])
-    candidate = MagicMock(content=content)
-    response = MagicMock(candidates=[candidate])
+    _configure_gemini_client(mock_client_cls, _build_gemini_audio_response(audio_data=audio_data))
 
-    mock_client = MagicMock()
-    mock_client.models.generate_content.return_value = response
-    mock_client_cls.return_value = mock_client
-
-    result = generate_tts_audio(
-        content="Hello world",
-        audio_type=PlanAudioType.RECITATION,
-        language="en",
-    )
+    result = generate_tts_audio(**_EN_RECITATION)
 
     assert result[:4] == b"RIFF"
     assert result.endswith(audio_data)
-    mock_client.models.generate_content.assert_called_once()
 
 
 @patch("google.genai.Client")
 @patch("pecha_api.plans.audio.tts_service.get", return_value=None)
 def test_generate_tts_audio_raises_when_api_key_missing(mock_get, mock_client_cls):
     with pytest.raises(RuntimeError, match="GEMINI_API_KEY is not configured"):
-        generate_tts_audio(
-            content="Hello world",
-            audio_type=PlanAudioType.RECITATION,
-            language="en",
-        )
+        generate_tts_audio(**_EN_RECITATION)
     mock_client_cls.assert_not_called()
 
 
@@ -131,33 +135,19 @@ def test_generate_tts_audio_raises_when_api_key_missing(mock_get, mock_client_cl
 @patch("pecha_api.plans.audio.tts_service.get", return_value="test-api-key")
 def test_generate_tts_audio_raises_when_no_inline_data(mock_get, mock_client_cls):
     inline_data = MagicMock(data=None, mime_type="audio/L16;rate=24000")
-    part = MagicMock(inline_data=inline_data)
-    content = MagicMock(parts=[part])
-    candidate = MagicMock(content=content)
-    response = MagicMock(candidates=[candidate])
-
-    mock_client = MagicMock()
-    mock_client.models.generate_content.return_value = response
-    mock_client_cls.return_value = mock_client
+    _configure_gemini_client(
+        mock_client_cls,
+        _build_gemini_audio_response(inline_data=inline_data),
+    )
 
     with pytest.raises(RuntimeError, match="no audio data"):
-        generate_tts_audio(
-            content="Hello world",
-            audio_type=PlanAudioType.RECITATION,
-            language="en",
-        )
+        generate_tts_audio(**_EN_RECITATION)
 
 
 @patch("google.genai.Client")
 @patch("pecha_api.plans.audio.tts_service.get", return_value="test-api-key")
 def test_generate_tts_audio_raises_when_no_candidates(mock_get, mock_client_cls):
-    mock_client = MagicMock()
-    mock_client.models.generate_content.return_value = MagicMock(candidates=[])
-    mock_client_cls.return_value = mock_client
+    _configure_gemini_client(mock_client_cls, MagicMock(candidates=[]))
 
     with pytest.raises(RuntimeError, match="no audio data"):
-        generate_tts_audio(
-            content="Hello world",
-            audio_type=PlanAudioType.RECITATION,
-            language="en",
-        )
+        generate_tts_audio(**_EN_RECITATION)

--- a/tests/plans/audio/test_tts_test_views.py
+++ b/tests/plans/audio/test_tts_test_views.py
@@ -37,6 +37,23 @@ def test_preview_tts_returns_wav(mock_generate):
 
 @patch(
     "pecha_api.plans.audio.tts_test_views.generate_tts_audio",
+    side_effect=RuntimeError("TTS generation returned no audio data"),
+)
+def test_preview_tts_returns_502_for_runtime_error(mock_generate):
+    response = client.post(
+        "/preview",
+        json={
+            "text": "Hello",
+            "language": "en",
+        },
+    )
+
+    assert response.status_code == 502
+    assert "no audio data" in response.json()["detail"]
+
+
+@patch(
+    "pecha_api.plans.audio.tts_test_views.generate_tts_audio",
     side_effect=ValueError("Unsupported language for TTS: zh"),
 )
 def test_preview_tts_returns_400_for_validation_error(mock_generate):

--- a/tests/plans/audio/test_tts_test_views.py
+++ b/tests/plans/audio/test_tts_test_views.py
@@ -1,11 +1,14 @@
 from unittest.mock import patch
 
-import pytest
 from fastapi.testclient import TestClient
 
 from pecha_api.app import api
 
 client = TestClient(api)
+
+
+def _post_tts_preview(**payload):
+    return client.post("/preview", json={"text": "Hello", **payload})
 
 
 def test_tts_test_view_returns_html():
@@ -20,14 +23,7 @@ def test_tts_test_view_returns_html():
     return_value=b"RIFF" + b"\x00" * 40,
 )
 def test_preview_tts_returns_wav(mock_generate):
-    response = client.post(
-        "/preview",
-        json={
-            "text": "Hello",
-            "language": "en",
-            "type": "TEXT_READING",
-        },
-    )
+    response = _post_tts_preview(language="en", type="TEXT_READING")
 
     assert response.status_code == 200
     assert response.headers["content-type"] == "audio/wav"
@@ -40,13 +36,7 @@ def test_preview_tts_returns_wav(mock_generate):
     side_effect=RuntimeError("TTS generation returned no audio data"),
 )
 def test_preview_tts_returns_502_for_runtime_error(mock_generate):
-    response = client.post(
-        "/preview",
-        json={
-            "text": "Hello",
-            "language": "en",
-        },
-    )
+    response = _post_tts_preview(language="en")
 
     assert response.status_code == 502
     assert "no audio data" in response.json()["detail"]
@@ -57,13 +47,7 @@ def test_preview_tts_returns_502_for_runtime_error(mock_generate):
     side_effect=ValueError("Unsupported language for TTS: zh"),
 )
 def test_preview_tts_returns_400_for_validation_error(mock_generate):
-    response = client.post(
-        "/preview",
-        json={
-            "text": "Hello",
-            "language": "zh",
-        },
-    )
+    response = _post_tts_preview(language="zh")
 
     assert response.status_code == 400
     assert "Unsupported language" in response.json()["detail"]

--- a/tests/plans/conftest.py
+++ b/tests/plans/conftest.py
@@ -31,6 +31,7 @@ _CMS_MODULES = (
     "pecha_api.plans.series.series_service",
     "pecha_api.plans.audio.cms_plan_audio_service",
     "pecha_api.plans.audio.plan_day_audio_service",
+    "pecha_api.plans.audio.plan_subtask_audio_service",
     "pecha_api.plans.dashboard.dashboard_service",
 )
 

--- a/tests/plans/image_upload/test_media_views.py
+++ b/tests/plans/image_upload/test_media_views.py
@@ -267,6 +267,40 @@ class TestMediaUploadSuccess:
         assert response.status_code == status.HTTP_201_CREATED
 
 
+class TestSubtaskAudioUploadSuccess:
+    def test_upload_subtask_audio_success(self, authenticated_client):
+        sub_task_id = "550e8400-e29b-41d4-a716-446655440000"
+        mock_response = MagicMock()
+        mock_response.sub_task_id = sub_task_id
+        mock_response.task_id = "660e8400-e29b-41d4-a716-446655440001"
+        mock_response.audio_key = "audio/plan_subtasks/task/sub.mp3"
+        mock_response.audio_url = "https://audio.url"
+        mock_response.duration_ms = 30000
+        mock_response.message = "Sub task audio uploaded successfully"
+
+        with patch(
+            "pecha_api.plans.media.media_views.upload_plan_subtask_audio",
+            return_value=mock_response,
+        ) as mock_upload:
+            files = [TestDataFactory.create_test_file(filename="subtask.mp3", content_type="audio/mpeg")]
+            headers = {"Authorization": f"Bearer {VALID_TOKEN}"}
+            params = {"sub_task_id": sub_task_id}
+
+            response = authenticated_client.post(
+                "/cms/media/upload/subtask-audio",
+                files=files,
+                headers=headers,
+                params=params,
+            )
+
+            assert response.status_code == status.HTTP_201_CREATED
+            response_data = response.json()
+            assert response_data["sub_task_id"] == sub_task_id
+            assert response_data["audio_url"] == "https://audio.url"
+            assert response_data["duration_ms"] == 30000
+            mock_upload.assert_called_once()
+
+
 class TestTextMediaUploadSuccess:
     """Test cases for successful text media upload scenarios"""
 

--- a/tests/plans/sub_tasks/test_plan_sub_tasks_views.py
+++ b/tests/plans/sub_tasks/test_plan_sub_tasks_views.py
@@ -17,6 +17,7 @@ from pecha_api.plans.tasks.sub_tasks.plan_sub_tasks_views import (
     create_sub_tasks,
     update_sub_task,
     change_subtask_order,
+    delete_subtask_audio,
 )
 
 
@@ -404,3 +405,24 @@ async def test_change_subtask_order_update_failed():
         assert exc_info.value.status_code == 400
         assert "failed" in exc_info.value.detail.lower()
         assert mock_change_order.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_delete_subtask_audio_success():
+    sub_task_id = uuid.uuid4()
+    creds = _Creds(token="valid_token")
+
+    with patch(
+        "pecha_api.plans.tasks.sub_tasks.plan_sub_tasks_views.delete_plan_subtask_audio",
+        return_value=None,
+    ) as mock_delete:
+        resp = await delete_subtask_audio(
+            sub_task_id=sub_task_id,
+            authentication_credential=creds,
+        )
+
+        assert resp is None
+        mock_delete.assert_called_once_with(
+            token="valid_token",
+            sub_task_id=sub_task_id,
+        )

--- a/tests/segments/test_segments_service.py
+++ b/tests/segments/test_segments_service.py
@@ -1,7 +1,6 @@
 import uuid
 from unittest.mock import AsyncMock, patch, MagicMock
 from fastapi import HTTPException
-import uuid
 import pytest
 from pecha_api.texts.segments.segments_service import (
     create_new_segment,
@@ -46,6 +45,36 @@ from pecha_api.texts.texts_response_models import TextDTO
 
 from pecha_api.error_contants import ErrorConstants
 from pecha_api.cache.cache_enums import CacheType
+
+
+def _mock_source_segment(*, segment_id="seg_1", text_id="text_id_1", content="content"):
+    return type("Segment", (), {
+        "id": segment_id,
+        "text_id": text_id,
+        "content": content,
+        "mapping": [],
+        "type": SegmentType.SOURCE,
+    })()
+
+
+def _text_dto(text_id="text_id_1", **overrides) -> TextDTO:
+    defaults = {
+        "id": text_id,
+        "title": "title",
+        "language": "bo",
+        "type": "root_text",
+        "group_id": "group_id_1",
+        "is_published": True,
+        "created_date": "2021-01-01",
+        "updated_date": "2021-01-01",
+        "published_date": "2021-01-01",
+        "published_by": "admin",
+        "categories": [],
+        "views": 0,
+    }
+    defaults.update(overrides)
+    return TextDTO(**defaults)
+
 
 @pytest.mark.asyncio
 async def test_get_translations_by_segment_id_success():
@@ -444,27 +473,6 @@ async def test_get_infos_by_segment_id_invalid_segment_id():
 async def test_get_root_text_mapping_by_segment_id_success():
     segment_id = "seg_1"
     text_id = "text_id_1"
-    mock_segment = type("Segment", (), {
-        "id": segment_id,
-        "text_id": text_id,
-        "content": "root segment content",
-        "mapping": [],
-        "type": SegmentType.SOURCE,
-    })()
-    mock_text_detail = TextDTO(
-        id=text_id,
-        title="title",
-        language="bo",
-        type="root_text",
-        group_id="group_id_1",
-        is_published=True,
-        created_date="2021-01-01",
-        updated_date="2021-01-01",
-        published_date="2021-01-01",
-        published_by="admin",
-        categories=[],
-        views=0,
-    )
     mock_root_mapping = [
         SegmentRootMapping(
             text_id=text_id,
@@ -486,11 +494,15 @@ async def test_get_root_text_mapping_by_segment_id_success():
     ), patch(
         "pecha_api.texts.segments.segments_service.get_segment_by_id",
         new_callable=AsyncMock,
-        return_value=mock_segment,
+        return_value=_mock_source_segment(
+            segment_id=segment_id,
+            text_id=text_id,
+            content="root segment content",
+        ),
     ), patch(
         "pecha_api.texts.segments.segments_service.TextUtils.get_text_details_by_id",
         new_callable=AsyncMock,
-        return_value=mock_text_detail,
+        return_value=_text_dto(text_id),
     ), patch(
         "pecha_api.texts.segments.segments_service.get_related_mapped_segments",
         new_callable=AsyncMock,

--- a/tests/segments/test_segments_service.py
+++ b/tests/segments/test_segments_service.py
@@ -33,6 +33,7 @@ from pecha_api.texts.segments.segments_response_models import (
     Resources,
     SegmentRootMappingResponse,
     SegmentRootMapping,
+    MappedSegmentResponseDTO,
     MappedSegmentDTO,
     SegmentUpdateRequest,
     SegmentUpdate
@@ -440,6 +441,74 @@ async def test_get_infos_by_segment_id_invalid_segment_id():
 
 
 @pytest.mark.asyncio
+async def test_get_root_text_mapping_by_segment_id_success():
+    segment_id = "seg_1"
+    text_id = "text_id_1"
+    mock_segment = type("Segment", (), {
+        "id": segment_id,
+        "text_id": text_id,
+        "content": "root segment content",
+        "mapping": [],
+        "type": SegmentType.SOURCE,
+    })()
+    mock_text_detail = TextDTO(
+        id=text_id,
+        title="title",
+        language="bo",
+        type="root_text",
+        group_id="group_id_1",
+        is_published=True,
+        created_date="2021-01-01",
+        updated_date="2021-01-01",
+        published_date="2021-01-01",
+        published_by="admin",
+        categories=[],
+        views=0,
+    )
+    mock_root_mapping = [
+        SegmentRootMapping(
+            text_id=text_id,
+            title="Mapped Root",
+            language="bo",
+            segments=[
+                MappedSegmentResponseDTO(
+                    segment_id="mapped-seg-1",
+                    content="mapped content",
+                )
+            ],
+        )
+    ]
+
+    with patch(
+        "pecha_api.texts.segments.segments_service.SegmentUtils.validate_segment_exists",
+        new_callable=AsyncMock,
+        return_value=True,
+    ), patch(
+        "pecha_api.texts.segments.segments_service.get_segment_by_id",
+        new_callable=AsyncMock,
+        return_value=mock_segment,
+    ), patch(
+        "pecha_api.texts.segments.segments_service.TextUtils.get_text_details_by_id",
+        new_callable=AsyncMock,
+        return_value=mock_text_detail,
+    ), patch(
+        "pecha_api.texts.segments.segments_service.get_related_mapped_segments",
+        new_callable=AsyncMock,
+        return_value=[],
+    ), patch(
+        "pecha_api.texts.segments.segments_service.SegmentUtils.get_segment_root_mapping_details",
+        new_callable=AsyncMock,
+        return_value=mock_root_mapping,
+    ):
+        result = await get_root_text_mapping_by_segment_id(segment_id=segment_id)
+
+    assert isinstance(result, SegmentRootMappingResponse)
+    assert result.parent_segment.segment_id == segment_id
+    assert result.parent_segment.content == "root segment content"
+    assert result.segment_root_mapping == mock_root_mapping
+
+
+@pytest.mark.asyncio
 async def test_get_root_text_mapping_by_segment_id_invalid_segment_id():
     segment_id = "efb26a06-f373-450b-ba57-e7a8d4dd5b64"
     with patch("pecha_api.texts.segments.segments_service.SegmentUtils.validate_segment_exists", new_callable=AsyncMock, return_value=False):
@@ -563,29 +632,6 @@ async def test_get_info_by_segment_id_cache_hit():
             resources=Resources(sheets=0),
         )
     )
-    
-    mock_text_detail = TextDTO(
-        id="text_id_1",
-        title="title",
-        language="en",
-        type="commentary",
-        group_id="group_id_1",
-        is_published=True,
-        created_date="created_date",
-        updated_date="updated_date",
-        published_date="published_date",
-        published_by="published_by",
-        categories=["categories"],
-        views=0
-    )
-    
-    mock_segment = type('Segment', (), {
-        'id': segment_id,
-        'text_id': "text_id_1",
-        'content': "content",
-        'mapping': [],
-        'type': SegmentType.SOURCE
-    })()
 
     with patch(
         "pecha_api.texts.segments.segments_service.SegmentUtils.validate_segment_exists",
@@ -594,34 +640,14 @@ async def test_get_info_by_segment_id_cache_hit():
     ), patch(
         "pecha_api.texts.segments.segments_service.get_segment_info_by_id_cache",
         new_callable=AsyncMock,
-        return_value=None,  # Changed to None to test actual flow
+        return_value=cached_response,
     ), patch(
         "pecha_api.texts.segments.segments_service.get_segment_by_id",
         new_callable=AsyncMock,
-        return_value=mock_segment,
-    ), patch(
-        "pecha_api.texts.segments.segments_service.TextUtils.get_text_details_by_id",
-        new_callable=AsyncMock,
-        return_value=mock_text_detail,
-    ), patch(
-        "pecha_api.texts.segments.segments_service.get_related_mapped_segments",
-        new_callable=AsyncMock,
-        return_value=[],
-    ), patch(
-        "pecha_api.texts.segments.segments_service.SegmentUtils.get_count_of_each_commentary_and_version",
-        new_callable=AsyncMock,
-    ) as mock_count, patch(
-        "pecha_api.texts.segments.segments_service.SegmentUtils.get_root_mapping_count",
-        new_callable=AsyncMock,
-    ) as mock_root_count, patch(
-        "pecha_api.texts.segments.segments_service.set_segment_info_by_id_cache",
-        new_callable=AsyncMock,
-    ):
-        mock_count.return_value = {"version": 0, "commentary": 0}
-        mock_root_count.return_value = 0
+    ) as mock_get_segment:
         result = await get_info_by_segment_id(segment_id)
-        assert isinstance(result, SegmentInfoResponse)
-        assert result.segment_info.segment_id == segment_id
+        assert result == cached_response
+        mock_get_segment.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/texts/test_texts_service.py
+++ b/tests/texts/test_texts_service.py
@@ -989,7 +989,9 @@ async def test_get_text_details_by_text_id_with_text_id_content_id_segment_id_su
         ]
     )
 
-    with patch("pecha_api.texts.texts_service._validate_text_detail_request", new_callable=AsyncMock, return_value=True), \
+    with patch("pecha_api.texts.texts_service.get_text_details_cache", new_callable=AsyncMock, return_value=None), \
+        patch("pecha_api.texts.texts_service.set_text_details_cache", new_callable=AsyncMock, return_value=None), \
+        patch("pecha_api.texts.texts_service._validate_text_detail_request", new_callable=AsyncMock, return_value=True), \
         patch("pecha_api.texts.texts_service.TextUtils.get_text_detail_by_id", new_callable=AsyncMock, return_value=mock_text_detail), \
         patch("pecha_api.texts.texts_service.get_table_of_content_by_content_id", new_callable=AsyncMock, return_value=mock_table_of_content), \
         patch("pecha_api.texts.texts_service.SegmentUtils.get_mapped_segment_content_for_table_of_content", new_callable=AsyncMock, return_value=mock_mapped_table_of_content):
@@ -1096,7 +1098,9 @@ async def test_get_text_details_by_text_id_with_text_id_content_id_segment_id_pr
         ]
     )
 
-    with patch("pecha_api.texts.texts_service._validate_text_detail_request", new_callable=AsyncMock, return_value=True), \
+    with patch("pecha_api.texts.texts_service.get_text_details_cache", new_callable=AsyncMock, return_value=None), \
+        patch("pecha_api.texts.texts_service.set_text_details_cache", new_callable=AsyncMock, return_value=None), \
+        patch("pecha_api.texts.texts_service._validate_text_detail_request", new_callable=AsyncMock, return_value=True), \
         patch("pecha_api.texts.texts_service.TextUtils.get_text_detail_by_id", new_callable=AsyncMock, return_value=mock_text_detail), \
         patch("pecha_api.texts.texts_service.get_table_of_content_by_content_id", new_callable=AsyncMock, return_value=mock_table_of_content), \
         patch("pecha_api.texts.texts_service.SegmentUtils.get_mapped_segment_content_for_table_of_content", new_callable=AsyncMock, return_value=mock_mapped_table_of_content):
@@ -1197,7 +1201,9 @@ async def test_get_text_details_by_text_id_with_segment_id_only_success():
         ]
     )
 
-    with patch("pecha_api.texts.texts_service._validate_text_detail_request", new_callable=AsyncMock, return_value=True), \
+    with patch("pecha_api.texts.texts_service.get_text_details_cache", new_callable=AsyncMock, return_value=None), \
+        patch("pecha_api.texts.texts_service.set_text_details_cache", new_callable=AsyncMock, return_value=None), \
+        patch("pecha_api.texts.texts_service._validate_text_detail_request", new_callable=AsyncMock, return_value=True), \
         patch("pecha_api.texts.texts_service.TextUtils.get_text_detail_by_id", new_callable=AsyncMock, return_value=mock_text_detail), \
         patch("pecha_api.texts.texts_service.find_table_of_content_with_segment", new_callable=AsyncMock, return_value=mock_table_of_contents[0]), \
         patch("pecha_api.texts.texts_service.SegmentUtils.get_mapped_segment_content_for_table_of_content", new_callable=AsyncMock, return_value=mock_mapped_table_of_contents):
@@ -1334,7 +1340,9 @@ async def test_get_text_details_by_text_id_with_content_id_only_success():
         ]
     )
 
-    with patch("pecha_api.texts.texts_service._validate_text_detail_request", new_callable=AsyncMock, return_value=True), \
+    with patch("pecha_api.texts.texts_service.get_text_details_cache", new_callable=AsyncMock, return_value=None), \
+        patch("pecha_api.texts.texts_service.set_text_details_cache", new_callable=AsyncMock, return_value=None), \
+        patch("pecha_api.texts.texts_service._validate_text_detail_request", new_callable=AsyncMock, return_value=True), \
         patch("pecha_api.texts.texts_service.TextUtils.get_text_detail_by_id", new_callable=AsyncMock, return_value=mock_text_detail), \
         patch(
             "pecha_api.texts.texts_service.get_first_segment_table_of_content",
@@ -5192,3 +5200,106 @@ async def test_get_table_of_content_by_version_text_id_batch_fetch():
     with patch("pecha_api.texts.texts_service.get_contents_by_text_ids", new_callable=AsyncMock, return_value={"version-1": [mock_toc]}):
         result = await _get_table_of_content_by_version_text_id(versions=versions)
         assert result == {"version-1": ["toc-1"]}
+
+
+@pytest.mark.asyncio
+async def test_get_text_details_by_text_id_returns_cached_data():
+    cached_response = DetailTableOfContentResponse(
+        text_detail=TextDTO(
+            id="text-id",
+            title="Cached",
+            language="bo",
+            group_id="g1",
+            type="version",
+            is_published=True,
+            created_date="",
+            updated_date="",
+            published_date="",
+            published_by="",
+            categories=[],
+            views=0,
+        ),
+        content=DetailTableOfContent(id="content-1", text_id="text-id", sections=[]),
+        size=2,
+        pagination_direction=PaginationDirection.NEXT,
+        current_segment_position=1,
+        total_segments=10,
+    )
+    with patch(
+        "pecha_api.texts.texts_service.get_text_details_cache",
+        new_callable=AsyncMock,
+        return_value=cached_response,
+    ), patch(
+        "pecha_api.texts.texts_service._validate_text_detail_request",
+        new_callable=AsyncMock,
+    ) as mock_validate:
+        response = await get_text_details_by_text_id(
+            text_id="text-id",
+            text_details_request=TextDetailsRequest(
+                content_id="content-1",
+                segment_id="segment-1",
+                size=2,
+                direction=PaginationDirection.NEXT,
+            ),
+        )
+        assert response == cached_response
+        mock_validate.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_receive_table_of_content_segment_id_not_found():
+    from pecha_api.texts.texts_service import _receive_table_of_content
+
+    with patch(
+        "pecha_api.texts.texts_service.find_table_of_content_with_segment",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await _receive_table_of_content(
+                text_id="text-id",
+                text_details_request=TextDetailsRequest(segment_id="missing-segment"),
+            )
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == ErrorConstants.TABLE_OF_CONTENT_NOT_FOUND_MESSAGE
+
+
+@pytest.mark.asyncio
+async def test_get_linked_translation_texts_skips_missing_text_detail():
+    mapped_segments = [
+        SegmentDTO(id="mapped-1", text_id="text-1", content="c1", type=SegmentType.SOURCE),
+        SegmentDTO(id="mapped-2", text_id="text-2", content="c2", type=SegmentType.SOURCE),
+    ]
+    text_details = {
+        "text-1": TextDTO(
+            id="text-1", title="Version A", language="bo", group_id="g1", type="version",
+            is_published=True, created_date="", updated_date="", published_date="",
+            published_by="", categories=[], views=0,
+        ),
+    }
+    with patch("pecha_api.texts.texts_service.get_related_mapped_segments", new_callable=AsyncMock, return_value=mapped_segments), \
+         patch("pecha_api.texts.texts_service.TextUtils.get_text_details_by_ids", new_callable=AsyncMock, return_value=text_details):
+        result = await _get_linked_translation_texts(segment_id="segment-1")
+        assert len(result) == 1
+        assert result[0].id == "text-1"
+
+
+@pytest.mark.asyncio
+async def test_get_linked_translation_texts_skips_excluded_text_ids():
+    excluded_id = "excluded-text-id"
+    mapped_segments = [
+        SegmentDTO(id="mapped-1", text_id=excluded_id, content="c1", type=SegmentType.SOURCE),
+    ]
+    text_details = {
+        excluded_id: TextDTO(
+            id=excluded_id, title="Excluded", language="bo", group_id="g1", type="version",
+            is_published=True, created_date="", updated_date="", published_date="",
+            published_by="", categories=[], views=0,
+        ),
+    }
+    with patch("pecha_api.texts.texts_service.get_related_mapped_segments", new_callable=AsyncMock, return_value=mapped_segments), \
+         patch("pecha_api.texts.texts_service.TextUtils.get_text_details_by_ids", new_callable=AsyncMock, return_value=text_details), \
+         patch("pecha_api.constants.Constants.excluded_text_ids", [excluded_id]):
+        result = await _get_linked_translation_texts(segment_id="segment-1")
+        assert result == []

--- a/tests/texts/test_texts_service.py
+++ b/tests/texts/test_texts_service.py
@@ -66,7 +66,40 @@ from pecha_api.texts.texts_enums import TextType, PaginationDirection, LANGUAGE_
 from pecha_api.sheets.sheets_enum import SortBy, SortOrder
 
 from pecha_api.error_contants import ErrorConstants
+from contextlib import contextmanager, ExitStack
 from typing import List
+
+
+@contextmanager
+def _disable_text_details_cache():
+    with patch(
+        "pecha_api.texts.texts_service.get_text_details_cache",
+        new_callable=AsyncMock,
+        return_value=None,
+    ), patch(
+        "pecha_api.texts.texts_service.set_text_details_cache",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        yield
+
+
+def _version_text_dto(text_id: str, title: str = "Version A") -> TextDTO:
+    return TextDTO(
+        id=text_id,
+        title=title,
+        language="bo",
+        group_id="g1",
+        type="version",
+        is_published=True,
+        created_date="",
+        updated_date="",
+        published_date="",
+        published_by="",
+        categories=[],
+        views=0,
+    )
+
 
 @pytest.mark.asyncio
 async def test_get_text_by_text_id_or_collection_without_collection_id_success():
@@ -989,8 +1022,7 @@ async def test_get_text_details_by_text_id_with_text_id_content_id_segment_id_su
         ]
     )
 
-    with patch("pecha_api.texts.texts_service.get_text_details_cache", new_callable=AsyncMock, return_value=None), \
-        patch("pecha_api.texts.texts_service.set_text_details_cache", new_callable=AsyncMock, return_value=None), \
+    with _disable_text_details_cache(), \
         patch("pecha_api.texts.texts_service._validate_text_detail_request", new_callable=AsyncMock, return_value=True), \
         patch("pecha_api.texts.texts_service.TextUtils.get_text_detail_by_id", new_callable=AsyncMock, return_value=mock_text_detail), \
         patch("pecha_api.texts.texts_service.get_table_of_content_by_content_id", new_callable=AsyncMock, return_value=mock_table_of_content), \
@@ -1098,8 +1130,7 @@ async def test_get_text_details_by_text_id_with_text_id_content_id_segment_id_pr
         ]
     )
 
-    with patch("pecha_api.texts.texts_service.get_text_details_cache", new_callable=AsyncMock, return_value=None), \
-        patch("pecha_api.texts.texts_service.set_text_details_cache", new_callable=AsyncMock, return_value=None), \
+    with _disable_text_details_cache(), \
         patch("pecha_api.texts.texts_service._validate_text_detail_request", new_callable=AsyncMock, return_value=True), \
         patch("pecha_api.texts.texts_service.TextUtils.get_text_detail_by_id", new_callable=AsyncMock, return_value=mock_text_detail), \
         patch("pecha_api.texts.texts_service.get_table_of_content_by_content_id", new_callable=AsyncMock, return_value=mock_table_of_content), \
@@ -1201,8 +1232,7 @@ async def test_get_text_details_by_text_id_with_segment_id_only_success():
         ]
     )
 
-    with patch("pecha_api.texts.texts_service.get_text_details_cache", new_callable=AsyncMock, return_value=None), \
-        patch("pecha_api.texts.texts_service.set_text_details_cache", new_callable=AsyncMock, return_value=None), \
+    with _disable_text_details_cache(), \
         patch("pecha_api.texts.texts_service._validate_text_detail_request", new_callable=AsyncMock, return_value=True), \
         patch("pecha_api.texts.texts_service.TextUtils.get_text_detail_by_id", new_callable=AsyncMock, return_value=mock_text_detail), \
         patch("pecha_api.texts.texts_service.find_table_of_content_with_segment", new_callable=AsyncMock, return_value=mock_table_of_contents[0]), \
@@ -1340,8 +1370,7 @@ async def test_get_text_details_by_text_id_with_content_id_only_success():
         ]
     )
 
-    with patch("pecha_api.texts.texts_service.get_text_details_cache", new_callable=AsyncMock, return_value=None), \
-        patch("pecha_api.texts.texts_service.set_text_details_cache", new_callable=AsyncMock, return_value=None), \
+    with _disable_text_details_cache(), \
         patch("pecha_api.texts.texts_service._validate_text_detail_request", new_callable=AsyncMock, return_value=True), \
         patch("pecha_api.texts.texts_service.TextUtils.get_text_detail_by_id", new_callable=AsyncMock, return_value=mock_text_detail), \
         patch(
@@ -5142,29 +5171,62 @@ async def test_get_language_versions_returns_cached_data():
 
 
 @pytest.mark.asyncio
-async def test_get_linked_translation_texts_success():
-    segment_id = "segment-1"
+@pytest.mark.parametrize(
+    "mapped_text_ids,text_details,excluded_ids,expected_titles",
+    [
+        (
+            ["text-1", "text-2"],
+            {
+                "text-1": _version_text_dto("text-1"),
+                "text-2": TextDTO(
+                    id="text-2", title="Commentary", language="bo", group_id="g1", type="commentary",
+                    is_published=True, created_date="", updated_date="", published_date="",
+                    published_by="", categories=[], views=0,
+                ),
+            },
+            None,
+            ["Version A"],
+        ),
+        (
+            ["text-1", "text-2"],
+            {"text-1": _version_text_dto("text-1")},
+            None,
+            ["Version A"],
+        ),
+        (
+            ["excluded-text-id"],
+            {"excluded-text-id": _version_text_dto("excluded-text-id", title="Excluded")},
+            ["excluded-text-id"],
+            [],
+        ),
+    ],
+)
+async def test_get_linked_translation_texts_filters_results(mapped_text_ids, text_details, excluded_ids, expected_titles):
     mapped_segments = [
-        SegmentDTO(id="mapped-1", text_id="text-1", content="c1", type=SegmentType.SOURCE),
-        SegmentDTO(id="mapped-2", text_id="text-2", content="c2", type=SegmentType.SOURCE),
+        SegmentDTO(id=f"mapped-{text_id}", text_id=text_id, content="c", type=SegmentType.SOURCE)
+        for text_id in mapped_text_ids
     ]
-    text_details = {
-        "text-1": TextDTO(
-            id="text-1", title="Version A", language="bo", group_id="g1", type="version",
-            is_published=True, created_date="", updated_date="", published_date="",
-            published_by="", categories=[], views=0,
+    patches = [
+        patch(
+            "pecha_api.texts.texts_service.get_related_mapped_segments",
+            new_callable=AsyncMock,
+            return_value=mapped_segments,
         ),
-        "text-2": TextDTO(
-            id="text-2", title="Commentary", language="bo", group_id="g1", type="commentary",
-            is_published=True, created_date="", updated_date="", published_date="",
-            published_by="", categories=[], views=0,
+        patch(
+            "pecha_api.texts.texts_service.TextUtils.get_text_details_by_ids",
+            new_callable=AsyncMock,
+            return_value=text_details,
         ),
-    }
-    with patch("pecha_api.texts.texts_service.get_related_mapped_segments", new_callable=AsyncMock, return_value=mapped_segments), \
-         patch("pecha_api.texts.texts_service.TextUtils.get_text_details_by_ids", new_callable=AsyncMock, return_value=text_details):
-        result = await _get_linked_translation_texts(segment_id=segment_id)
-        assert len(result) == 1
-        assert result[0].title == "Version A"
+    ]
+    if excluded_ids is not None:
+        patches.append(patch("pecha_api.constants.Constants.excluded_text_ids", excluded_ids))
+
+    with ExitStack() as stack:
+        for patcher in patches:
+            stack.enter_context(patcher)
+        result = await _get_linked_translation_texts(segment_id="segment-1")
+
+    assert [text.title for text in result] == expected_titles
 
 
 @pytest.mark.asyncio
@@ -5205,20 +5267,7 @@ async def test_get_table_of_content_by_version_text_id_batch_fetch():
 @pytest.mark.asyncio
 async def test_get_text_details_by_text_id_returns_cached_data():
     cached_response = DetailTableOfContentResponse(
-        text_detail=TextDTO(
-            id="text-id",
-            title="Cached",
-            language="bo",
-            group_id="g1",
-            type="version",
-            is_published=True,
-            created_date="",
-            updated_date="",
-            published_date="",
-            published_by="",
-            categories=[],
-            views=0,
-        ),
+        text_detail=_version_text_dto("text-id", title="Cached"),
         content=DetailTableOfContent(id="content-1", text_id="text-id", sections=[]),
         size=2,
         pagination_direction=PaginationDirection.NEXT,
@@ -5263,43 +5312,3 @@ async def test_receive_table_of_content_segment_id_not_found():
 
     assert exc_info.value.status_code == 404
     assert exc_info.value.detail == ErrorConstants.TABLE_OF_CONTENT_NOT_FOUND_MESSAGE
-
-
-@pytest.mark.asyncio
-async def test_get_linked_translation_texts_skips_missing_text_detail():
-    mapped_segments = [
-        SegmentDTO(id="mapped-1", text_id="text-1", content="c1", type=SegmentType.SOURCE),
-        SegmentDTO(id="mapped-2", text_id="text-2", content="c2", type=SegmentType.SOURCE),
-    ]
-    text_details = {
-        "text-1": TextDTO(
-            id="text-1", title="Version A", language="bo", group_id="g1", type="version",
-            is_published=True, created_date="", updated_date="", published_date="",
-            published_by="", categories=[], views=0,
-        ),
-    }
-    with patch("pecha_api.texts.texts_service.get_related_mapped_segments", new_callable=AsyncMock, return_value=mapped_segments), \
-         patch("pecha_api.texts.texts_service.TextUtils.get_text_details_by_ids", new_callable=AsyncMock, return_value=text_details):
-        result = await _get_linked_translation_texts(segment_id="segment-1")
-        assert len(result) == 1
-        assert result[0].id == "text-1"
-
-
-@pytest.mark.asyncio
-async def test_get_linked_translation_texts_skips_excluded_text_ids():
-    excluded_id = "excluded-text-id"
-    mapped_segments = [
-        SegmentDTO(id="mapped-1", text_id=excluded_id, content="c1", type=SegmentType.SOURCE),
-    ]
-    text_details = {
-        excluded_id: TextDTO(
-            id=excluded_id, title="Excluded", language="bo", group_id="g1", type="version",
-            is_published=True, created_date="", updated_date="", published_date="",
-            published_by="", categories=[], views=0,
-        ),
-    }
-    with patch("pecha_api.texts.texts_service.get_related_mapped_segments", new_callable=AsyncMock, return_value=mapped_segments), \
-         patch("pecha_api.texts.texts_service.TextUtils.get_text_details_by_ids", new_callable=AsyncMock, return_value=text_details), \
-         patch("pecha_api.constants.Constants.excluded_text_ids", [excluded_id]):
-        result = await _get_linked_translation_texts(segment_id="segment-1")
-        assert result == []


### PR DESCRIPTION
- Introduced a new endpoint for uploading audio files associated with subtasks, returning relevant details upon success.
- Added a corresponding endpoint for deleting subtask audio files.
- Updated response models to include SubTaskAudioUploadResponse.
- Enhanced tests to cover new audio upload and deletion functionalities.