### PR TITLE
Add Gregorian month handling and validation in calendar services

### DIFF
--- a/pecha_api/calendar/calendar_parser.py
+++ b/pecha_api/calendar/calendar_parser.py
@@ -121,6 +121,28 @@ def parse_calendar_file(file_path: str) -> Dict[str, Dict[str, Any]]:
     return data
 
 
+def get_days_for_gregorian_month(
+    gregorian_year: int,
+    gregorian_month: int,
+) -> list[Dict[str, Any]]:
+    month_prefix = f"{gregorian_year}-{gregorian_month:02d}"
+    days_by_date: Dict[str, Dict[str, Any]] = {}
+
+    for tibetan_year in (gregorian_year - 1, gregorian_year, gregorian_year + 1):
+        if tibetan_year < MIN_CALENDAR_YEAR or tibetan_year > MAX_CALENDAR_YEAR:
+            continue
+        try:
+            year_data = parse_calendar_year(tibetan_year)
+        except FileNotFoundError:
+            continue
+        for day_data in year_data.values():
+            gregorian_date = day_data.get("gregorian_date")
+            if gregorian_date and gregorian_date.startswith(month_prefix):
+                days_by_date[gregorian_date] = day_data
+
+    return [days_by_date[day_key] for day_key in sorted(days_by_date)]
+
+
 def find_calendar_day_for_gregorian_date(
     gregorian_date: date | str,
 ) -> Optional[tuple[int, Dict[str, Any]]]:

--- a/pecha_api/calendar/calendar_response_models.py
+++ b/pecha_api/calendar/calendar_response_models.py
@@ -52,7 +52,10 @@ class CalendarYearResponse(BaseModel):
 
 
 class CalendarMonthResponse(BaseModel):
-    year: int
-    month: int
-    designation: Optional[str] = None
+    year: int = Field(description="Gregorian calendar year")
+    month: int = Field(description="Gregorian calendar month (1-12)")
+    designation: Optional[str] = Field(
+        default=None,
+        description="Deprecated; lunar month designation is on each day in `days`",
+    )
     days: List[CalendarDay]

--- a/pecha_api/calendar/calendar_service.py
+++ b/pecha_api/calendar/calendar_service.py
@@ -8,6 +8,7 @@ from .calendar_parser import (
     MAX_CALENDAR_YEAR,
     MIN_CALENDAR_YEAR,
     find_calendar_day_for_gregorian_date,
+    get_days_for_gregorian_month,
     parse_calendar_year,
 )
 from .calendar_response_models import (
@@ -48,11 +49,24 @@ def _validate_year(year: int) -> None:
         )
 
 
-def _validate_month(month: int) -> None:
-    if month < 1 or month > 13:
+MIN_GREGORIAN_YEAR = MIN_CALENDAR_YEAR
+MAX_GREGORIAN_YEAR = MAX_CALENDAR_YEAR + 1
+
+
+def _validate_gregorian_year(year: int) -> None:
+    if year < MIN_GREGORIAN_YEAR or year > MAX_GREGORIAN_YEAR:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Gregorian year {year} is not available. "
+            f"Supported range: {MIN_GREGORIAN_YEAR}-{MAX_GREGORIAN_YEAR}.",
+        )
+
+
+def _validate_gregorian_month(month: int) -> None:
+    if month < 1 or month > 12:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Month must be between 1 and 13.",
+            detail="Month must be between 1 and 12.",
         )
 
 
@@ -123,29 +137,20 @@ def get_calendar_year_service(year: int) -> CalendarYearResponse:
 
 
 def get_calendar_month_service(year: int, month: int) -> CalendarMonthResponse:
-    _validate_year(year)
-    _validate_month(month)
+    _validate_gregorian_year(year)
+    _validate_gregorian_month(month)
 
-    try:
-        year_data = parse_calendar_year(year)
-    except FileNotFoundError as exc:
+    month_days_data = get_days_for_gregorian_month(year, month)
+    if not month_days_data:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=str(exc),
-        ) from exc
-
-    grouped_months = _group_days_by_month(year_data)
-    month_days = grouped_months.get(month)
-    if not month_days:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"No calendar data found for Tibetan year {year}, month {month}.",
+            detail=f"No calendar data found for {year}-{month:02d}.",
         )
 
-    designation = month_days[0].lunar_month.designation if month_days[0].lunar_month else None
+    month_days = [_to_calendar_day(day_data) for day_data in month_days_data]
     return CalendarMonthResponse(
         year=year,
         month=month,
-        designation=designation,
+        designation=None,
         days=month_days,
     )

--- a/tests/calendar/test_calendar_parser.py
+++ b/tests/calendar/test_calendar_parser.py
@@ -1,0 +1,138 @@
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from pecha_api.calendar.calendar_parser import (
+    MAX_CALENDAR_YEAR,
+    MIN_CALENDAR_YEAR,
+    find_calendar_day_for_gregorian_date,
+    get_calendar_file_for_year,
+    get_days_for_gregorian_month,
+    parse_calendar_file,
+    parse_calendar_year,
+)
+
+SAMPLE_CALENDAR = """\
+New Year: 2025, Wood-female-Snake
+
+Tibetan Lunar Month: 1 - Earth-male-Dragon
+
+1: Fri. mon gre. Earth-Water; 28 Feb 2025
+  yongs 'joms, mi sdug pa, Tiger, kham 7
+  6;52,56 22;45,42 22;44,38 18;30,21 10;1,51
+  Solar: Earth-Dragon. Gui 8
+2: Sat. mon gru. Earth-Earth; 1 Mar 2025
+  zhi ba, byis pa, Rabbit, gin 8
+  0;47,41 23;49,26 22;49,8 19;38,35 10;2,50
+  Solar: Earth-Snake. Liu 9
+17. Omitted: Horse kham 5
+  omitted qualities line
+
+Tibetan Lunar Month: 2 - Earth-female-Snake
+
+1: Sat. mon gru. Earth-Earth; 1 Mar 2025
+  zhi ba, byis pa, Rabbit, gin 8
+"""
+
+
+@pytest.fixture(autouse=True)
+def clear_calendar_year_cache():
+    parse_calendar_year.cache_clear()
+    yield
+    parse_calendar_year.cache_clear()
+
+
+@pytest.fixture
+def sample_calendar_file(tmp_path: Path) -> Path:
+    file_path = tmp_path / "2025.txt"
+    file_path.write_text(SAMPLE_CALENDAR, encoding="utf-8")
+    return file_path
+
+
+class TestGetCalendarFileForYear:
+    def test_returns_path_for_available_year(self):
+        path = get_calendar_file_for_year(2025)
+        assert path.name == "2025.txt"
+        assert path.is_file()
+
+    def test_raises_for_year_out_of_range(self):
+        with pytest.raises(FileNotFoundError, match="out of supported range"):
+            get_calendar_file_for_year(MIN_CALENDAR_YEAR - 1)
+        with pytest.raises(FileNotFoundError, match="out of supported range"):
+            get_calendar_file_for_year(MAX_CALENDAR_YEAR + 1)
+
+    def test_raises_when_file_missing(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "pecha_api.calendar.calendar_parser.PHUGPA_CALENDAR_DIR",
+            tmp_path,
+        )
+        with pytest.raises(FileNotFoundError, match="No calendar file for year 2025"):
+            get_calendar_file_for_year(2025)
+
+
+class TestParseCalendarFile:
+    def test_parses_gregorian_days_with_lunar_and_solar_details(self, sample_calendar_file):
+        data = parse_calendar_file(str(sample_calendar_file))
+
+        assert "2025-02-28" in data
+        day = data["2025-02-28"]
+        assert day["lunar_day"] == 1
+        assert day["lunar_month"]["month"] == 1
+        assert day["new_year"]["year"] == "2025"
+        assert day["lunar_times"] is not None
+        assert day["solar"]["designation"] == "Earth-Dragon"
+        assert day["solar"]["number"] == "8"
+
+    def test_parses_omitted_day_without_gregorian_date(self, sample_calendar_file):
+        data = parse_calendar_file(str(sample_calendar_file))
+        omitted_keys = [key for key in data if key.startswith("omitted_")]
+
+        assert len(omitted_keys) == 1
+        omitted_day = data[omitted_keys[0]]
+        assert omitted_day["gregorian_date"] is None
+        assert omitted_day["lunar_day"] == 17
+
+
+class TestParseCalendarYear:
+    def test_loads_real_calendar_year(self):
+        data = parse_calendar_year(2025)
+
+        assert "2025-03-01" in data
+        assert data["2025-03-01"]["lunar_month"]["month"] == 1
+
+
+class TestGetDaysForGregorianMonth:
+    def test_returns_sorted_days_for_gregorian_month(self):
+        days = get_days_for_gregorian_month(2025, 3)
+
+        assert len(days) == 31
+        assert days[0]["gregorian_date"] == "2025-03-01"
+        assert days[-1]["gregorian_date"] == "2025-03-31"
+
+    def test_spans_adjacent_tibetan_years(self):
+        days = get_days_for_gregorian_month(2025, 1)
+
+        assert len(days) == 31
+        assert days[0]["lunar_month"]["month"] == 11
+
+
+class TestFindCalendarDayForGregorianDate:
+    def test_finds_day_using_date_object(self):
+        result = find_calendar_day_for_gregorian_date(date(2025, 3, 15))
+
+        assert result is not None
+        tibetan_year, day_data = result
+        assert tibetan_year == 2025
+        assert day_data["gregorian_date"] == "2025-03-15"
+
+    def test_finds_day_using_iso_string(self):
+        result = find_calendar_day_for_gregorian_date("2025-03-15")
+
+        assert result is not None
+        tibetan_year, day_data = result
+        assert tibetan_year == 2025
+        assert day_data["gregorian_date"] == "2025-03-15"
+
+    def test_returns_none_when_day_not_found(self):
+        assert find_calendar_day_for_gregorian_date("1800-01-01") is None

--- a/tests/calendar/test_calendar_service.py
+++ b/tests/calendar/test_calendar_service.py
@@ -1,0 +1,113 @@
+from datetime import date
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+from starlette import status
+
+from pecha_api.calendar.calendar_parser import parse_calendar_year
+from pecha_api.calendar.calendar_service import (
+    get_calendar_month_service,
+    get_calendar_today_service,
+    get_calendar_year_service,
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_calendar_year_cache():
+    parse_calendar_year.cache_clear()
+    yield
+    parse_calendar_year.cache_clear()
+
+
+class TestGetCalendarMonthService:
+    def test_returns_gregorian_month_with_lunar_dates(self):
+        result = get_calendar_month_service(2025, 3)
+
+        assert result.year == 2025
+        assert result.month == 3
+        assert len(result.days) == 31
+        assert result.days[0].gregorian_date == "2025-03-01"
+        assert result.days[0].lunar_month is not None
+
+    def test_raises_for_invalid_gregorian_year(self):
+        with pytest.raises(HTTPException) as exc_info:
+            get_calendar_month_service(1700, 3)
+
+        assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
+        assert "Gregorian year 1700" in exc_info.value.detail
+
+    def test_raises_for_invalid_gregorian_month(self):
+        with pytest.raises(HTTPException) as exc_info:
+            get_calendar_month_service(2025, 13)
+
+        assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
+        assert "between 1 and 12" in exc_info.value.detail
+
+    def test_raises_when_month_has_no_data(self):
+        with pytest.raises(HTTPException) as exc_info:
+            get_calendar_month_service(1800, 1)
+
+        assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
+        assert "No calendar data found for 1800-01" in exc_info.value.detail
+
+
+class TestGetCalendarYearService:
+    def test_returns_tibetan_year_grouped_by_lunar_month(self):
+        result = get_calendar_year_service(2025)
+
+        assert result.year == 2025
+        assert result.new_year is not None
+        assert result.new_year.year == "2025"
+        assert "1" in result.months
+        assert result.months["1"].days[0].lunar_month.month == 1
+
+    def test_raises_for_invalid_tibetan_year(self):
+        with pytest.raises(HTTPException) as exc_info:
+            get_calendar_year_service(1700)
+
+        assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
+        assert "Calendar year 1700" in exc_info.value.detail
+
+    def test_raises_when_calendar_file_missing(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "pecha_api.calendar.calendar_parser.PHUGPA_CALENDAR_DIR",
+            tmp_path,
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            get_calendar_year_service(2025)
+
+        assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
+        assert "No calendar file for year 2025" in exc_info.value.detail
+
+
+class TestGetCalendarTodayService:
+    def test_returns_today_calendar_day(self):
+        sample_day = {
+            "gregorian_date": "2025-03-15",
+            "lunar_day": 16,
+            "lunar_month": {"month": 1, "designation": "Earth-male-Dragon"},
+            "new_year": {"year": "2025", "designation": "Wood-female-Snake"},
+            "day_summary": "sample day",
+        }
+
+        with patch(
+            "pecha_api.calendar.calendar_service.find_calendar_day_for_gregorian_date",
+            return_value=(2025, sample_day),
+        ):
+            result = get_calendar_today_service()
+
+        assert result.tibetan_year == 2025
+        assert result.day.lunar_day == 16
+        assert result.gregorian_date == date.today()
+
+    def test_raises_when_today_not_found(self):
+        with patch(
+            "pecha_api.calendar.calendar_service.find_calendar_day_for_gregorian_date",
+            return_value=None,
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                get_calendar_today_service()
+
+        assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
+        assert "No calendar data found for" in exc_info.value.detail

--- a/tests/calendar/test_calendar_views.py
+++ b/tests/calendar/test_calendar_views.py
@@ -1,0 +1,106 @@
+from datetime import date
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+from starlette import status
+
+from pecha_api.app import api
+from pecha_api.calendar.calendar_response_models import (
+    CalendarDay,
+    CalendarMonthResponse,
+    CalendarTodayResponse,
+    CalendarYearResponse,
+    LunarMonthInfo,
+    NewYearInfo,
+)
+
+client = TestClient(api)
+
+
+class TestCalendarViewEndpoint:
+    def test_get_calendar_view_returns_html(self):
+        response = client.get("/calendar/view")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert "text/html" in response.headers["content-type"]
+        assert "<html" in response.text.lower()
+
+
+class TestCalendarTodayEndpoint:
+    def test_get_calendar_today_success(self):
+        today_response = CalendarTodayResponse(
+            gregorian_date=date(2025, 3, 15),
+            tibetan_year=2025,
+            day=CalendarDay(
+                gregorian_date="2025-03-15",
+                lunar_day=16,
+                lunar_month=LunarMonthInfo(month=1, designation="Earth-male-Dragon"),
+                day_summary="sample day",
+            ),
+        )
+
+        with patch(
+            "pecha_api.calendar.calendar_views.get_calendar_today_service",
+            return_value=today_response,
+        ):
+            response = client.get("/calendar/today")
+
+        assert response.status_code == status.HTTP_200_OK
+        body = response.json()
+        assert body["tibetan_year"] == 2025
+        assert body["day"]["lunar_day"] == 16
+
+
+class TestCalendarYearEndpoint:
+    def test_get_calendar_year_success(self):
+        year_response = CalendarYearResponse(
+            year=2025,
+            new_year=NewYearInfo(year="2025", designation="Wood-female-Snake"),
+            months={},
+        )
+
+        with patch(
+            "pecha_api.calendar.calendar_views.get_calendar_year_service",
+            return_value=year_response,
+        ):
+            response = client.get("/calendar/2025")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["year"] == 2025
+
+
+class TestCalendarMonthEndpoint:
+    def test_get_calendar_month_success(self):
+        month_response = CalendarMonthResponse(
+            year=2025,
+            month=3,
+            days=[
+                CalendarDay(
+                    gregorian_date="2025-03-01",
+                    lunar_day=2,
+                    lunar_month=LunarMonthInfo(month=1, designation="Earth-male-Dragon"),
+                    day_summary="sample day",
+                )
+            ],
+        )
+
+        with patch(
+            "pecha_api.calendar.calendar_views.get_calendar_month_service",
+            return_value=month_response,
+        ):
+            response = client.get("/calendar/2025/3")
+
+        assert response.status_code == status.HTTP_200_OK
+        body = response.json()
+        assert body["year"] == 2025
+        assert body["month"] == 3
+        assert len(body["days"]) == 1
+
+    def test_get_calendar_month_integration(self):
+        response = client.get("/calendar/2025/3")
+
+        assert response.status_code == status.HTTP_200_OK
+        body = response.json()
+        assert body["year"] == 2025
+        assert body["month"] == 3
+        assert len(body["days"]) == 31


### PR DESCRIPTION
- Introduced `get_days_for_gregorian_month` function to retrieve days for a specified Gregorian month across relevant Tibetan years.
- Updated validation functions to ensure proper handling of Gregorian year and month inputs.
- Refactored `get_calendar_month_service` to utilize the new month retrieval function, improving clarity and functionality.
- Enhanced response models to provide clearer descriptions for year, month, and designation fields.