### PR TITLE
Enhance mantra functionality with CMS support and validation

### DIFF
--- a/pecha_api/app.py
+++ b/pecha_api/app.py
@@ -133,6 +133,7 @@ api.include_router(timer_router)
 api.include_router(accumulator_router)
 api.include_router(daily_log_views.daily_log_router)
 api.include_router(mantra_views.mantra_router)
+api.include_router(mantra_views.cms_mantra_router)
 api.include_router(events_router)
 api.include_router(cms_events_router)
 

--- a/pecha_api/mantra/mantra_metadata_model.py
+++ b/pecha_api/mantra/mantra_metadata_model.py
@@ -21,4 +21,4 @@ class MantraMetadata(Base):
     pronunciation = Column(Text, nullable=True)
     language = Column(LanguageCodeEnum, nullable=False)
 
-    mantra = relationship("Mantra", back_populates="metadata_entries")
+    parent_mantra = relationship("Mantra", back_populates="metadata_entries")

--- a/pecha_api/mantra/mantra_model.py
+++ b/pecha_api/mantra/mantra_model.py
@@ -25,7 +25,7 @@ class Mantra(Base):
 
     metadata_entries = relationship(
         "MantraMetadata",
-        back_populates="mantra",
+        back_populates="parent_mantra",
         cascade="all, delete-orphan",
     )
 

--- a/pecha_api/mantra/mantra_repository.py
+++ b/pecha_api/mantra/mantra_repository.py
@@ -29,7 +29,6 @@ def save_mantra(db: Session, mantra: Mantra, metadata_entries: List) -> Mantra:
         db.flush()
         _persist_metadata_entries(db, mantra.id, metadata_entries)
         db.commit()
-        db.refresh(mantra)
         return get_mantra_by_id(db, mantra.id)
     except IntegrityError as exc:
         db.rollback()

--- a/pecha_api/mantra/mantra_repository.py
+++ b/pecha_api/mantra/mantra_repository.py
@@ -35,7 +35,7 @@ def save_mantra(db: Session, mantra: Mantra, metadata_entries: List) -> Mantra:
         db.rollback()
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail={"error": "BAD_REQUEST", "message": str(exc.orig)},
+            detail={"error": "BAD_REQUEST", "message": "A database integrity constraint was violated."},
         ) from exc
 
 

--- a/pecha_api/mantra/mantra_repository.py
+++ b/pecha_api/mantra/mantra_repository.py
@@ -1,10 +1,54 @@
+from fastapi import HTTPException
 from sqlalchemy import select, exists
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, selectinload
+from starlette import status
 from typing import Dict, List, Optional
 from uuid import UUID
 
 from .mantra_model import Mantra
 from .mantra_metadata_model import MantraMetadata
+
+
+def _persist_metadata_entries(db: Session, mantra_id: UUID, metadata_entries: List) -> None:
+    for entry in metadata_entries:
+        db.add(
+            MantraMetadata(
+                mantra_id=mantra_id,
+                mantra=entry.mantra,
+                title=entry.title,
+                pronunciation=entry.pronunciation,
+                language=entry.language,
+            )
+        )
+
+
+def save_mantra(db: Session, mantra: Mantra, metadata_entries: List) -> Mantra:
+    try:
+        db.add(mantra)
+        db.flush()
+        _persist_metadata_entries(db, mantra.id, metadata_entries)
+        db.commit()
+        db.refresh(mantra)
+        return get_mantra_by_id(db, mantra.id)
+    except IntegrityError as exc:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"error": "BAD_REQUEST", "message": str(exc.orig)},
+        ) from exc
+
+
+def get_mantra_by_id(db: Session, mantra_id: UUID) -> Optional[Mantra]:
+    return (
+        db.query(Mantra)
+        .options(
+            selectinload(Mantra.metadata_entries),
+            selectinload(Mantra.mala),
+        )
+        .filter(Mantra.id == mantra_id)
+        .first()
+    )
 
 
 def get_all_mantras(db: Session, language: Optional[str] = None) -> List[Mantra]:

--- a/pecha_api/mantra/mantra_response_models.py
+++ b/pecha_api/mantra/mantra_response_models.py
@@ -1,8 +1,42 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 from typing import Optional, List
 from uuid import UUID
 
 from ..plans.plans_enums import LanguageCode
+
+
+def _validate_unique_languages(metadata: List["MantraMetadataInput"]) -> List["MantraMetadataInput"]:
+    languages = [entry.language.value for entry in metadata]
+    if len(languages) != len(set(languages)):
+        raise ValueError("Duplicate languages in metadata are not allowed")
+    return metadata
+
+
+class MantraMetadataInput(BaseModel):
+    mantra: str
+    title: Optional[str] = None
+    pronunciation: Optional[str] = None
+    language: LanguageCode
+
+    @field_validator("mantra")
+    @classmethod
+    def validate_mantra_not_empty(cls, value: str) -> str:
+        if not value or not value.strip():
+            raise ValueError("mantra text must not be empty")
+        return value.strip()
+
+
+class CreateMantraRequest(BaseModel):
+    audio_url: Optional[str] = None
+    mala_image_id: Optional[UUID] = None
+    metadata: List[MantraMetadataInput]
+
+    @field_validator("metadata")
+    @classmethod
+    def validate_metadata(cls, value: List[MantraMetadataInput]) -> List[MantraMetadataInput]:
+        if not value:
+            raise ValueError("At least one metadata entry is required")
+        return _validate_unique_languages(value)
 
 
 class MantraMetadataDTO(BaseModel):

--- a/pecha_api/mantra/mantra_service.py
+++ b/pecha_api/mantra/mantra_service.py
@@ -1,9 +1,20 @@
 from typing import Optional
 
-from ..db.database import SessionLocal
+from fastapi import HTTPException
+from starlette import status
+
+from ..accumulator.accumulator_repository import get_mala_image_by_id
 from ..accumulator.accumulator_service import generate_mala_image_presigned_url
-from .mantra_repository import get_all_mantras
-from .mantra_response_models import MantraDTO, MantraMetadataDTO, MantraResponse
+from ..db.database import SessionLocal
+from ..plans.authors.plan_authors_service import validate_cms_author_details
+from .mantra_model import Mantra
+from .mantra_repository import get_all_mantras, save_mantra
+from .mantra_response_models import (
+    CreateMantraRequest,
+    MantraDTO,
+    MantraMetadataDTO,
+    MantraResponse,
+)
 
 
 def _build_mantra_dto(mantra, language: Optional[str]) -> MantraDTO:
@@ -32,3 +43,24 @@ def get_mantras_service(language: Optional[str] = None) -> MantraResponse:
         return MantraResponse(
             mantras=[_build_mantra_dto(mantra, language) for mantra in mantras]
         )
+
+
+def create_mantra_service(token: str, request: CreateMantraRequest) -> MantraDTO:
+    validate_cms_author_details(token=token)
+
+    mantra = Mantra(
+        audio_url=request.audio_url,
+        mala_image=request.mala_image_id,
+    )
+
+    with SessionLocal() as db:
+        if request.mala_image_id is not None:
+            mala = get_mala_image_by_id(db, request.mala_image_id)
+            if mala is None:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f"Mala image with id '{request.mala_image_id}' does not exist",
+                )
+
+        saved = save_mantra(db, mantra, request.metadata)
+        return _build_mantra_dto(saved, language=None)

--- a/pecha_api/mantra/mantra_views.py
+++ b/pecha_api/mantra/mantra_views.py
@@ -1,13 +1,21 @@
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Depends, Query
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from typing import Annotated, Optional
 from starlette import status
 
-from .mantra_response_models import MantraResponse
-from .mantra_service import get_mantras_service
+from .mantra_response_models import CreateMantraRequest, MantraDTO, MantraResponse
+from .mantra_service import create_mantra_service, get_mantras_service
+
+oauth2_scheme = HTTPBearer()
 
 mantra_router = APIRouter(
     prefix="/mantra",
     tags=["Mantra"]
+)
+
+cms_mantra_router = APIRouter(
+    prefix="/cms/mantras",
+    tags=["CMS Mantras"],
 )
 
 
@@ -21,3 +29,18 @@ def get_mantras_endpoint(
 ):
 
     return get_mantras_service(language=language)
+
+
+@cms_mantra_router.post(
+    "",
+    status_code=status.HTTP_201_CREATED,
+    response_model=MantraDTO,
+)
+def create_mantra_endpoint(
+    create_mantra_request: CreateMantraRequest,
+    authentication_credential: Annotated[HTTPAuthorizationCredentials, Depends(oauth2_scheme)],
+) -> MantraDTO:
+    return create_mantra_service(
+        token=authentication_credential.credentials,
+        request=create_mantra_request,
+    )

--- a/tests/mantra/test_cms_mantra_service.py
+++ b/tests/mantra/test_cms_mantra_service.py
@@ -1,0 +1,78 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+from fastapi import HTTPException
+
+from pecha_api.mantra.mantra_response_models import CreateMantraRequest, MantraMetadataInput
+from pecha_api.mantra.mantra_service import create_mantra_service
+from pecha_api.plans.plans_enums import LanguageCode
+
+
+class TestCreateMantraService:
+    @patch("pecha_api.mantra.mantra_service.validate_cms_author_details")
+    @patch("pecha_api.mantra.mantra_service.SessionLocal")
+    @patch("pecha_api.mantra.mantra_service.save_mantra")
+    @patch("pecha_api.mantra.mantra_service._build_mantra_dto")
+    def test_create_mantra_service_success(
+        self,
+        mock_build_dto,
+        mock_save_mantra,
+        mock_session,
+        mock_validate_auth,
+    ):
+        mock_db = MagicMock()
+        mock_session.return_value.__enter__.return_value = mock_db
+
+        saved_mantra = MagicMock()
+        mock_save_mantra.return_value = saved_mantra
+        expected_dto = MagicMock()
+        mock_build_dto.return_value = expected_dto
+
+        request = CreateMantraRequest(
+            audio_url="mantras/test.mp3",
+            metadata=[
+                MantraMetadataInput(
+                    mantra="Om mani padme hum",
+                    title="Compassion mantra",
+                    language=LanguageCode.EN,
+                )
+            ],
+        )
+
+        result = create_mantra_service(token="token", request=request)
+
+        assert result is expected_dto
+        mock_validate_auth.assert_called_once_with(token="token")
+        mock_save_mantra.assert_called_once()
+        mock_build_dto.assert_called_once_with(saved_mantra, language=None)
+
+    @patch("pecha_api.mantra.mantra_service.validate_cms_author_details")
+    @patch("pecha_api.mantra.mantra_service.SessionLocal")
+    @patch("pecha_api.mantra.mantra_service.get_mala_image_by_id")
+    def test_create_mantra_service_invalid_mala_image(
+        self,
+        mock_get_mala,
+        mock_session,
+        mock_validate_auth,
+    ):
+        mock_db = MagicMock()
+        mock_session.return_value.__enter__.return_value = mock_db
+        mock_get_mala.return_value = None
+
+        mala_id = uuid4()
+        request = CreateMantraRequest(
+            mala_image_id=mala_id,
+            metadata=[
+                MantraMetadataInput(
+                    mantra="Om mani padme hum",
+                    language=LanguageCode.EN,
+                )
+            ],
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            create_mantra_service(token="token", request=request)
+
+        assert exc_info.value.status_code == 400
+        assert str(mala_id) in exc_info.value.detail

--- a/tests/mantra/test_cms_mantra_views.py
+++ b/tests/mantra/test_cms_mantra_views.py
@@ -1,0 +1,101 @@
+import uuid
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from pecha_api.app import api
+from pecha_api.mantra.mantra_response_models import MantraDTO, MantraMetadataDTO
+from pecha_api.plans.plans_enums import LanguageCode
+
+client = TestClient(api)
+
+
+def _sample_mantra_dto() -> MantraDTO:
+    return MantraDTO(
+        id=uuid.uuid4(),
+        audio_url="mantras/medicine-buddha.mp3",
+        metadata=[
+            MantraMetadataDTO(
+                id=uuid.uuid4(),
+                mantra="Tayatha om bekandze bekandze maha bekandze radza samudgate soha",
+                title="Medicine Buddha Mantra",
+                pronunciation="tayatha om bekandze...",
+                language=LanguageCode.EN,
+            )
+        ],
+    )
+
+
+def test_create_mantra_success():
+    payload = {
+        "audio_url": "mantras/medicine-buddha.mp3",
+        "metadata": [
+            {
+                "language": "EN",
+                "title": "Medicine Buddha Mantra",
+                "pronunciation": "tayatha om bekandze...",
+                "mantra": "Tayatha om bekandze bekandze maha bekandze radza samudgate soha",
+            },
+            {
+                "language": "BO",
+                "title": "སྨན་བླའི་སྔགས།",
+                "mantra": "ཨོཾ་བེ་ཀཱནྜེ་བེ་ཀཱནྜེ་མ་ཧཱ་བེ་ཀཱནྜེ་རཱ་ཇ་ས་མུདྒ་ཏེ་སྭཱ་ཧཱ།",
+            },
+        ],
+    }
+    sample_dto = _sample_mantra_dto()
+
+    with patch(
+        "pecha_api.mantra.mantra_views.create_mantra_service",
+        return_value=sample_dto,
+    ) as mock_create:
+        response = client.post(
+            "/api/v1/cms/mantras",
+            json=payload,
+            headers={"Authorization": "Bearer dummy"},
+        )
+
+    assert response.status_code == 201
+    assert response.json()["audio_url"] == sample_dto.audio_url
+    mock_create.assert_called_once()
+
+
+def test_create_mantra_requires_auth():
+    response = client.post(
+        "/api/v1/cms/mantras",
+        json={
+            "metadata": [
+                {
+                    "language": "EN",
+                    "mantra": "Om mani padme hum",
+                }
+            ]
+        },
+    )
+
+    assert response.status_code == 403
+
+
+def test_create_mantra_rejects_empty_metadata():
+    response = client.post(
+        "/api/v1/cms/mantras",
+        json={"metadata": []},
+        headers={"Authorization": "Bearer dummy"},
+    )
+
+    assert response.status_code == 422
+
+
+def test_create_mantra_rejects_duplicate_languages():
+    response = client.post(
+        "/api/v1/cms/mantras",
+        json={
+            "metadata": [
+                {"language": "EN", "mantra": "First"},
+                {"language": "EN", "mantra": "Second"},
+            ]
+        },
+        headers={"Authorization": "Bearer dummy"},
+    )
+
+    assert response.status_code == 422


### PR DESCRIPTION
- Added a new CMS endpoint for creating mantras, including validation for metadata entries.
- Refactored mantra relationships to use 'parent_mantra' for clarity.
- Introduced unique language validation for mantra metadata to prevent duplicates.
- Updated mantra service to handle mantra creation with associated metadata entries.
- Enhanced response models to support new mantra creation requests.