### PR TITLE
Add PresetMantraDTO and enhance accumulator services

### DIFF
--- a/migrations/versions/j3c4d5e6f7a8_merge_mantra_rename_and_mala_heads.py
+++ b/migrations/versions/j3c4d5e6f7a8_merge_mantra_rename_and_mala_heads.py
@@ -1,0 +1,25 @@
+"""merge mantra metadata rename and mala_image heads
+
+Revision ID: j3c4d5e6f7a8
+Revises: ffca36f72f3f, i2b3c4d5e6f7
+Create Date: 2026-06-17 20:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "j3c4d5e6f7a8"
+down_revision: Union[str, Sequence[str], None] = ("ffca36f72f3f", "i2b3c4d5e6f7")
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
- Introduced PresetMantraDTO for handling mantra details in a single language.
- Updated PublicAccumulatorDTO to reference PresetMantraDTO instead of mantra_id.
- Enhanced accumulator service functions to build and include mantra details based on language.
- Modified get_all_accumulators_service to support language filtering for mantra metadata.
- Updated related tests to ensure proper functionality and coverage for new features.