### PR TITLE
Add user series days completed feature with pagination support

### DIFF
--- a/pecha_api/plans/users/plan_users_progress_repository.py
+++ b/pecha_api/plans/users/plan_users_progress_repository.py
@@ -1,7 +1,7 @@
 from uuid import UUID
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, selectinload, joinedload
-from sqlalchemy import func
+from sqlalchemy import desc, func
 from pecha_api.plans.users.plan_users_response_models import EnrolledUserPlan
 from .plan_users_models import UserPlanProgress, UserTaskCompletion, UserDayCompletion, UserSubTaskCompletion
 from pecha_api.plans.plans_models import Plan
@@ -25,12 +25,46 @@ def save_plan_progress(db: Session, plan_progress: EnrolledUserPlan):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ResponseError(error=BAD_REQUEST, message=e.orig).model_dump())
 
 def get_user_total_practice_days(db: Session, user_id: UUID) -> int:
-    """Number of unique calendar dates on which the user completed a plan day."""
-    return db.query(
-        func.count(func.distinct(func.date(UserDayCompletion.completed_at)))
-    ).filter(
+    """Total number of plan days the user has completed."""
+    return db.query(func.count(UserDayCompletion.id)).filter(
         UserDayCompletion.user_id == user_id,
     ).scalar() or 0
+
+
+def get_user_series_days_completed_paginated(
+    db: Session,
+    user_id: UUID,
+    skip: int = 0,
+    limit: int = 20,
+) -> Tuple[List[Tuple[UUID, int]], int]:
+    """Return (series_id, days_completed) rows and total series count for pagination."""
+    grouped = (
+        db.query(
+            Plan.series_id.label("series_id"),
+            func.count(UserDayCompletion.id).label("days_completed"),
+            func.max(UserDayCompletion.completed_at).label("last_completed_at"),
+        )
+        .join(PlanItem, UserDayCompletion.day_id == PlanItem.id)
+        .join(Plan, PlanItem.plan_id == Plan.id)
+        .filter(
+            UserDayCompletion.user_id == user_id,
+            Plan.series_id.isnot(None),
+        )
+        .group_by(Plan.series_id)
+        .subquery()
+    )
+
+    total = db.query(func.count()).select_from(grouped).scalar() or 0
+
+    rows = (
+        db.query(grouped.c.series_id, grouped.c.days_completed)
+        .order_by(desc(grouped.c.last_completed_at))
+        .offset(skip)
+        .limit(limit)
+        .all()
+    )
+
+    return rows, total
 
 
 def get_plan_progress(db: Session, plan_id: UUID) -> List[UserPlanProgress]:

--- a/pecha_api/plans/users/plan_users_response_models.py
+++ b/pecha_api/plans/users/plan_users_response_models.py
@@ -156,3 +156,19 @@ class UserSeriesProgressResponse(BaseModel):
 class UpdateSeriesEnrollmentRequest(BaseModel):
     auto_enroll_next: Optional[bool] = None
     status: Optional[SeriesStatus] = None
+
+
+class UserSeriesDaysCompletedDTO(BaseModel):
+    series_id: UUID
+    series_title: str
+    series_description: Optional[str] = None
+    image: Optional[ImageUrlModel] = None
+    days_completed: int
+    group: Optional[AuthorGroupSummaryDTO] = None
+
+
+class UserSeriesDaysCompletedResponse(BaseModel):
+    series: List[UserSeriesDaysCompletedDTO]
+    skip: int
+    limit: int
+    total: int

--- a/pecha_api/plans/users/plan_users_service.py
+++ b/pecha_api/plans/users/plan_users_service.py
@@ -28,7 +28,9 @@ from pecha_api.plans.users.plan_users_response_models import (
     UserSeriesEnrollmentDTO,
     UserSeriesEnrollmentsResponse,
     UserSeriesProgressResponse,
-    UpdateSeriesEnrollmentRequest
+    UpdateSeriesEnrollmentRequest,
+    UserSeriesDaysCompletedDTO,
+    UserSeriesDaysCompletedResponse,
 )
 
 
@@ -77,7 +79,8 @@ from pecha_api.plans.users.plan_users_progress_repository import (
     get_plan_progress_by_user_id_and_plan_ids,
     save_plan_progress,
     get_user_enrolled_plans_with_details,
-    delete_user_plan_progress
+    delete_user_plan_progress,
+    get_user_series_days_completed_paginated,
 )
 from pecha_api.plans.users.plan_user_series_repository import (
     get_user_series_enrollment_by_user_and_series,
@@ -861,6 +864,68 @@ def get_user_series_enrollments(
             skip=skip,
             limit=limit,
             total=total
+        )
+
+
+def get_user_series_days_completed(
+    token: str,
+    language: Optional[str] = None,
+    skip: int = 0,
+    limit: int = 20,
+) -> UserSeriesDaysCompletedResponse:
+    """Get paginated list of series with completed day counts for the current user."""
+    current_user = validate_and_extract_user_details(token=token)
+
+    with SessionLocal() as db:
+        rows, total = get_user_series_days_completed_paginated(
+            db=db,
+            user_id=current_user.id,
+            skip=skip,
+            limit=limit,
+        )
+
+        if not rows:
+            return UserSeriesDaysCompletedResponse(
+                series=[],
+                skip=skip,
+                limit=limit,
+                total=total,
+            )
+
+        series_ids = [series_id for series_id, _ in rows]
+        series_by_id = {series.id: series for series in get_series_by_ids(db, series_ids)}
+        series_group_ids = get_group_ids_by_series_ids(db=db, series_ids=series_ids)
+        group_summaries = get_group_summaries_by_ids(
+            db=db, group_ids=list(series_group_ids.values()), language=language
+        )
+
+        series_dtos = []
+        for series_id, days_completed in rows:
+            series = series_by_id.get(series_id)
+            if not series:
+                continue
+            series_metadata = series.metadata_entries[0] if series.metadata_entries else None
+            series_dtos.append(
+                UserSeriesDaysCompletedDTO(
+                    series_id=series_id,
+                    series_title=series_metadata.title if series_metadata else "Untitled Series",
+                    series_description=series_metadata.description if series_metadata else None,
+                    image=safe_get_image_url(
+                        series.image, resource_id=series.id, resource_type="series"
+                    ),
+                    days_completed=days_completed,
+                    group=_group_summary_for_id(
+                        series_group_ids.get(series_id),
+                        group_summaries,
+                    ),
+                )
+            )
+
+        return UserSeriesDaysCompletedResponse(
+            series=series_dtos,
+            skip=skip,
+            limit=limit,
+            total=total,
         )
 
 

--- a/pecha_api/plans/users/plan_users_views.py
+++ b/pecha_api/plans/users/plan_users_views.py
@@ -15,7 +15,8 @@ from pecha_api.plans.users.plan_users_response_models import (
     UserSeriesEnrollRequest,
     UserSeriesEnrollmentsResponse,
     UserSeriesProgressResponse,
-    UpdateSeriesEnrollmentRequest
+    UpdateSeriesEnrollmentRequest,
+    UserSeriesDaysCompletedResponse,
 )
 
 from pecha_api.plans.users.plan_users_service import (
@@ -31,6 +32,7 @@ from pecha_api.plans.users.plan_users_service import (
     enroll_user_in_series,
     get_user_series_enrollments,
     get_user_series_progress,
+    get_user_series_days_completed,
     update_user_series_enrollment_service,
     unenroll_user_from_series
 )
@@ -182,6 +184,29 @@ async def get_user_series_enrollments_endpoint(
         language=language,
         skip=skip,
         limit=limit
+    )
+
+
+@user_progress_router.get(
+    "/series/day-completed",
+    status_code=status.HTTP_200_OK,
+    response_model=UserSeriesDaysCompletedResponse,
+)
+async def get_user_series_days_completed_endpoint(
+    authentication_credential: Annotated[HTTPAuthorizationCredentials, Depends(oauth2_scheme)],
+    language: Annotated[
+        Optional[str],
+        Query(description="Filter group metadata by language (e.g. 'en', 'bo', 'zh')"),
+    ] = None,
+    skip: Annotated[int, Query(ge=0)] = 0,
+    limit: Annotated[int, Query(ge=1, le=50)] = 20,
+):
+    """Get paginated list of series with completed day counts for the current user."""
+    return get_user_series_days_completed(
+        token=authentication_credential.credentials,
+        language=language,
+        skip=skip,
+        limit=limit,
     )
 
 

--- a/tests/plans/users/test_plan_users_progress_repository.py
+++ b/tests/plans/users/test_plan_users_progress_repository.py
@@ -1,0 +1,88 @@
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+from pecha_api.plans.users.plan_users_progress_repository import (
+    get_user_series_days_completed_paginated,
+    get_user_total_practice_days,
+)
+
+
+def test_get_user_total_practice_days_returns_count():
+    user_id = uuid4()
+    db = MagicMock()
+    db.query.return_value.filter.return_value.scalar.return_value = 15
+
+    assert get_user_total_practice_days(db=db, user_id=user_id) == 15
+
+
+def test_get_user_total_practice_days_returns_zero_when_no_completions():
+    user_id = uuid4()
+    db = MagicMock()
+    db.query.return_value.filter.return_value.scalar.return_value = None
+
+    assert get_user_total_practice_days(db=db, user_id=user_id) == 0
+
+
+@patch("pecha_api.plans.users.plan_users_progress_repository.desc", side_effect=lambda column: column)
+def test_get_user_series_days_completed_paginated_returns_rows_and_total(_mock_desc):
+    user_id = uuid4()
+    series_id = uuid4()
+    grouped_subq = MagicMock()
+
+    build_query = MagicMock()
+    build_query.join.return_value = build_query
+    build_query.filter.return_value = build_query
+    build_query.group_by.return_value.subquery.return_value = grouped_subq
+
+    total_query = MagicMock()
+    total_query.select_from.return_value.scalar.return_value = 2
+
+    rows_query = MagicMock()
+    rows_query.order_by.return_value.offset.return_value.limit.return_value.all.return_value = [
+        (series_id, 10),
+    ]
+
+    db = MagicMock()
+    db.query.side_effect = [build_query, total_query, rows_query]
+
+    rows, total = get_user_series_days_completed_paginated(
+        db=db,
+        user_id=user_id,
+        skip=0,
+        limit=20,
+    )
+
+    assert total == 2
+    assert rows == [(series_id, 10)]
+    rows_query.order_by.return_value.offset.assert_called_once_with(0)
+    rows_query.order_by.return_value.offset.return_value.limit.assert_called_once_with(20)
+
+
+@patch("pecha_api.plans.users.plan_users_progress_repository.desc", side_effect=lambda column: column)
+def test_get_user_series_days_completed_paginated_returns_zero_total_when_empty(_mock_desc):
+    user_id = uuid4()
+    grouped_subq = MagicMock()
+
+    build_query = MagicMock()
+    build_query.join.return_value = build_query
+    build_query.filter.return_value = build_query
+    build_query.group_by.return_value.subquery.return_value = grouped_subq
+
+    total_query = MagicMock()
+    total_query.select_from.return_value.scalar.return_value = None
+
+    rows_query = MagicMock()
+    rows_query.order_by.return_value.offset.return_value.limit.return_value.all.return_value = []
+
+    db = MagicMock()
+    db.query.side_effect = [build_query, total_query, rows_query]
+
+    rows, total = get_user_series_days_completed_paginated(
+        db=db,
+        user_id=user_id,
+        skip=5,
+        limit=10,
+    )
+
+    assert total == 0
+    assert rows == []

--- a/tests/plans/users/test_plan_users_series_service.py
+++ b/tests/plans/users/test_plan_users_series_service.py
@@ -21,6 +21,7 @@ from pecha_api.plans.users.plan_users_service import (
     _build_series_plan_dto_for_progress,
     enroll_user_in_series,
     get_user_series_enrollments,
+    get_user_series_days_completed,
     get_user_series_progress,
     update_user_series_enrollment_service,
     unenroll_user_from_series,
@@ -565,6 +566,82 @@ def test_get_user_series_enrollments_presigned_url_error():
 
     assert len(result.enrollments) == 1
     assert result.enrollments[0].image is None
+
+
+def test_get_user_series_days_completed_empty():
+    user_id = uuid.uuid4()
+    mock_user = SimpleNamespace(id=user_id)
+    db_mock, session_cm = _mock_session_with_db()
+
+    with patch(
+        "pecha_api.plans.users.plan_users_service.validate_and_extract_user_details",
+        return_value=mock_user,
+    ), patch(
+        "pecha_api.plans.users.plan_users_service.SessionLocal",
+        return_value=session_cm,
+    ), patch(
+        "pecha_api.plans.users.plan_users_service.get_user_series_days_completed_paginated",
+        return_value=([], 0),
+    ):
+        result = get_user_series_days_completed(token="tok", skip=0, limit=20)
+
+    assert result.series == []
+    assert result.total == 0
+    assert result.skip == 0
+    assert result.limit == 20
+
+
+def test_get_user_series_days_completed_success():
+    user_id = uuid.uuid4()
+    series_id = uuid.uuid4()
+    mock_user = SimpleNamespace(id=user_id)
+    db_mock, session_cm = _mock_session_with_db()
+
+    series = SimpleNamespace(
+        id=series_id,
+        image="series-image-key",
+        metadata_entries=[SimpleNamespace(title="Morning Practice", description="Daily series")],
+    )
+
+    with patch(
+        "pecha_api.plans.users.plan_users_service.validate_and_extract_user_details",
+        return_value=mock_user,
+    ), patch(
+        "pecha_api.plans.users.plan_users_service.SessionLocal",
+        return_value=session_cm,
+    ), patch(
+        "pecha_api.plans.users.plan_users_service.get_user_series_days_completed_paginated",
+        return_value=([(series_id, 12)], 1),
+    ) as mock_repo, patch(
+        "pecha_api.plans.users.plan_users_service.get_series_by_ids",
+        return_value=[series],
+    ), patch(
+        "pecha_api.plans.users.plan_users_service.get_group_ids_by_series_ids",
+        return_value={series_id: uuid.uuid4()},
+    ), patch(
+        "pecha_api.plans.users.plan_users_service.get_group_summaries_by_ids",
+        return_value={},
+    ), patch(
+        "pecha_api.plans.users.plan_users_service.safe_get_image_url",
+        return_value=ImageUrlModel(
+            thumbnail="https://signed.example.com/thumb.jpg",
+            medium="https://signed.example.com/medium.jpg",
+            original="https://signed.example.com/original.jpg",
+        ),
+    ):
+        result = get_user_series_days_completed(token="tok", skip=0, limit=20)
+
+    mock_repo.assert_called_once_with(
+        db=db_mock,
+        user_id=user_id,
+        skip=0,
+        limit=20,
+    )
+    assert result.total == 1
+    assert len(result.series) == 1
+    assert result.series[0].series_id == series_id
+    assert result.series[0].series_title == "Morning Practice"
+    assert result.series[0].days_completed == 12
 
 
 def test_get_user_series_progress_success():

--- a/tests/plans/users/test_plan_users_series_service.py
+++ b/tests/plans/users/test_plan_users_series_service.py
@@ -644,6 +644,91 @@ def test_get_user_series_days_completed_success():
     assert result.series[0].days_completed == 12
 
 
+def test_get_user_series_days_completed_skips_missing_series():
+    user_id = uuid.uuid4()
+    series_id = uuid.uuid4()
+    missing_series_id = uuid.uuid4()
+    mock_user = SimpleNamespace(id=user_id)
+    db_mock, session_cm = _mock_session_with_db()
+
+    known_series = SimpleNamespace(
+        id=series_id,
+        image=None,
+        metadata_entries=[SimpleNamespace(title="Known Series", description=None)],
+    )
+
+    with patch(
+        "pecha_api.plans.users.plan_users_service.validate_and_extract_user_details",
+        return_value=mock_user,
+    ), patch(
+        "pecha_api.plans.users.plan_users_service.SessionLocal",
+        return_value=session_cm,
+    ), patch(
+        "pecha_api.plans.users.plan_users_service.get_user_series_days_completed_paginated",
+        return_value=([(series_id, 4), (missing_series_id, 2)], 2),
+    ), patch(
+        "pecha_api.plans.users.plan_users_service.get_series_by_ids",
+        return_value=[known_series],
+    ), patch(
+        "pecha_api.plans.users.plan_users_service.get_group_ids_by_series_ids",
+        return_value={series_id: uuid.uuid4()},
+    ), patch(
+        "pecha_api.plans.users.plan_users_service.get_group_summaries_by_ids",
+        return_value={},
+    ), patch(
+        "pecha_api.plans.users.plan_users_service.safe_get_image_url",
+        return_value=None,
+    ):
+        result = get_user_series_days_completed(token="tok", skip=0, limit=20)
+
+    assert result.total == 2
+    assert len(result.series) == 1
+    assert result.series[0].series_id == series_id
+    assert result.series[0].days_completed == 4
+
+
+def test_get_user_series_days_completed_uses_untitled_when_metadata_missing():
+    user_id = uuid.uuid4()
+    series_id = uuid.uuid4()
+    mock_user = SimpleNamespace(id=user_id)
+    db_mock, session_cm = _mock_session_with_db()
+
+    series = SimpleNamespace(
+        id=series_id,
+        image=None,
+        metadata_entries=[],
+    )
+
+    with patch(
+        "pecha_api.plans.users.plan_users_service.validate_and_extract_user_details",
+        return_value=mock_user,
+    ), patch(
+        "pecha_api.plans.users.plan_users_service.SessionLocal",
+        return_value=session_cm,
+    ), patch(
+        "pecha_api.plans.users.plan_users_service.get_user_series_days_completed_paginated",
+        return_value=([(series_id, 3)], 1),
+    ), patch(
+        "pecha_api.plans.users.plan_users_service.get_series_by_ids",
+        return_value=[series],
+    ), patch(
+        "pecha_api.plans.users.plan_users_service.get_group_ids_by_series_ids",
+        return_value={},
+    ), patch(
+        "pecha_api.plans.users.plan_users_service.get_group_summaries_by_ids",
+        return_value={},
+    ), patch(
+        "pecha_api.plans.users.plan_users_service.safe_get_image_url",
+        return_value=None,
+    ):
+        result = get_user_series_days_completed(token="tok", language="en", skip=2, limit=5)
+
+    assert result.skip == 2
+    assert result.limit == 5
+    assert result.series[0].series_title == "Untitled Series"
+    assert result.series[0].series_description is None
+
+
 def test_get_user_series_progress_success():
     user_id = uuid.uuid4()
     series_id = uuid.uuid4()

--- a/tests/plans/users/test_plan_users_views.py
+++ b/tests/plans/users/test_plan_users_views.py
@@ -1112,3 +1112,34 @@ def test_get_user_series_days_completed_endpoint_success(authenticated_client):
         assert mock_get.call_args.kwargs.get("token") == VALID_TOKEN
         assert mock_get.call_args.kwargs.get("skip") == 0
         assert mock_get.call_args.kwargs.get("limit") == 20
+
+
+def test_get_user_series_days_completed_endpoint_with_filters(authenticated_client):
+    from pecha_api.plans.users.plan_users_response_models import UserSeriesDaysCompletedResponse
+
+    mock_response = UserSeriesDaysCompletedResponse(
+        series=[],
+        skip=5,
+        limit=10,
+        total=0,
+    )
+
+    with patch(
+        "pecha_api.plans.users.plan_users_views.get_user_series_days_completed",
+        return_value=mock_response,
+    ) as mock_get:
+        response = authenticated_client.get(
+            "/users/me/series/day-completed?language=bo&skip=5&limit=10",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert mock_get.call_args.kwargs.get("language") == "bo"
+        assert mock_get.call_args.kwargs.get("skip") == 5
+        assert mock_get.call_args.kwargs.get("limit") == 10
+
+
+def test_get_user_series_days_completed_endpoint_unauthenticated(unauthenticated_client):
+    response = unauthenticated_client.get("/users/me/series/day-completed")
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/tests/plans/users/test_plan_users_views.py
+++ b/tests/plans/users/test_plan_users_views.py
@@ -1065,3 +1065,50 @@ def test_unenroll_from_series_success(authenticated_client):
         assert response.status_code == status.HTTP_204_NO_CONTENT
         assert mock_unenroll.call_args.kwargs.get("token") == VALID_TOKEN
         assert mock_unenroll.call_args.kwargs.get("series_id") == series_id
+
+
+def test_get_user_series_days_completed_endpoint_success(authenticated_client):
+    from pecha_api.plans.media.media_response_models import ImageUrlModel
+    from pecha_api.plans.users.plan_users_response_models import (
+        UserSeriesDaysCompletedResponse,
+        UserSeriesDaysCompletedDTO,
+    )
+
+    series_id = uuid.uuid4()
+    mock_response = UserSeriesDaysCompletedResponse(
+        series=[
+            UserSeriesDaysCompletedDTO(
+                series_id=series_id,
+                series_title="Test Series",
+                series_description="Description",
+                image=ImageUrlModel(
+                    thumbnail="https://signed.example.com/series-thumb.jpg",
+                    medium="https://signed.example.com/series-medium.jpg",
+                    original="https://signed.example.com/series.jpg",
+                ),
+                days_completed=15,
+            )
+        ],
+        skip=0,
+        limit=20,
+        total=1,
+    )
+
+    with patch(
+        "pecha_api.plans.users.plan_users_views.get_user_series_days_completed",
+        return_value=mock_response,
+    ) as mock_get:
+        response = authenticated_client.get(
+            "/users/me/series/day-completed",
+            headers={"Authorization": f"Bearer {VALID_TOKEN}"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["total"] == 1
+        assert len(data["series"]) == 1
+        assert data["series"][0]["series_title"] == "Test Series"
+        assert data["series"][0]["days_completed"] == 15
+        assert mock_get.call_args.kwargs.get("token") == VALID_TOKEN
+        assert mock_get.call_args.kwargs.get("skip") == 0
+        assert mock_get.call_args.kwargs.get("limit") == 20


### PR DESCRIPTION
- Introduced `get_user_series_days_completed_paginated` function to retrieve completed days for user series with pagination.
- Added new response models: `UserSeriesDaysCompletedDTO` and `UserSeriesDaysCompletedResponse` for structured API responses.
- Implemented `get_user_series_days_completed` service function to handle business logic and data retrieval.
- Created endpoint `/series/day-completed` to expose the new functionality.
- Added unit tests for the new service and endpoint to ensure correctness and reliability.