### PR TITLE
Add PresetMantraDTO and enhance accumulator services

### DIFF
--- a/migrations/versions/i2b3c4d5e6f7_rename_mantra_metadata_columns.py
+++ b/migrations/versions/i2b3c4d5e6f7_rename_mantra_metadata_columns.py
@@ -1,0 +1,30 @@
+"""rename mantra_metadata columns
+
+Rename text -> mantra, meaning -> title, transliteration -> pronunciation.
+
+Revision ID: i2b3c4d5e6f7
+Revises: h1a2b3c4d5e6
+Create Date: 2026-06-17 16:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "i2b3c4d5e6f7"
+down_revision: Union[str, None] = "h1a2b3c4d5e6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.alter_column("mantra_metadata", "text", new_column_name="mantra")
+    op.alter_column("mantra_metadata", "meaning", new_column_name="title")
+    op.alter_column("mantra_metadata", "transliteration", new_column_name="pronunciation")
+
+
+def downgrade() -> None:
+    op.alter_column("mantra_metadata", "pronunciation", new_column_name="transliteration")
+    op.alter_column("mantra_metadata", "title", new_column_name="meaning")
+    op.alter_column("mantra_metadata", "mantra", new_column_name="text")

--- a/pecha_api/accumulator/accumulator_response_models.py
+++ b/pecha_api/accumulator/accumulator_response_models.py
@@ -13,6 +13,20 @@ class AccumulatorMetadataDTO(BaseModel):
     description: Optional[str] = None
 
 
+class PresetMantraDTO(BaseModel):
+    """Mantra content for a preset, resolved for a single language."""
+    id: UUID
+    mantra: str
+    title: Optional[str] = None
+    pronunciation: Optional[str] = None
+    audio_url: Optional[str] = None
+    mala_image_id: Optional[UUID] = None
+    mala_image_url: Optional[str] = Field(
+        None,
+        description="Presigned S3 URL for the mantra's default mala image",
+    )
+
+
 class AccumulatorDTO(BaseModel):
     id: UUID
     user_id: UUID
@@ -48,7 +62,7 @@ class PublicAccumulatorDTO(BaseModel):
     target_count: Optional[int] = None
     current_count: int
     text_id: Optional[UUID] = None
-    mantra_id: Optional[UUID] = None
+    mantra: Optional[PresetMantraDTO] = None
     mala_image_id: Optional[UUID] = None
     mala_image_url: Optional[str] = Field(None, description="Presigned S3 URL for the chosen mala image (None when no image is set)")
     metadata: List[AccumulatorMetadataDTO] = []

--- a/pecha_api/accumulator/accumulator_service.py
+++ b/pecha_api/accumulator/accumulator_service.py
@@ -1,4 +1,4 @@
-from typing import Optional, List
+from typing import Dict, Optional, List
 from uuid import UUID, uuid4
 import logging
 
@@ -26,10 +26,14 @@ from .accumulator_repository import (
     get_mantra_mala_image_id,
     get_mala_image_by_id
 )
+from ..mantra.mantra_model import Mantra
+from ..mantra.mantra_metadata_model import MantraMetadata
+from ..mantra.mantra_repository import get_mantras_by_ids
 from .accumulator_response_models import (
     AccumulatorsResponse,
     AccumulatorDTO,
     AccumulatorMetadataDTO,
+    PresetMantraDTO,
     PublicAccumulatorDTO,
     PublicAccumulatorsResponse,
     CreateAccumulatorRequest,
@@ -41,6 +45,7 @@ from .accumulator_response_models import (
 )
 from .accumulator_models import Accumulator
 from .accumulator_metadata_model import AccumulatorMetadata
+from .accumulator_history_model import AccumulatorHistory
 from .accumulator_enums import AccumulatorType
 from .response_message import (
     NOT_FOUND,
@@ -123,13 +128,63 @@ def convert_accumulators_to_dtos(accumulators: List[Accumulator]) -> List[Accumu
     return [convert_accumulator_to_dto(accumulator) for accumulator in accumulators]
 
 
-def convert_accumulator_to_public_dto(accumulator: Accumulator) -> PublicAccumulatorDTO:
+def _metadata_language(entry: MantraMetadata) -> str:
+    return entry.language.value if hasattr(entry.language, "value") else entry.language
+
+
+def _pick_mantra_metadata(
+    metadata_entries: List[MantraMetadata],
+    language: Optional[str],
+) -> Optional[MantraMetadata]:
+    if not metadata_entries:
+        return None
+    if language:
+        language_upper = language.upper()
+        for entry in metadata_entries:
+            if _metadata_language(entry) == language_upper:
+                return entry
+        return None
+    for entry in metadata_entries:
+        if _metadata_language(entry) == "EN":
+            return entry
+    return metadata_entries[0]
+
+
+def build_preset_mantra_dto(
+    mantra: Mantra,
+    language: Optional[str],
+) -> Optional[PresetMantraDTO]:
+    metadata = _pick_mantra_metadata(mantra.metadata_entries, language)
+    if metadata is None:
+        return None
+    mala = mantra.mala
+    return PresetMantraDTO(
+        id=mantra.id,
+        mantra=metadata.mantra,
+        title=metadata.title,
+        pronunciation=metadata.pronunciation,
+        audio_url=mantra.audio_url,
+        mala_image_id=mala.id if mala is not None else None,
+        mala_image_url=generate_mala_image_presigned_url(mala.url) if mala is not None else None,
+    )
+
+
+def convert_accumulator_to_public_dto(
+    accumulator: Accumulator,
+    mantras_by_id: Optional[Dict[UUID, Mantra]] = None,
+    language: Optional[str] = None,
+) -> PublicAccumulatorDTO:
     accumulator_type = (
         AccumulatorType(accumulator.type.value)
         if hasattr(accumulator.type, 'value')
         else accumulator.type
     )
     mala_image_id, mala_image_url = resolve_mala_image_fields(accumulator)
+    mantra_dto = None
+    if accumulator.mantra_id and mantras_by_id:
+        mantra = mantras_by_id.get(accumulator.mantra_id)
+        if mantra is not None:
+            mantra_dto = build_preset_mantra_dto(mantra, language)
     return PublicAccumulatorDTO(
         id=accumulator.id,
         group_id=accumulator.group_id,
@@ -137,7 +192,7 @@ def convert_accumulator_to_public_dto(accumulator: Accumulator) -> PublicAccumul
         target_count=accumulator.target_count,
         current_count=accumulator.current_count or 0,
         text_id=accumulator.text_id,
-        mantra_id=accumulator.mantra_id,
+        mantra=mantra_dto,
         mala_image_id=mala_image_id,
         mala_image_url=mala_image_url,
         metadata=convert_metadata_entries_to_dtos(accumulator),
@@ -159,14 +214,98 @@ def is_user_created_accumulator(accumulator: Accumulator) -> bool:
     return accumulator_type == AccumulatorType.USER.value
 
 
+def _create_accumulator_from_preset(
+    db,
+    user_id: UUID,
+    preset_id: UUID,
+) -> Accumulator:
+    """Create a user accumulator by copying fields from a public preset."""
+    preset = get_preset_by_id(db, preset_id)
+    if preset is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"error": NOT_FOUND, "message": PRESET_NOT_FOUND}
+        )
+
+    existing = get_user_accumulator_by_parent(db, user_id, preset.id)
+    if existing is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={"error": CONFLICT, "message": ACCUMULATOR_ALREADY_EXISTS}
+        )
+
+    mantra_mala_image_id = (
+        get_mantra_mala_image_id(db, preset.mantra_id)
+        if preset.mantra_id is not None
+        else None
+    )
+
+    new_accumulator = Accumulator(
+        id=uuid4(),
+        user_id=user_id,
+        group_id=preset.group_id,
+        parent_id=preset.id,
+        type=AccumulatorType.USER,
+        target_count=preset.target_count,
+        current_count=0,
+        text_id=preset.text_id,
+        mantra_id=preset.mantra_id,
+        mala_image=mantra_mala_image_id or preset.mala_image,
+    )
+
+    new_accumulator.metadata_entries = [
+        AccumulatorMetadata(
+            id=uuid4(),
+            name=entry.name,
+            description=entry.description,
+            language=entry.language,
+        )
+        for entry in preset.metadata_entries
+    ]
+
+    add_accumulator(db, new_accumulator)
+    return commit_accumulator(db, new_accumulator)
+
+
+def _build_accumulator_history_dto(
+    accumulator: Accumulator,
+    total_counted: int,
+    sessions: List[AccumulatorHistory],
+) -> AccumulatorHistoryDTO:
+    mala_image_id, mala_image_url = resolve_mala_image_fields(accumulator)
+    return AccumulatorHistoryDTO(
+        accumulator_id=accumulator.id,
+        parent_id=accumulator.parent_id,
+        target_count=accumulator.target_count,
+        current_count=accumulator.current_count or 0,
+        total_counted=total_counted,
+        mala_image_id=mala_image_id,
+        mala_image_url=mala_image_url,
+        metadata=convert_metadata_entries_to_dtos(accumulator),
+        sessions=[
+            AccumulatorSessionDTO(
+                count=session.count,
+                created_at=session.created_at
+            )
+            for session in sessions
+        ]
+    )
+
+
 def get_all_accumulators_service(
     skip: int = 0,
-    limit: int = 20
+    limit: int = 20,
+    language: Optional[str] = None,
 ) -> PublicAccumulatorsResponse:
     with SessionLocal() as db:
         accumulators, total = get_all_accumulators(db, skip, limit)
+        mantra_ids = [a.mantra_id for a in accumulators if a.mantra_id is not None]
+        mantras_by_id = get_mantras_by_ids(db, mantra_ids)
         return PublicAccumulatorsResponse(
-            accumulators=[convert_accumulator_to_public_dto(a) for a in accumulators],
+            accumulators=[
+                convert_accumulator_to_public_dto(a, mantras_by_id, language)
+                for a in accumulators
+            ],
             total=total,
             skip=skip,
             limit=limit
@@ -191,64 +330,15 @@ def get_user_accumulators_service(
 def create_accumulator_service(token: str, request: CreateAccumulatorRequest) -> AccumulatorDTO:
     """Create the user's accumulator from a tapped preset.
 
-    The app calls this only after GET /accumulators/{parent_id} returned 404,
-    i.e. the user has no accumulator for this preset yet. The preset's fields
-    are copied into a new user accumulator whose parent_id links back to the
-    preset. A user has at most one active accumulator per preset, so a duplicate
-    create is rejected."""
+    The preset's fields are copied into a new user accumulator whose parent_id
+    links back to the preset. A user has at most one active accumulator per
+    preset, so a duplicate create is rejected."""
     current_user = validate_and_extract_user_details(token=token)
 
     with SessionLocal() as db:
-        preset = get_preset_by_id(db, request.parent_id)
-        if preset is None:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail={"error": NOT_FOUND, "message": PRESET_NOT_FOUND}
-            )
-
-        existing = get_user_accumulator_by_parent(db, current_user.id, preset.id)
-        if existing is not None:
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail={"error": CONFLICT, "message": ACCUMULATOR_ALREADY_EXISTS}
-            )
-
-        # Default the new accumulator's mala image to the preset's mantra's
-        # mala image (the per-mantra default). Fall back to the preset's own
-        # mala image when the mantra has none set.
-        mantra_mala_image_id = (
-            get_mantra_mala_image_id(db, preset.mantra_id)
-            if preset.mantra_id is not None
-            else None
+        saved_accumulator = _create_accumulator_from_preset(
+            db, current_user.id, request.parent_id
         )
-
-        new_accumulator = Accumulator(
-            id=uuid4(),
-            user_id=current_user.id,
-            group_id=preset.group_id,
-            parent_id=preset.id,
-            type=AccumulatorType.USER,
-            target_count=preset.target_count,
-            current_count=0,
-            text_id=preset.text_id,
-            mantra_id=preset.mantra_id,
-            mala_image=mantra_mala_image_id or preset.mala_image,
-        )
-
-        # Copy the preset's per-language metadata (name/description) so the new
-        # accumulator starts with the same display text.
-        new_accumulator.metadata_entries = [
-            AccumulatorMetadata(
-                id=uuid4(),
-                name=entry.name,
-                description=entry.description,
-                language=entry.language,
-            )
-            for entry in preset.metadata_entries
-        ]
-
-        add_accumulator(db, new_accumulator)
-        saved_accumulator = commit_accumulator(db, new_accumulator)
         return convert_accumulator_to_dto(saved_accumulator)
 
 
@@ -333,38 +423,21 @@ def get_accumulator_detail_service(
     parent_id: UUID
 ) -> AccumulatorHistoryDTO:
     """Fetch the current user's accumulator created from the given preset
-    (parent_id), with its history. 404 if the user has none yet, which signals
-    the app to POST and create one."""
+    (parent_id), with its history. Creates one from the preset when the user
+    has none yet."""
     current_user = validate_and_extract_user_details(token=token)
 
     with SessionLocal() as db:
         result = get_accumulator_with_history(db, current_user.id, parent_id)
 
         if result is None:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail={"error": NOT_FOUND, "message": ACCUMULATOR_NOT_FOUND}
+            accumulator = _create_accumulator_from_preset(
+                db, current_user.id, parent_id
             )
+            return _build_accumulator_history_dto(accumulator, total_counted=0, sessions=[])
 
         accumulator, total_counted, sessions = result
-        mala_image_id, mala_image_url = resolve_mala_image_fields(accumulator)
-        return AccumulatorHistoryDTO(
-            accumulator_id=accumulator.id,
-            parent_id=accumulator.parent_id,
-            target_count=accumulator.target_count,
-            current_count=accumulator.current_count or 0,
-            total_counted=total_counted,
-            mala_image_id=mala_image_id,
-            mala_image_url=mala_image_url,
-            metadata=convert_metadata_entries_to_dtos(accumulator),
-            sessions=[
-                AccumulatorSessionDTO(
-                    count=session.count,
-                    created_at=session.created_at
-                )
-                for session in sessions
-            ]
-        )
+        return _build_accumulator_history_dto(accumulator, total_counted, sessions)
 
 
 def get_accumulator_history_service(

--- a/pecha_api/accumulator/accumulator_views.py
+++ b/pecha_api/accumulator/accumulator_views.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends, Query
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
-from typing import Annotated
+from typing import Annotated, Optional
 from uuid import UUID
 from starlette import status
 
@@ -38,8 +38,12 @@ oauth2_scheme = HTTPBearer()
 async def get_all_preset_accumulators(
     skip: int = Query(0, ge=0, description="Number of records to skip"),
     limit: int = Query(20, ge=1, le=100, description="Maximum number of records to return"),
+    language: Annotated[
+        Optional[str],
+        Query(description="Language code for mantra title, text, and pronunciation (e.g. 'en', 'bo', 'zh')"),
+    ] = None,
 ):
-    return get_all_accumulators_service(skip=skip, limit=limit)
+    return get_all_accumulators_service(skip=skip, limit=limit, language=language)
 
 
 @accumulator_router.get("/user", response_model=AccumulatorsResponse)

--- a/pecha_api/mantra/mantra_metadata_model.py
+++ b/pecha_api/mantra/mantra_metadata_model.py
@@ -16,9 +16,9 @@ class MantraMetadata(Base):
         ForeignKey("mantra.id", ondelete="CASCADE"),
         nullable=False,
     )
-    text = Column(Text, nullable=False)
-    meaning = Column(Text, nullable=True)
-    transliteration = Column(Text, nullable=True)
+    mantra = Column(Text, nullable=False)
+    title = Column(Text, nullable=True)
+    pronunciation = Column(Text, nullable=True)
     language = Column(LanguageCodeEnum, nullable=False)
 
     mantra = relationship("Mantra", back_populates="metadata_entries")

--- a/pecha_api/mantra/mantra_repository.py
+++ b/pecha_api/mantra/mantra_repository.py
@@ -1,6 +1,7 @@
 from sqlalchemy import select, exists
 from sqlalchemy.orm import Session, selectinload
-from typing import List, Optional
+from typing import Dict, List, Optional
+from uuid import UUID
 
 from .mantra_model import Mantra
 from .mantra_metadata_model import MantraMetadata
@@ -22,3 +23,18 @@ def get_all_mantras(db: Session, language: Optional[str] = None) -> List[Mantra]
         )
 
     return query.all()
+
+
+def get_mantras_by_ids(db: Session, mantra_ids: List[UUID]) -> Dict[UUID, Mantra]:
+    if not mantra_ids:
+        return {}
+    mantras = (
+        db.query(Mantra)
+        .options(
+            selectinload(Mantra.metadata_entries),
+            selectinload(Mantra.mala),
+        )
+        .filter(Mantra.id.in_(mantra_ids))
+        .all()
+    )
+    return {mantra.id: mantra for mantra in mantras}

--- a/pecha_api/mantra/mantra_response_models.py
+++ b/pecha_api/mantra/mantra_response_models.py
@@ -7,9 +7,9 @@ from ..plans.plans_enums import LanguageCode
 
 class MantraMetadataDTO(BaseModel):
     id: UUID
-    text: str
-    meaning: Optional[str] = None
-    transliteration: Optional[str] = None
+    mantra: str
+    title: Optional[str] = None
+    pronunciation: Optional[str] = None
     language: LanguageCode
 
     class Config:

--- a/tests/accumulator/test_accumulator_service.py
+++ b/tests/accumulator/test_accumulator_service.py
@@ -12,9 +12,13 @@ from pecha_api.accumulator.accumulator_service import (
     update_accumulator_service,
     delete_accumulator_service,
     get_accumulator_history_service,
+    get_accumulator_detail_service,
     update_mala_image_service,
     convert_accumulator_to_dto,
     convert_accumulator_to_public_dto,
+    build_preset_mantra_dto,
+    generate_mala_image_presigned_url,
+    _create_accumulator_from_preset,
     is_user_created_accumulator,
     validate_mantra_exists,
 )
@@ -23,10 +27,12 @@ from pecha_api.accumulator.accumulator_response_models import (
     PublicAccumulatorsResponse,
     AccumulatorDTO,
     PublicAccumulatorDTO,
+    PresetMantraDTO,
     CreateAccumulatorRequest,
     UpdateAccumulatorRequest,
     UpdateMalaImageRequest,
     AccumulatorHistoryResponse,
+    AccumulatorHistoryDTO,
 )
 from pecha_api.accumulator.accumulator_models import Accumulator
 from pecha_api.accumulator.accumulator_history_model import AccumulatorHistory
@@ -35,8 +41,41 @@ from pecha_api.mantra.mantra_model import Mantra
 from pecha_api.mantra.mantra_metadata_model import MantraMetadata  
 
 
+from pecha_api.plans.plans_enums import LanguageCode
+
+
 class TestDataFactory:
     """Factory for creating test data objects."""
+
+    @staticmethod
+    def create_mock_mantra_metadata(
+        mantra="Om Mani Padme Hum",
+        title="The jewel in the lotus",
+        pronunciation="om mani padme hum",
+        language=LanguageCode.EN,
+    ):
+        entry = MagicMock(spec=MantraMetadata)
+        entry.mantra = mantra
+        entry.title = title
+        entry.pronunciation = pronunciation
+        entry.language = language
+        return entry
+
+    @staticmethod
+    def create_mock_mantra(
+        mantra_id=None,
+        audio_url="audio/mantra.mp3",
+        metadata_entries=None,
+        mala=None,
+    ):
+        mantra = MagicMock(spec=Mantra)
+        mantra.id = mantra_id or uuid4()
+        mantra.audio_url = audio_url
+        if metadata_entries is None:
+            metadata_entries = [TestDataFactory.create_mock_mantra_metadata()]
+        mantra.metadata_entries = metadata_entries
+        mantra.mala = mala
+        return mantra
 
     @staticmethod
     def create_mock_metadata(name="Test Accumulator", description=None, language="EN"):
@@ -136,9 +175,10 @@ class TestDataFactory:
 class TestGetAllAccumulatorsService:
     """Test cases for get_all_accumulators_service function."""
 
+    @patch('pecha_api.accumulator.accumulator_service.get_mantras_by_ids')
     @patch('pecha_api.accumulator.accumulator_service.SessionLocal')
     @patch('pecha_api.accumulator.accumulator_service.get_all_accumulators')
-    def test_get_all_accumulators_service_success(self, mock_get_all, mock_session):
+    def test_get_all_accumulators_service_success(self, mock_get_all, mock_session, mock_get_mantras):
         """Test successful retrieval of all accumulators."""
         mock_db = MagicMock()
         mock_session.return_value.__enter__.return_value = mock_db
@@ -146,6 +186,7 @@ class TestGetAllAccumulatorsService:
         acc1 = TestDataFactory.create_mock_accumulator(name="Acc 1")
         acc2 = TestDataFactory.create_mock_accumulator(name="Acc 2")
         mock_get_all.return_value = ([acc1, acc2], 2)
+        mock_get_mantras.return_value = {}
 
         result = get_all_accumulators_service(skip=0, limit=20)
 
@@ -159,30 +200,85 @@ class TestGetAllAccumulatorsService:
         assert not hasattr(result.accumulators[0], "user_id")
 
         mock_get_all.assert_called_once_with(mock_db, 0, 20)
+        mock_get_mantras.assert_called_once_with(mock_db, [])
 
+    @patch('pecha_api.accumulator.accumulator_service.get_mantras_by_ids')
     @patch('pecha_api.accumulator.accumulator_service.SessionLocal')
     @patch('pecha_api.accumulator.accumulator_service.get_all_accumulators')
-    def test_get_all_accumulators_service_empty(self, mock_get_all, mock_session):
+    def test_get_all_accumulators_service_includes_mantra_detail(
+        self, mock_get_all, mock_session, mock_get_mantras
+    ):
+        """Preset list should embed mantra detail for the requested language."""
+        mock_db = MagicMock()
+        mock_session.return_value.__enter__.return_value = mock_db
+
+        mantra_id = uuid4()
+        mala = MagicMock()
+        mala.id = uuid4()
+        mala.url = "mala-images/default.png"
+        mantra = TestDataFactory.create_mock_mantra(
+            mantra_id=mantra_id,
+            mala=mala,
+            metadata_entries=[
+                TestDataFactory.create_mock_mantra_metadata(
+                    mantra="Tibetan text",
+                    title="Tibetan title",
+                    pronunciation="tibetan pronunciation",
+                    language=LanguageCode.BO,
+                ),
+                TestDataFactory.create_mock_mantra_metadata(
+                    mantra="English text",
+                    title="English title",
+                    pronunciation="english pronunciation",
+                    language=LanguageCode.EN,
+                ),
+            ],
+        )
+        preset = TestDataFactory.create_mock_accumulator(
+            name="Preset",
+            accumulator_type=AccumulatorType.PRESET,
+            mantra_id=mantra_id,
+        )
+        mock_get_all.return_value = ([preset], 1)
+        mock_get_mantras.return_value = {mantra_id: mantra}
+
+        result = get_all_accumulators_service(skip=0, limit=20, language="bo")
+
+        assert result.accumulators[0].mantra.id == mantra_id
+        assert result.accumulators[0].mantra.mantra == "Tibetan text"
+        assert result.accumulators[0].mantra.title == "Tibetan title"
+        assert result.accumulators[0].mantra.pronunciation == "tibetan pronunciation"
+        assert result.accumulators[0].mantra.audio_url == mantra.audio_url
+        assert result.accumulators[0].mantra.mala_image_id == mala.id
+        mock_get_mantras.assert_called_once_with(mock_db, [mantra_id])
+
+    @patch('pecha_api.accumulator.accumulator_service.get_mantras_by_ids')
+    @patch('pecha_api.accumulator.accumulator_service.SessionLocal')
+    @patch('pecha_api.accumulator.accumulator_service.get_all_accumulators')
+    def test_get_all_accumulators_service_empty(self, mock_get_all, mock_session, mock_get_mantras):
         """Test get_all_accumulators_service when no accumulators exist."""
         mock_db = MagicMock()
         mock_session.return_value.__enter__.return_value = mock_db
 
         mock_get_all.return_value = ([], 0)
+        mock_get_mantras.return_value = {}
 
         result = get_all_accumulators_service(skip=0, limit=20)
 
         assert len(result.accumulators) == 0
         assert result.total == 0
 
+    @patch('pecha_api.accumulator.accumulator_service.get_mantras_by_ids')
     @patch('pecha_api.accumulator.accumulator_service.SessionLocal')
     @patch('pecha_api.accumulator.accumulator_service.get_all_accumulators')
-    def test_get_all_accumulators_service_pagination(self, mock_get_all, mock_session):
+    def test_get_all_accumulators_service_pagination(self, mock_get_all, mock_session, mock_get_mantras):
         """Test get_all_accumulators_service with custom pagination."""
         mock_db = MagicMock()
         mock_session.return_value.__enter__.return_value = mock_db
 
         acc1 = TestDataFactory.create_mock_accumulator()
         mock_get_all.return_value = ([acc1], 10)
+        mock_get_mantras.return_value = {}
 
         result = get_all_accumulators_service(skip=5, limit=1)
 
@@ -641,6 +737,69 @@ class TestUpdateAccumulatorService:
 
         assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN
 
+    @patch('pecha_api.accumulator.accumulator_service.TextUtils.validate_text_exists', new_callable=AsyncMock)
+    @patch('pecha_api.accumulator.accumulator_service.SessionLocal')
+    @patch('pecha_api.accumulator.accumulator_service.update_accumulator')
+    @patch('pecha_api.accumulator.accumulator_service.get_accumulator_by_id')
+    @patch('pecha_api.accumulator.accumulator_service.validate_and_extract_user_details')
+    @pytest.mark.asyncio
+    async def test_update_accumulator_service_updates_text_id(
+        self, mock_validate, mock_get, mock_update, mock_session, mock_validate_text
+    ):
+        """Test update_accumulator_service updates text_id after validation."""
+        user_id = uuid4()
+        accumulator_id = uuid4()
+        text_id = uuid4()
+        token = "valid_token"
+
+        mock_validate.return_value = TestDataFactory.create_mock_user(user_id=user_id)
+        mock_db = MagicMock()
+        mock_session.return_value.__enter__.return_value = mock_db
+        mock_validate_text.return_value = None
+
+        existing = TestDataFactory.create_mock_accumulator(
+            accumulator_id=accumulator_id, user_id=user_id
+        )
+        mock_get.return_value = existing
+        mock_update.return_value = existing
+
+        request = TestDataFactory.create_update_request(text_id=text_id)
+        await update_accumulator_service(token=token, accumulator_id=accumulator_id, request=request)
+
+        assert existing.text_id == text_id
+        mock_validate_text.assert_awaited_once_with(text_id=str(text_id))
+
+    @patch('pecha_api.accumulator.accumulator_service.validate_mantra_exists')
+    @patch('pecha_api.accumulator.accumulator_service.SessionLocal')
+    @patch('pecha_api.accumulator.accumulator_service.update_accumulator')
+    @patch('pecha_api.accumulator.accumulator_service.get_accumulator_by_id')
+    @patch('pecha_api.accumulator.accumulator_service.validate_and_extract_user_details')
+    @pytest.mark.asyncio
+    async def test_update_accumulator_service_updates_mantra_id(
+        self, mock_validate, mock_get, mock_update, mock_session, mock_validate_mantra
+    ):
+        """Test update_accumulator_service updates mantra_id after validation."""
+        user_id = uuid4()
+        accumulator_id = uuid4()
+        mantra_id = uuid4()
+        token = "valid_token"
+
+        mock_validate.return_value = TestDataFactory.create_mock_user(user_id=user_id)
+        mock_db = MagicMock()
+        mock_session.return_value.__enter__.return_value = mock_db
+
+        existing = TestDataFactory.create_mock_accumulator(
+            accumulator_id=accumulator_id, user_id=user_id
+        )
+        mock_get.return_value = existing
+        mock_update.return_value = existing
+
+        request = TestDataFactory.create_update_request(mantra_id=mantra_id)
+        await update_accumulator_service(token=token, accumulator_id=accumulator_id, request=request)
+
+        assert existing.mantra_id == mantra_id
+        mock_validate_mantra.assert_called_once_with(mock_db, mantra_id)
+
     @patch('pecha_api.accumulator.accumulator_service.SessionLocal')
     @patch('pecha_api.accumulator.accumulator_service.get_accumulator_by_id')
     @patch('pecha_api.accumulator.accumulator_service.validate_and_extract_user_details')
@@ -932,6 +1091,96 @@ class TestGetAccumulatorHistoryService:
         assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
 
 
+class TestGetAccumulatorDetailService:
+    """Test cases for get_accumulator_detail_service."""
+
+    @patch('pecha_api.accumulator.accumulator_service.SessionLocal')
+    @patch('pecha_api.accumulator.accumulator_service.get_accumulator_with_history')
+    @patch('pecha_api.accumulator.accumulator_service.validate_and_extract_user_details')
+    def test_get_accumulator_detail_service_success(self, mock_validate, mock_get_history, mock_session):
+        """Return history when the user already has an accumulator for the preset."""
+        token = "valid_token"
+        user_id = uuid4()
+        parent_id = uuid4()
+        mock_validate.return_value = TestDataFactory.create_mock_user(user_id=user_id)
+        mock_db = MagicMock()
+        mock_session.return_value.__enter__.return_value = mock_db
+
+        accumulator = TestDataFactory.create_mock_accumulator(
+            user_id=user_id,
+            parent_id=parent_id,
+            current_count=50,
+        )
+        sessions = [TestDataFactory.create_mock_history(accumulator_id=accumulator.id, user_id=user_id)]
+        mock_get_history.return_value = (accumulator, 50, sessions)
+
+        result = get_accumulator_detail_service(token=token, parent_id=parent_id)
+
+        assert isinstance(result, AccumulatorHistoryDTO)
+        assert result.accumulator_id == accumulator.id
+        assert result.parent_id == parent_id
+        assert result.current_count == 50
+        assert result.total_counted == 50
+        assert len(result.sessions) == 1
+        mock_get_history.assert_called_once_with(mock_db, user_id, parent_id)
+
+    @patch('pecha_api.accumulator.accumulator_service._create_accumulator_from_preset')
+    @patch('pecha_api.accumulator.accumulator_service.SessionLocal')
+    @patch('pecha_api.accumulator.accumulator_service.get_accumulator_with_history')
+    @patch('pecha_api.accumulator.accumulator_service.validate_and_extract_user_details')
+    def test_get_accumulator_detail_service_creates_when_missing(
+        self, mock_validate, mock_get_history, mock_session, mock_create
+    ):
+        """Auto-create from preset when the user has no accumulator yet."""
+        token = "valid_token"
+        user_id = uuid4()
+        parent_id = uuid4()
+        mock_validate.return_value = TestDataFactory.create_mock_user(user_id=user_id)
+        mock_db = MagicMock()
+        mock_session.return_value.__enter__.return_value = mock_db
+        mock_get_history.return_value = None
+
+        created = TestDataFactory.create_mock_accumulator(
+            user_id=user_id,
+            parent_id=parent_id,
+            current_count=0,
+        )
+        mock_create.return_value = created
+
+        result = get_accumulator_detail_service(token=token, parent_id=parent_id)
+
+        assert isinstance(result, AccumulatorHistoryDTO)
+        assert result.accumulator_id == created.id
+        assert result.parent_id == parent_id
+        assert result.current_count == 0
+        assert result.total_counted == 0
+        assert result.sessions == []
+        mock_create.assert_called_once_with(mock_db, user_id, parent_id)
+
+    @patch('pecha_api.accumulator.accumulator_service._create_accumulator_from_preset')
+    @patch('pecha_api.accumulator.accumulator_service.SessionLocal')
+    @patch('pecha_api.accumulator.accumulator_service.get_accumulator_with_history')
+    @patch('pecha_api.accumulator.accumulator_service.validate_and_extract_user_details')
+    def test_get_accumulator_detail_service_preset_not_found(
+        self, mock_validate, mock_get_history, mock_session, mock_create
+    ):
+        """Still returns 404 when the preset itself does not exist."""
+        token = "valid_token"
+        mock_validate.return_value = TestDataFactory.create_mock_user()
+        mock_db = MagicMock()
+        mock_session.return_value.__enter__.return_value = mock_db
+        mock_get_history.return_value = None
+        mock_create.side_effect = HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"error": "NOT_FOUND", "message": "Preset accumulator not found"},
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            get_accumulator_detail_service(token=token, parent_id=uuid4())
+
+        assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
+
+
 class TestHelperFunctions:
     """Test cases for helper/conversion functions."""
 
@@ -976,7 +1225,116 @@ class TestHelperFunctions:
         assert isinstance(result, PublicAccumulatorDTO)
         assert not hasattr(result, "user_id")
         assert not hasattr(result, "preset_id")
+        assert not hasattr(result, "mantra_id")
         assert result.id == accumulator.id
+        assert result.mantra is None
+
+    def test_build_preset_mantra_dto_defaults_to_english(self):
+        """Without a language filter, English metadata is preferred."""
+        mantra = TestDataFactory.create_mock_mantra(
+            metadata_entries=[
+                TestDataFactory.create_mock_mantra_metadata(
+                    mantra="BO text", language=LanguageCode.BO
+                ),
+                TestDataFactory.create_mock_mantra_metadata(
+                    mantra="EN text", language=LanguageCode.EN
+                ),
+            ],
+        )
+
+        result = build_preset_mantra_dto(mantra, language=None)
+
+        assert result is not None
+        assert result.mantra == "EN text"
+
+    def test_build_preset_mantra_dto_returns_none_without_metadata(self):
+        """No metadata entries yields no mantra detail."""
+        mantra = TestDataFactory.create_mock_mantra(metadata_entries=[])
+
+        assert build_preset_mantra_dto(mantra, language="en") is None
+
+    def test_build_preset_mantra_dto_returns_none_when_language_missing(self):
+        """Requested language with no matching metadata yields None."""
+        mantra = TestDataFactory.create_mock_mantra(
+            metadata_entries=[
+                TestDataFactory.create_mock_mantra_metadata(language=LanguageCode.EN)
+            ],
+        )
+
+        assert build_preset_mantra_dto(mantra, language="bo") is None
+
+    def test_build_preset_mantra_dto_falls_back_to_first_metadata(self):
+        """Without English metadata, the first entry is used."""
+        mantra = TestDataFactory.create_mock_mantra(
+            metadata_entries=[
+                TestDataFactory.create_mock_mantra_metadata(
+                    mantra="BO text", language=LanguageCode.BO
+                ),
+            ],
+        )
+
+        result = build_preset_mantra_dto(mantra, language=None)
+
+        assert result is not None
+        assert result.mantra == "BO text"
+
+    def test_convert_accumulator_to_public_dto_includes_mantra_detail(self):
+        """Public DTO embeds mantra detail when mantra data is available."""
+        mantra_id = uuid4()
+        mantra = TestDataFactory.create_mock_mantra(mantra_id=mantra_id)
+        accumulator = TestDataFactory.create_mock_accumulator(mantra_id=mantra_id)
+
+        result = convert_accumulator_to_public_dto(
+            accumulator,
+            mantras_by_id={mantra_id: mantra},
+            language="en",
+        )
+
+        assert result.mantra is not None
+        assert result.mantra.id == mantra_id
+        assert result.mantra.mantra == "Om Mani Padme Hum"
+
+    @patch('pecha_api.accumulator.accumulator_service.generate_presigned_access_url')
+    @patch('pecha_api.accumulator.accumulator_service.get')
+    def test_generate_mala_image_presigned_url_success(self, mock_get, mock_presign):
+        """Presigned URL is returned for a valid mala image key."""
+        mock_get.return_value = "test-bucket"
+        mock_presign.return_value = "https://signed-url"
+
+        assert generate_mala_image_presigned_url("mala-images/default.png") == "https://signed-url"
+
+    def test_generate_mala_image_presigned_url_none_for_empty_url(self):
+        """Empty mala image url returns None without calling S3."""
+        assert generate_mala_image_presigned_url(None) is None
+
+    @patch('pecha_api.accumulator.accumulator_service.generate_presigned_access_url', side_effect=Exception("s3 down"))
+    @patch('pecha_api.accumulator.accumulator_service.get', return_value="test-bucket")
+    def test_generate_mala_image_presigned_url_handles_errors(self, _mock_get, _mock_presign):
+        """S3 failures are swallowed and return None."""
+        assert generate_mala_image_presigned_url("mala-images/default.png") is None
+
+    @patch('pecha_api.accumulator.accumulator_service.commit_accumulator')
+    @patch('pecha_api.accumulator.accumulator_service.add_accumulator')
+    @patch('pecha_api.accumulator.accumulator_service.get_mantra_mala_image_id', return_value=None)
+    @patch('pecha_api.accumulator.accumulator_service.get_user_accumulator_by_parent')
+    @patch('pecha_api.accumulator.accumulator_service.get_preset_by_id')
+    def test_create_accumulator_from_preset_raises_when_duplicate(
+        self, mock_get_preset, mock_get_by_parent, _mock_mala, _mock_add, _mock_commit
+    ):
+        """Shared create helper rejects duplicate preset accumulators."""
+        user_id = uuid4()
+        preset_id = uuid4()
+        mock_get_preset.return_value = TestDataFactory.create_mock_accumulator(
+            accumulator_id=preset_id, accumulator_type=AccumulatorType.PRESET
+        )
+        mock_get_by_parent.return_value = TestDataFactory.create_mock_accumulator(
+            user_id=user_id, parent_id=preset_id
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            _create_accumulator_from_preset(MagicMock(), user_id, preset_id)
+
+        assert exc_info.value.status_code == status.HTTP_409_CONFLICT
 
     def test_is_user_created_accumulator_user_type(self):
         """is_user_created_accumulator returns True for USER type."""

--- a/tests/accumulator/test_accumulator_views.py
+++ b/tests/accumulator/test_accumulator_views.py
@@ -13,6 +13,8 @@ from pecha_api.accumulator.accumulator_views import (
     update_user_accumulator,
     delete_user_accumulator,
     get_user_accumulator_history,
+    get_accumulator_detail,
+    update_accumulator_mala_image,
 )
 from pecha_api.accumulator.accumulator_response_models import (
     AccumulatorsResponse,
@@ -22,6 +24,7 @@ from pecha_api.accumulator.accumulator_response_models import (
     PublicAccumulatorDTO,
     CreateAccumulatorRequest,
     UpdateAccumulatorRequest,
+    UpdateMalaImageRequest,
     AccumulatorHistoryResponse,
     AccumulatorHistoryDTO,
     AccumulatorSessionDTO,
@@ -103,7 +106,7 @@ class TestGetAllAccumulators:
         assert isinstance(result, PublicAccumulatorsResponse)
         assert len(result.accumulators) == 2
         assert result.total == 2
-        mock_service.assert_called_once_with(skip=0, limit=20)
+        mock_service.assert_called_once_with(skip=0, limit=20, language=None)
 
     @patch('pecha_api.accumulator.accumulator_views.get_all_accumulators_service')
     @pytest.mark.asyncio
@@ -134,7 +137,19 @@ class TestGetAllAccumulators:
         assert result.skip == 5
         assert result.limit == 1
         assert result.total == 10
-        mock_service.assert_called_once_with(skip=5, limit=1)
+        mock_service.assert_called_once_with(skip=5, limit=1, language=None)
+
+    @patch('pecha_api.accumulator.accumulator_views.get_all_accumulators_service')
+    @pytest.mark.asyncio
+    async def test_get_all_accumulators_with_language(self, mock_service):
+        """Test get_all_accumulators forwards the language filter to the service."""
+        mock_service.return_value = PublicAccumulatorsResponse(
+            accumulators=[], total=0, skip=0, limit=20
+        )
+
+        await get_all_preset_accumulators(skip=0, limit=20, language="bo")
+
+        mock_service.assert_called_once_with(skip=0, limit=20, language="bo")
 
 
 class TestGetUserAccumulators:
@@ -483,3 +498,62 @@ class TestGetUserAccumulatorHistory:
             )
 
         assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+class TestGetAccumulatorDetail:
+    """Test cases for get_accumulator_detail endpoint."""
+
+    @patch('pecha_api.accumulator.accumulator_views.get_accumulator_detail_service')
+    @pytest.mark.asyncio
+    async def test_get_accumulator_detail_success(self, mock_service):
+        """Test successful retrieval (or auto-create) of accumulator detail."""
+        parent_id = uuid4()
+        mock_service.return_value = AccumulatorHistoryDTO(
+            accumulator_id=uuid4(),
+            parent_id=parent_id,
+            target_count=108,
+            current_count=0,
+            total_counted=0,
+            metadata=[AccumulatorMetadataDTO(language="EN", name="Mani")],
+            sessions=[],
+        )
+
+        result = await get_accumulator_detail(
+            parent_id=parent_id,
+            credentials=TestDataFactory.create_auth_credentials(token="valid_token"),
+        )
+
+        assert isinstance(result, AccumulatorHistoryDTO)
+        assert result.parent_id == parent_id
+        mock_service.assert_called_once_with(token="valid_token", parent_id=parent_id)
+
+
+class TestUpdateAccumulatorMalaImage:
+    """Test cases for update_accumulator_mala_image endpoint."""
+
+    @patch('pecha_api.accumulator.accumulator_views.update_mala_image_service')
+    @pytest.mark.asyncio
+    async def test_update_accumulator_mala_image_success(self, mock_service):
+        """Test successful update of accumulator mala image."""
+        accumulator_id = uuid4()
+        mala_image_id = uuid4()
+        token = "valid_token"
+        request = UpdateMalaImageRequest(mala_image_id=mala_image_id)
+
+        mock_service.return_value = TestDataFactory.create_accumulator_dto(
+            accumulator_id=accumulator_id,
+            name="Updated Mala",
+        )
+
+        result = await update_accumulator_mala_image(
+            accumulator_id=accumulator_id,
+            request=request,
+            credentials=TestDataFactory.create_auth_credentials(token=token),
+        )
+
+        assert isinstance(result, AccumulatorDTO)
+        mock_service.assert_called_once_with(
+            token=token,
+            accumulator_id=accumulator_id,
+            request=request,
+        )

--- a/tests/mantra/test_mantra_repository.py
+++ b/tests/mantra/test_mantra_repository.py
@@ -1,0 +1,34 @@
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from pecha_api.mantra.mantra_repository import get_mantras_by_ids
+
+
+class TestGetMantrasByIds:
+    """Test cases for get_mantras_by_ids."""
+
+    def test_get_mantras_by_ids_empty_list(self):
+        """Empty input should short-circuit without querying."""
+        db = MagicMock()
+
+        result = get_mantras_by_ids(db, [])
+
+        assert result == {}
+        db.query.assert_not_called()
+
+    def test_get_mantras_by_ids_returns_map(self):
+        """Mantras are returned keyed by id."""
+        db = MagicMock()
+        mantra_id = uuid4()
+        mantra = MagicMock()
+        mantra.id = mantra_id
+
+        query = db.query.return_value
+        query.options.return_value = query
+        query.filter.return_value = query
+        query.all.return_value = [mantra]
+
+        result = get_mantras_by_ids(db, [mantra_id])
+
+        assert result == {mantra_id: mantra}
+        query.filter.assert_called_once()

--- a/tests/mantra/test_mantra_service.py
+++ b/tests/mantra/test_mantra_service.py
@@ -15,17 +15,17 @@ class TestDataFactory:
     @staticmethod
     def create_mock_metadata(
         metadata_id=None,
-        text="Om Mani Padme Hum",
-        meaning="The jewel in the lotus",
-        transliteration="om mani padme hum",
+        mantra="Om Mani Padme Hum",
+        title="The jewel in the lotus",
+        pronunciation="om mani padme hum",
         language=LanguageCode.EN,
     ):
         """Create a mock MantraMetadata entry."""
         entry = MagicMock(spec=MantraMetadata)
         entry.id = metadata_id or uuid4()
-        entry.text = text
-        entry.meaning = meaning
-        entry.transliteration = transliteration
+        entry.mantra = mantra
+        entry.title = title
+        entry.pronunciation = pronunciation
         entry.language = language
         return entry
 
@@ -51,10 +51,10 @@ class TestGetMantrasService:
         mock_session.return_value.__enter__.return_value = mock_db
 
         mantra1 = TestDataFactory.create_mock_mantra(
-            metadata_entries=[TestDataFactory.create_mock_metadata(text="Mantra 1")]
+            metadata_entries=[TestDataFactory.create_mock_metadata(mantra="Mantra 1")]
         )
         mantra2 = TestDataFactory.create_mock_mantra(
-            metadata_entries=[TestDataFactory.create_mock_metadata(text="Mantra 2")]
+            metadata_entries=[TestDataFactory.create_mock_metadata(mantra="Mantra 2")]
         )
         mock_get_all.return_value = [mantra1, mantra2]
 
@@ -62,7 +62,7 @@ class TestGetMantrasService:
 
         assert isinstance(result, MantraResponse)
         assert len(result.mantras) == 2
-        assert result.mantras[0].metadata[0].text == "Mantra 1"
+        assert result.mantras[0].metadata[0].mantra == "Mantra 1"
         mock_get_all.assert_called_once_with(mock_db, language=None)
 
     @patch('pecha_api.mantra.mantra_service.SessionLocal')
@@ -96,8 +96,8 @@ class TestGetMantrasService:
         mock_db = MagicMock()
         mock_session.return_value.__enter__.return_value = mock_db
 
-        en_entry = TestDataFactory.create_mock_metadata(text="English", language=LanguageCode.EN)
-        bo_entry = TestDataFactory.create_mock_metadata(text="Tibetan", language=LanguageCode.BO)
+        en_entry = TestDataFactory.create_mock_metadata(mantra="English", language=LanguageCode.EN)
+        bo_entry = TestDataFactory.create_mock_metadata(mantra="Tibetan", language=LanguageCode.BO)
         mantra = TestDataFactory.create_mock_mantra(metadata_entries=[en_entry, bo_entry])
         mock_get_all.return_value = [mantra]
 
@@ -114,7 +114,7 @@ class TestGetMantrasService:
         mock_db = MagicMock()
         mock_session.return_value.__enter__.return_value = mock_db
 
-        bo_entry = TestDataFactory.create_mock_metadata(text="Tibetan", language=LanguageCode.BO)
+        bo_entry = TestDataFactory.create_mock_metadata(mantra="Tibetan", language=LanguageCode.BO)
         mantra = TestDataFactory.create_mock_mantra(metadata_entries=[bo_entry])
         mock_get_all.return_value = [mantra]
 
@@ -130,8 +130,8 @@ class TestBuildMantraDto:
     def test_build_mantra_dto_no_language_includes_all(self):
         """Without a language filter, all metadata entries are included."""
         entries = [
-            TestDataFactory.create_mock_metadata(text="EN", language=LanguageCode.EN),
-            TestDataFactory.create_mock_metadata(text="BO", language=LanguageCode.BO),
+            TestDataFactory.create_mock_metadata(mantra="EN", language=LanguageCode.EN),
+            TestDataFactory.create_mock_metadata(mantra="BO", language=LanguageCode.BO),
         ]
         mantra = TestDataFactory.create_mock_mantra(metadata_entries=entries)
 
@@ -145,8 +145,8 @@ class TestBuildMantraDto:
     def test_build_mantra_dto_filters_by_language(self):
         """With a language filter, only matching entries are kept."""
         entries = [
-            TestDataFactory.create_mock_metadata(text="EN", language=LanguageCode.EN),
-            TestDataFactory.create_mock_metadata(text="ZH", language=LanguageCode.ZH),
+            TestDataFactory.create_mock_metadata(mantra="EN", language=LanguageCode.EN),
+            TestDataFactory.create_mock_metadata(mantra="ZH", language=LanguageCode.ZH),
         ]
         mantra = TestDataFactory.create_mock_mantra(metadata_entries=entries)
 

--- a/tests/mantra/test_mantra_views.py
+++ b/tests/mantra/test_mantra_views.py
@@ -11,12 +11,12 @@ class TestDataFactory:
     """Factory for creating test data objects."""
 
     @staticmethod
-    def create_metadata_dto(text="Om Mani Padme Hum", language=LanguageCode.EN) -> MantraMetadataDTO:
+    def create_metadata_dto(mantra="Om Mani Padme Hum", language=LanguageCode.EN) -> MantraMetadataDTO:
         return MantraMetadataDTO(
             id=uuid4(),
-            text=text,
-            meaning="meaning",
-            transliteration="translit",
+            mantra=mantra,
+            title="title",
+            pronunciation="pronunciation",
             language=language,
         )
 


### PR DESCRIPTION
- Introduced PresetMantraDTO for handling mantra details in a single language.
- Updated PublicAccumulatorDTO to reference PresetMantraDTO instead of mantra_id.
- Enhanced accumulator service functions to build and include mantra details based on language.
- Modified get_all_accumulators_service to support language filtering for mantra metadata.
- Updated related tests to ensure proper functionality and coverage for new features.