### PR TITLE
Add description_long field to group metadata models and update relate…

### DIFF
--- a/migrations/versions/c6d7e8f9a0b1_add_description_long_to_author_group_metadata.py
+++ b/migrations/versions/c6d7e8f9a0b1_add_description_long_to_author_group_metadata.py
@@ -1,0 +1,26 @@
+"""add description_long to author group metadata
+
+Revision ID: c6d7e8f9a0b1
+Revises: b4c5d6e7f8a9
+Create Date: 2026-06-16 12:00:00.000000
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "c6d7e8f9a0b1"
+down_revision: Union[str, None] = "b4c5d6e7f8a9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "author_group_metadata",
+        sa.Column("description_long", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("author_group_metadata", "description_long")

--- a/pecha_api/plans/groups/group_summary_models.py
+++ b/pecha_api/plans/groups/group_summary_models.py
@@ -12,6 +12,7 @@ class GroupMetadataDTO(BaseModel):
     title: str
     sub_title: Optional[str] = None
     description: Optional[str] = None
+    description_long: Optional[str] = None
     language: str
 
 

--- a/pecha_api/plans/groups/groups_models.py
+++ b/pecha_api/plans/groups/groups_models.py
@@ -194,6 +194,7 @@ class AuthorGroupMetadata(Base):
     title = Column(String(255), nullable=False)
     sub_title = Column(String(255), nullable=True)
     description = Column(Text, nullable=True)
+    description_long = Column(Text, nullable=True)
 
     group = relationship("AuthorGroup", back_populates="metadata_entries")
 

--- a/pecha_api/plans/groups/groups_response_models.py
+++ b/pecha_api/plans/groups/groups_response_models.py
@@ -44,6 +44,7 @@ class GroupMetadataInput(BaseModel):
     title: str
     sub_title: Optional[str] = None
     description: Optional[str] = None
+    description_long: Optional[str] = None
     language: LanguageCode
 
 

--- a/pecha_api/plans/groups/groups_service.py
+++ b/pecha_api/plans/groups/groups_service.py
@@ -161,6 +161,7 @@ def _metadata_to_dtos(metadata_entries, language: Optional[str] = None) -> List[
             title=item.title,
             sub_title=_optional_metadata_str(getattr(item, "sub_title", None)),
             description=item.description,
+            description_long=_optional_metadata_str(getattr(item, "description_long", None)),
             language=_language_value(item.language),
         )
         for item in sorted(metadata_entries, key=lambda value: value.language)
@@ -503,6 +504,7 @@ def create_author_group(token: str, request: CreateAuthorGroupRequest) -> Author
                 title=item.title,
                 sub_title=item.sub_title,
                 description=item.description,
+                description_long=item.description_long,
             )
             for item in request.metadata
         ]
@@ -558,6 +560,7 @@ def update_author_group(token: str, group_id: UUID, request: UpdateAuthorGroupRe
                     title=item.title,
                     sub_title=item.sub_title,
                     description=item.description,
+                    description_long=item.description_long,
                 )
                 for item in request.metadata
             ]


### PR DESCRIPTION
…d services

- Introduced description_long as an optional field in GroupMetadataDTO, AuthorGroupMetadata, and GroupMetadataInput.
- Updated the _metadata_to_dtos, create_author_group, and update_author_group functions to handle the new description_long field.