### PR TITLE
Enhance random featured series retrieval with language filtering

### DIFF
--- a/pecha_api/plans/series/series_repository.py
+++ b/pecha_api/plans/series/series_repository.py
@@ -339,16 +339,28 @@ def get_series_paginated(
 def get_random_featured_published_series(
     db: Session,
     limit: int = 10,
+    language: Optional[str] = None,
 ) -> Tuple[List[Tuple[Series, int, int]], int]:
     plan_count = _series_active_plans_count_subquery(published_only=True).label("plan_count")
+    filters = [
+        Series.deleted_at.is_(None),
+        Series.featured.is_(True),
+        Series.status == PlanStatus.PUBLISHED,
+    ]
+    if language:
+        language_upper = language.upper()
+        filters.append(
+            exists(
+                select(1).where(
+                    SeriesMetadata.series_id == Series.id,
+                    SeriesMetadata.language == language_upper,
+                )
+            )
+        )
     query = (
         db.query(Series, plan_count)
         .options(selectinload(Series.metadata_entries))
-        .filter(
-            Series.deleted_at.is_(None),
-            Series.featured.is_(True),
-            Series.status == PlanStatus.PUBLISHED,
-        )
+        .filter(*filters)
     )
     total = query.count()
     if total == 0:

--- a/pecha_api/plans/series/series_service.py
+++ b/pecha_api/plans/series/series_service.py
@@ -346,7 +346,11 @@ def get_random_featured_series(
     from pecha_api.plans.response_message import NO_FEATURED_SERIES_FOUND
 
     with SessionLocal() as db_session:
-        rows, total = get_random_featured_published_series(db=db_session, limit=limit)
+        rows, total = get_random_featured_published_series(
+            db=db_session,
+            limit=limit,
+            language=language,
+        )
         if total == 0:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
@@ -369,6 +373,13 @@ def get_random_featured_series(
         )
         for row, plan_count, enrolled_count in rows
     ]
+    if language:
+        series_dtos = [dto for dto in series_dtos if dto.metadata is not None]
+        if not series_dtos:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=NO_FEATURED_SERIES_FOUND,
+            )
     return SeriesListResponse(
         series=series_dtos,
         skip=0,

--- a/tests/plans/series/test_series_repository.py
+++ b/tests/plans/series/test_series_repository.py
@@ -11,6 +11,7 @@ from pecha_api.plans.plans_models import Plan
 from pecha_api.plans.series.series_repository import (
     get_series_by_id,
     get_series_paginated,
+    get_random_featured_published_series,
     save_series_with_plans,
     update_series_with_plans,
     update_series_status,
@@ -33,6 +34,21 @@ def _paginated_query_chain(rows, total, *, with_filter=True, plan_counts=None):
     target.count.return_value = total
     ordered = MagicMock()
     ordered.offset.return_value.limit.return_value.all.return_value = query_rows
+    target.order_by.return_value = ordered
+    query_mock.options.return_value = options_mock
+    return query_mock
+
+
+def _random_featured_query_chain(rows, total, *, with_filter=True, plan_counts=None):
+    if plan_counts is None:
+        plan_counts = [0] * len(rows)
+    query_rows = list(zip(rows, plan_counts))
+    query_mock = MagicMock()
+    options_mock = MagicMock()
+    target = options_mock.filter.return_value if with_filter else options_mock
+    target.count.return_value = total
+    ordered = MagicMock()
+    ordered.limit.return_value.all.return_value = query_rows
     target.order_by.return_value = ordered
     query_mock.options.return_value = options_mock
     return query_mock
@@ -577,6 +593,37 @@ def test_get_series_paginated_published_only_does_not_add_series_filter():
 
     assert rows == []
     assert total == 0
+
+
+def test_get_random_featured_published_series_with_language_applies_metadata_filter():
+    db = _make_session_mock()
+
+    db.query.return_value = _random_featured_query_chain([], 0)
+
+    rows, total = get_random_featured_published_series(db=db, limit=10, language="bo")
+
+    assert rows == []
+    assert total == 0
+    filtered = db.query.return_value.options.return_value.filter
+    assert filtered.call_count == 1
+    filter_args = filtered.call_args[0]
+    assert len(filter_args) == 4
+
+
+def test_get_random_featured_published_series_without_language_uses_base_filters():
+    db = _make_session_mock()
+    row = MagicMock(spec=Series)
+
+    db.query.return_value = _random_featured_query_chain([row], 1)
+
+    rows, total = get_random_featured_published_series(db=db, limit=10)
+
+    assert total == 1
+    assert rows == [(row, 0, 0)]
+    filtered = db.query.return_value.options.return_value.filter
+    assert filtered.call_count == 1
+    filter_args = filtered.call_args[0]
+    assert len(filter_args) == 3
     filtered = db.query.return_value.options.return_value.filter
     assert filtered.call_count == 1
     filter_args = filtered.call_args[0]

--- a/tests/plans/series/test_series_service.py
+++ b/tests/plans/series/test_series_service.py
@@ -14,6 +14,7 @@ from pecha_api.plans.series.series_service import (
     _build_plan_order_pairs,
     create_new_series,
     get_filtered_series,
+    get_random_featured_series,
     get_series_detail,
     update_existing_series,
     update_existing_series_status,
@@ -1596,6 +1597,78 @@ def test_get_filtered_series_passes_language_to_repository():
     call_kwargs = mock_repo.call_args.kwargs
     assert call_kwargs["language"] == "zh"
     assert call_kwargs["status"] == PlanStatus.PUBLISHED
+
+
+def test_get_random_featured_series_passes_language_to_repository():
+    with patch("pecha_api.plans.series.series_service.SessionLocal") as mock_session_local, \
+         patch("pecha_api.plans.series.series_service.get_random_featured_published_series",
+               return_value=([], 0)) as mock_repo:
+        _session_local_context(mock_session_local)
+
+        with pytest.raises(HTTPException) as exc_info:
+            get_random_featured_series(language="bo", limit=10)
+
+    assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
+    call_kwargs = mock_repo.call_args.kwargs
+    assert call_kwargs["language"] == "bo"
+    assert call_kwargs["limit"] == 10
+
+
+def test_get_random_featured_series_excludes_series_without_requested_language_metadata():
+    row_with_bo = MagicMock()
+    row_with_bo.id = uuid.uuid4()
+    row_with_bo.metadata_entries = [_metadata_entry(title="བོད་", language=LanguageCode.BO)]
+    row_with_bo.image = None
+    row_with_bo.author_id = uuid.uuid4()
+    row_with_bo.group_id = None
+    row_with_bo.featured = True
+    row_with_bo.status = PlanStatus.PUBLISHED
+
+    row_en_only = MagicMock()
+    row_en_only.id = uuid.uuid4()
+    row_en_only.metadata_entries = [_metadata_entry(title="English only", language=LanguageCode.EN)]
+    row_en_only.image = None
+    row_en_only.author_id = uuid.uuid4()
+    row_en_only.group_id = None
+    row_en_only.featured = True
+    row_en_only.status = PlanStatus.PUBLISHED
+
+    with patch("pecha_api.plans.series.series_service.SessionLocal") as mock_session_local, \
+         patch("pecha_api.plans.series.series_service.get_random_featured_published_series",
+               return_value=([(row_with_bo, 2, 0), (row_en_only, 1, 0)], 2)), \
+         patch("pecha_api.plans.series.series_service._group_summaries_for_series_rows",
+               return_value={}):
+        _session_local_context(mock_session_local)
+
+        result = get_random_featured_series(language="bo", limit=10)
+
+    assert len(result.series) == 1
+    assert result.series[0].id == row_with_bo.id
+    assert result.series[0].metadata.title == "བོད་"
+    assert result.series[0].metadata.language == "BO"
+
+
+def test_get_random_featured_series_returns_404_when_no_metadata_for_language():
+    row_en_only = MagicMock()
+    row_en_only.id = uuid.uuid4()
+    row_en_only.metadata_entries = [_metadata_entry(title="English only", language=LanguageCode.EN)]
+    row_en_only.image = None
+    row_en_only.author_id = uuid.uuid4()
+    row_en_only.group_id = None
+    row_en_only.featured = True
+    row_en_only.status = PlanStatus.PUBLISHED
+
+    with patch("pecha_api.plans.series.series_service.SessionLocal") as mock_session_local, \
+         patch("pecha_api.plans.series.series_service.get_random_featured_published_series",
+               return_value=([(row_en_only, 1, 0)], 1)), \
+         patch("pecha_api.plans.series.series_service._group_summaries_for_series_rows",
+               return_value={}):
+        _session_local_context(mock_session_local)
+
+        with pytest.raises(HTTPException) as exc_info:
+            get_random_featured_series(language="bo", limit=10)
+
+    assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
 
 
 def test_get_cms_filtered_series_passes_language_to_repository():

--- a/tests/plans/series/test_series_service.py
+++ b/tests/plans/series/test_series_service.py
@@ -8,6 +8,7 @@ from sqlalchemy.exc import IntegrityError
 from starlette import status
 
 from pecha_api.plans.plans_enums import DifficultyLevel, LanguageCode, PlanStatus
+from pecha_api.plans.groups.groups_enums import AuthorGroupType
 from pecha_api.plans.series.series_model import Series
 from pecha_api.plans.series.series_service import (
     _validate_plan_ids,
@@ -328,6 +329,7 @@ def test_get_series_detail_returns_dto_without_plans():
     group_summary = AuthorGroupSummaryDTO(
         id=group_id,
         slug="test-group",
+        group_type=AuthorGroupType.PAGE,
         is_public=True,
         metadata=[],
     )
@@ -1597,6 +1599,36 @@ def test_get_filtered_series_passes_language_to_repository():
     call_kwargs = mock_repo.call_args.kwargs
     assert call_kwargs["language"] == "zh"
     assert call_kwargs["status"] == PlanStatus.PUBLISHED
+
+
+def test_get_random_featured_series_returns_featured_series_without_language_filter():
+    row = MagicMock()
+    row.id = uuid.uuid4()
+    row.metadata_entries = [
+        _metadata_entry(title="Featured", language=LanguageCode.EN),
+        _metadata_entry(title="བོད་", language=LanguageCode.BO),
+    ]
+    row.image = None
+    row.author_id = uuid.uuid4()
+    row.group_id = None
+    row.featured = True
+    row.status = PlanStatus.PUBLISHED
+
+    with patch("pecha_api.plans.series.series_service.SessionLocal") as mock_session_local, \
+         patch("pecha_api.plans.series.series_service.get_random_featured_published_series",
+               return_value=([(row, 4, 2)], 1)), \
+         patch("pecha_api.plans.series.series_service._group_summaries_for_series_rows",
+               return_value={}):
+        _session_local_context(mock_session_local)
+
+        result = get_random_featured_series(limit=10)
+
+    assert len(result.series) == 1
+    assert result.total == 1
+    assert result.series[0].featured is True
+    assert result.series[0].plan_count == 4
+    assert result.series[0].enrolled_count == 2
+    assert len(result.series[0].metadata) == 2
 
 
 def test_get_random_featured_series_passes_language_to_repository():

--- a/tests/plans/users/test_plan_users_service.py
+++ b/tests/plans/users/test_plan_users_service.py
@@ -480,6 +480,7 @@ async def test_get_user_enrolled_plans_includes_group_info():
     from datetime import datetime, timezone
     from pecha_api.plans.users.plan_users_service import get_user_enrolled_plans
     from pecha_api.plans.groups.group_summary_models import AuthorGroupSummaryDTO, GroupMetadataDTO
+    from pecha_api.plans.groups.groups_enums import AuthorGroupType
 
     user_id = uuid.uuid4()
     plan_id = uuid.uuid4()
@@ -504,6 +505,7 @@ async def test_get_user_enrolled_plans_includes_group_info():
     group_summary = AuthorGroupSummaryDTO(
         id=group_id,
         slug="dharma-group",
+        group_type=AuthorGroupType.COMMUNITY,
         is_public=True,
         metadata=[GroupMetadataDTO(id=uuid.uuid4(), title="Dharma Group", description=None, language="EN")],
         tags=[],


### PR DESCRIPTION
- Added optional language parameter to `get_random_featured_published_series` to filter results based on metadata language.
- Updated `get_random_featured_series` to pass the language parameter to the repository function.
- Implemented tests to verify correct behavior when filtering by language and handling cases with no available metadata for the requested language.