### PR TITLE
Enhance series response models and service to include schedule details

### DIFF
--- a/pecha_api/plans/series/series_response_models.py
+++ b/pecha_api/plans/series/series_response_models.py
@@ -97,6 +97,8 @@ class SeriesListItemDTO(BaseModel):
     status: PlanStatus
     plan_count: int = 0
     total_days: int = 0
+    start_date: Optional[datetime] = None
+    end_date: Optional[datetime] = None
     enrolled_count: int = 0
     group: Optional[AuthorGroupSummaryDTO] = None
 

--- a/pecha_api/plans/series/series_service.py
+++ b/pecha_api/plans/series/series_service.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Dict, List, Optional, Tuple
 from uuid import UUID
 
@@ -22,6 +22,7 @@ from pecha_api.plans.series.series_repository import (
     update_series_featured,
     soft_delete_series_with_plan_detach,
     get_random_featured_published_series,
+    get_series_with_plans_by_ids,
 )
 from pecha_api.plans.series.series_response_models import (
     CreateSeriesRequest,
@@ -120,7 +121,7 @@ def _build_plan_order_pairs(
 
 
 def _plan_to_dto(plan, group_id: Optional[UUID] = None) -> SeriesPlanDTO:
-    total_days = len(plan.items) if hasattr(plan, 'items') and plan.items else 0
+    total_days = _plan_total_days(plan)
     return SeriesPlanDTO(
         id=plan.id,
         title=plan.title,
@@ -139,6 +140,36 @@ def _plan_to_dto(plan, group_id: Optional[UUID] = None) -> SeriesPlanDTO:
         total_days=total_days,
         group_id=group_id,
     )
+
+
+def _plan_total_days(plan) -> int:
+    return len(plan.items) if hasattr(plan, "items") and plan.items else 0
+
+
+def _series_schedule_from_plans(
+    plans,
+    published_only: bool = False,
+    language: Optional[str] = None,
+) -> Tuple[Optional[datetime], Optional[datetime], int]:
+    sorted_plans = _get_sorted_active_plans(
+        plans,
+        published_only=published_only,
+        language=language,
+    )
+    if not sorted_plans:
+        return None, None, 0
+
+    series_total_days = sum(_plan_total_days(plan) for plan in sorted_plans)
+    first_plan = sorted_plans[0]
+    if not first_plan.start_date:
+        return None, None, series_total_days
+
+    start_date = first_plan.start_date
+    if series_total_days <= 0:
+        return start_date, start_date, series_total_days
+
+    end_date = start_date + timedelta(days=series_total_days - 1)
+    return start_date, end_date, series_total_days
 
 
 def _get_sorted_active_plans(
@@ -238,6 +269,9 @@ def _series_to_list_item_dto(
     enrolled_count: int = 0,
     language: Optional[str] = None,
     group: Optional[AuthorGroupSummaryDTO] = None,
+    start_date: Optional[datetime] = None,
+    end_date: Optional[datetime] = None,
+    total_days: int = 0,
 ) -> SeriesListItemDTO:
     return SeriesListItemDTO(
         id=row.id,
@@ -248,7 +282,9 @@ def _series_to_list_item_dto(
         featured=bool(row.featured),
         status=_to_plan_status(row.status),
         plan_count=plan_count,
-        total_days=0,
+        total_days=total_days,
+        start_date=start_date,
+        end_date=end_date,
         enrolled_count=enrolled_count,
         group=group,
     )
@@ -362,17 +398,31 @@ def get_random_featured_series(
             series_rows=[row for row, _, _ in rows],
             language=language,
         )
-
-    series_dtos: List[SeriesListItemDTO] = [
-        _series_to_list_item_dto(
-            row,
-            plan_count=plan_count,
-            enrolled_count=enrolled_count,
-            language=language,
-            group=group_summaries.get(row.group_id),
+        series_with_plans = get_series_with_plans_by_ids(
+            db=db_session,
+            series_ids=[row.id for row, _, _ in rows],
         )
-        for row, plan_count, enrolled_count in rows
-    ]
+        plans_by_series_id = {series.id: series.plans for series in series_with_plans}
+
+    series_dtos: List[SeriesListItemDTO] = []
+    for row, plan_count, enrolled_count in rows:
+        start_date, end_date, total_days = _series_schedule_from_plans(
+            plans_by_series_id.get(row.id, []),
+            published_only=True,
+            language=language,
+        )
+        series_dtos.append(
+            _series_to_list_item_dto(
+                row,
+                plan_count=plan_count,
+                enrolled_count=enrolled_count,
+                language=language,
+                group=group_summaries.get(row.group_id),
+                start_date=start_date,
+                end_date=end_date,
+                total_days=total_days,
+            )
+        )
     if language:
         series_dtos = [dto for dto in series_dtos if dto.metadata is not None]
         if not series_dtos:

--- a/tests/plans/series/test_series_service.py
+++ b/tests/plans/series/test_series_service.py
@@ -13,6 +13,8 @@ from pecha_api.plans.series.series_model import Series
 from pecha_api.plans.series.series_service import (
     _validate_plan_ids,
     _build_plan_order_pairs,
+    _series_schedule_from_plans,
+    _plan_total_days,
     create_new_series,
     get_filtered_series,
     get_random_featured_series,
@@ -1797,6 +1799,123 @@ def test_get_random_featured_series_omits_schedule_when_first_plan_has_no_start_
     assert result.series[0].start_date is None
     assert result.series[0].end_date is None
     assert result.series[0].total_days == 5
+
+
+def test_series_schedule_from_plans_returns_empty_when_no_plans():
+    start_date, end_date, total_days = _series_schedule_from_plans([], published_only=True)
+
+    assert start_date is None
+    assert end_date is None
+    assert total_days == 0
+
+
+def test_series_schedule_from_plans_uses_start_date_when_series_has_no_days():
+    series_start = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    plan = _featured_series_plan(display_order=0, start_date=series_start, item_count=0)
+
+    start_date, end_date, total_days = _series_schedule_from_plans(
+        [plan],
+        published_only=True,
+    )
+
+    assert start_date == series_start
+    assert end_date == series_start
+    assert total_days == 0
+
+
+def test_series_schedule_from_plans_excludes_unpublished_plans():
+    series_start = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    draft_plan = _featured_series_plan(
+        display_order=0,
+        start_date=series_start,
+        item_count=2,
+        status=PlanStatus.DRAFT,
+    )
+
+    start_date, end_date, total_days = _series_schedule_from_plans(
+        [draft_plan],
+        published_only=True,
+    )
+
+    assert start_date is None
+    assert end_date is None
+    assert total_days == 0
+
+
+def test_series_schedule_from_plans_filters_by_language():
+    series_start = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    en_plan = _featured_series_plan(
+        display_order=0,
+        start_date=series_start,
+        item_count=2,
+        language=LanguageCode.EN,
+    )
+    bo_plan = _featured_series_plan(
+        display_order=1,
+        start_date=datetime(2026, 7, 10, tzinfo=timezone.utc),
+        item_count=5,
+        language=LanguageCode.BO,
+    )
+
+    start_date, end_date, total_days = _series_schedule_from_plans(
+        [en_plan, bo_plan],
+        published_only=True,
+        language="bo",
+    )
+
+    assert start_date == datetime(2026, 7, 10, tzinfo=timezone.utc)
+    assert total_days == 5
+    assert end_date == datetime(2026, 7, 14, tzinfo=timezone.utc)
+
+
+def test_plan_total_days_returns_zero_when_plan_has_no_items():
+    plan = MagicMock()
+    plan.items = None
+
+    assert _plan_total_days(plan) == 0
+
+
+def test_get_random_featured_series_schedule_respects_language_filter():
+    series_start = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    row = MagicMock()
+    row.id = uuid.uuid4()
+    row.metadata_entries = [_metadata_entry(title="བོད་", language=LanguageCode.BO)]
+    row.image = None
+    row.author_id = uuid.uuid4()
+    row.group_id = None
+    row.featured = True
+    row.status = PlanStatus.PUBLISHED
+
+    en_plan = _featured_series_plan(
+        display_order=0,
+        start_date=series_start,
+        item_count=4,
+        language=LanguageCode.EN,
+    )
+    bo_plan = _featured_series_plan(
+        display_order=1,
+        start_date=datetime(2026, 6, 15, tzinfo=timezone.utc),
+        item_count=2,
+        language=LanguageCode.BO,
+    )
+    series_with_plans = MagicMock()
+    series_with_plans.id = row.id
+    series_with_plans.plans = [en_plan, bo_plan]
+
+    with patch("pecha_api.plans.series.series_service.SessionLocal") as mock_session_local, \
+         patch("pecha_api.plans.series.series_service.get_random_featured_published_series",
+               return_value=([(row, 2, 0)], 1)), \
+         patch("pecha_api.plans.series.series_service.get_series_with_plans_by_ids",
+               return_value=[series_with_plans]), \
+         patch("pecha_api.plans.series.series_service._group_summaries_for_series_rows",
+               return_value={}):
+        _session_local_context(mock_session_local)
+
+        result = get_random_featured_series(language="bo", limit=10)
+
+    assert result.series[0].start_date == datetime(2026, 6, 15, tzinfo=timezone.utc)
+    assert result.series[0].total_days == 2
+    assert result.series[0].end_date == datetime(2026, 6, 16, tzinfo=timezone.utc)
 
 
 def test_get_cms_filtered_series_passes_language_to_repository():

--- a/tests/plans/series/test_series_service.py
+++ b/tests/plans/series/test_series_service.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -332,7 +332,6 @@ def test_get_series_detail_returns_dto_without_plans():
         slug="test-group",
         group_type=AuthorGroupType.PAGE,
         is_public=True,
-        group_type=AuthorGroupType.PAGE,
         metadata=[],
     )
     with patch("pecha_api.plans.series.series_service.SessionLocal") as mock_session_local, patch(
@@ -1703,6 +1702,101 @@ def test_get_random_featured_series_returns_404_when_no_metadata_for_language():
             get_random_featured_series(language="bo", limit=10)
 
     assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
+
+
+def _featured_series_plan(
+    *,
+    display_order,
+    start_date=None,
+    item_count=0,
+    language=LanguageCode.EN,
+    status=PlanStatus.PUBLISHED,
+):
+    plan = MagicMock()
+    plan.deleted_at = None
+    plan.display_order = display_order
+    plan.start_date = start_date
+    plan.status = status
+    plan.language = language
+    plan.items = [MagicMock() for _ in range(item_count)]
+    return plan
+
+
+def test_get_random_featured_series_includes_schedule_from_first_plan():
+    series_start = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    row = MagicMock()
+    row.id = uuid.uuid4()
+    row.metadata_entries = [_metadata_entry(title="Featured", language=LanguageCode.EN)]
+    row.image = None
+    row.author_id = uuid.uuid4()
+    row.group_id = None
+    row.featured = True
+    row.status = PlanStatus.PUBLISHED
+
+    first_plan = _featured_series_plan(
+        display_order=0,
+        start_date=series_start,
+        item_count=3,
+    )
+    second_plan = _featured_series_plan(
+        display_order=1,
+        start_date=datetime(2026, 6, 10, tzinfo=timezone.utc),
+        item_count=2,
+    )
+    series_with_plans = MagicMock()
+    series_with_plans.id = row.id
+    series_with_plans.plans = [second_plan, first_plan]
+
+    with patch("pecha_api.plans.series.series_service.SessionLocal") as mock_session_local, \
+         patch("pecha_api.plans.series.series_service.get_random_featured_published_series",
+               return_value=([(row, 2, 0)], 1)), \
+         patch("pecha_api.plans.series.series_service.get_series_with_plans_by_ids",
+               return_value=[series_with_plans]), \
+         patch("pecha_api.plans.series.series_service._group_summaries_for_series_rows",
+               return_value={}):
+        _session_local_context(mock_session_local)
+
+        result = get_random_featured_series(limit=10)
+
+    assert result.series[0].start_date == series_start
+    assert result.series[0].total_days == 5
+    assert result.series[0].end_date == series_start + timedelta(days=4)
+
+
+def test_get_random_featured_series_omits_schedule_when_first_plan_has_no_start_date():
+    row = MagicMock()
+    row.id = uuid.uuid4()
+    row.metadata_entries = [_metadata_entry(title="Featured", language=LanguageCode.EN)]
+    row.image = None
+    row.author_id = uuid.uuid4()
+    row.group_id = None
+    row.featured = True
+    row.status = PlanStatus.PUBLISHED
+
+    first_plan = _featured_series_plan(display_order=0, start_date=None, item_count=2)
+    second_plan = _featured_series_plan(
+        display_order=1,
+        start_date=datetime(2026, 6, 10, tzinfo=timezone.utc),
+        item_count=3,
+    )
+    series_with_plans = MagicMock()
+    series_with_plans.id = row.id
+    series_with_plans.plans = [first_plan, second_plan]
+
+    with patch("pecha_api.plans.series.series_service.SessionLocal") as mock_session_local, \
+         patch("pecha_api.plans.series.series_service.get_random_featured_published_series",
+               return_value=([(row, 2, 0)], 1)), \
+         patch("pecha_api.plans.series.series_service.get_series_with_plans_by_ids",
+               return_value=[series_with_plans]), \
+         patch("pecha_api.plans.series.series_service._group_summaries_for_series_rows",
+               return_value={}):
+        _session_local_context(mock_session_local)
+
+        result = get_random_featured_series(limit=10)
+
+    assert result.series[0].start_date is None
+    assert result.series[0].end_date is None
+    assert result.series[0].total_days == 5
 
 
 def test_get_cms_filtered_series_passes_language_to_repository():

--- a/tests/plans/series/test_series_views.py
+++ b/tests/plans/series/test_series_views.py
@@ -1,6 +1,8 @@
 import uuid
-import pytest
+from datetime import datetime, timezone
 from unittest.mock import patch, MagicMock
+
+import pytest
 
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
@@ -132,9 +134,46 @@ def test_get_featured_series_success(sample_series_list_response):
         assert item["featured"] is True
         assert "plans" not in item
         assert item["plan_count"] == featured_item.plan_count
+        assert item["start_date"] is None
+        assert item["end_date"] is None
+        assert item["total_days"] == featured_item.total_days
         assert data["skip"] == 0
         assert data["limit"] == 10
         assert data["total"] == 1
+
+
+def test_get_featured_series_includes_schedule_fields():
+    series_start = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    series_end = datetime(2026, 6, 5, tzinfo=timezone.utc)
+    list_item = SeriesListItemDTO(
+        id=uuid.uuid4(),
+        metadata=[_metadata("Featured Series")],
+        author_id=uuid.uuid4(),
+        featured=True,
+        status=PlanStatus.PUBLISHED,
+        plan_count=2,
+        total_days=5,
+        start_date=series_start,
+        end_date=series_end,
+    )
+    featured_response = SeriesListResponse(
+        series=[list_item],
+        skip=0,
+        limit=10,
+        total=1,
+    )
+
+    with patch(
+        "pecha_api.plans.series.public_series_view.get_random_featured_series",
+        return_value=featured_response,
+    ):
+        response = client.get("/series/featured")
+
+    assert response.status_code == status.HTTP_200_OK
+    item = response.json()["series"][0]
+    assert item["start_date"] == "2026-06-01T00:00:00Z"
+    assert item["end_date"] == "2026-06-05T00:00:00Z"
+    assert item["total_days"] == 5
 
 
 def test_get_featured_series_with_language(sample_series_list_response):

--- a/tests/plans/users/test_plan_users_service.py
+++ b/tests/plans/users/test_plan_users_service.py
@@ -507,7 +507,6 @@ async def test_get_user_enrolled_plans_includes_group_info():
         slug="dharma-group",
         group_type=AuthorGroupType.COMMUNITY,
         is_public=True,
-        group_type=AuthorGroupType.COMMUNITY,
         metadata=[GroupMetadataDTO(id=uuid.uuid4(), title="Dharma Group", description=None, language="EN")],
         tags=[],
         follower_count=5,


### PR DESCRIPTION
- Added optional start_date and end_date fields to SeriesListItemDTO for better scheduling information.
- Introduced _plan_total_days and _series_schedule_from_plans functions to calculate total days and determine start and end dates from plans.
- Updated _series_to_list_item_dto to incorporate scheduling details.
- Enhanced get_random_featured_series to retrieve and include schedule information from the first plan.
- Added tests to validate the inclusion of schedule details in the series response.