### PR TITLE
Add exclude_group_ids parameter to get_groups_paginated and update re…

### DIFF
--- a/pecha_api/plans/groups/groups_repository.py
+++ b/pecha_api/plans/groups/groups_repository.py
@@ -163,6 +163,7 @@ def get_groups_paginated(
     language: Optional[str] = None,
     tag_id: Optional[UUID] = None,
     group_ids: Optional[Sequence[UUID]] = None,
+    exclude_group_ids: Optional[Sequence[UUID]] = None,
     is_public: Optional[bool] = None,
     group_type: Optional[AuthorGroupType] = None,
 ) -> Tuple[List[AuthorGroup], int]:
@@ -208,6 +209,8 @@ def get_groups_paginated(
         if not group_ids:
             return [], 0
         filters.append(AuthorGroup.id.in_(group_ids))
+    if exclude_group_ids:
+        filters.append(AuthorGroup.id.not_in(exclude_group_ids))
 
     query = (
         db.query(AuthorGroup)

--- a/pecha_api/plans/groups/groups_service.py
+++ b/pecha_api/plans/groups/groups_service.py
@@ -678,8 +678,18 @@ def list_public_groups(
     language: Optional[str] = None,
     tag_id: Optional[UUID] = None,
     group_type: AuthorGroupType = AuthorGroupType.COMMUNITY,
+    token: Optional[str] = None,
 ) -> PublicAuthorGroupListResponse:
     with SessionLocal() as db:
+        exclude_group_ids = None
+        if token:
+            try:
+                user = validate_and_extract_user_details(token=token)
+                joined_ids = get_joined_group_ids_by_user(db=db, user_id=user.id)
+                if joined_ids:
+                    exclude_group_ids = joined_ids
+            except Exception:
+                pass
         groups, total = get_groups_paginated(
             db=db,
             skip=skip,
@@ -687,6 +697,7 @@ def list_public_groups(
             search=search,
             language=language,
             tag_id=tag_id,
+            exclude_group_ids=exclude_group_ids,
             is_public=True,
             group_type=group_type,
         )

--- a/pecha_api/plans/groups/groups_views.py
+++ b/pecha_api/plans/groups/groups_views.py
@@ -55,6 +55,7 @@ from pecha_api.plans.groups.groups_service import (
 )
 
 oauth2_scheme = HTTPBearer()
+optional_oauth2_scheme = HTTPBearer(auto_error=False)
 
 cms_groups_router = APIRouter(prefix="/cms/author/groups", tags=["CMS Author Groups"])
 public_groups_router = APIRouter(prefix="/author/groups", tags=["Author Groups"])
@@ -322,6 +323,9 @@ def get_public_group(
 
 @public_groups_router.get("", status_code=status.HTTP_200_OK, response_model=PublicAuthorGroupListResponse)
 def get_public_groups(
+    authentication_credential: Annotated[
+        Optional[HTTPAuthorizationCredentials], Depends(optional_oauth2_scheme)
+    ] = None,
     search: Annotated[Optional[str], Query()] = None,
     language: Annotated[Optional[str], Query()] = None,
     tag_id: Annotated[Optional[UUID], Query()] = None,
@@ -339,6 +343,7 @@ def get_public_groups(
         group_type=group_type,
         skip=skip,
         limit=limit,
+        token=authentication_credential.credentials if authentication_credential else None,
     )
 
 

--- a/tests/plans/groups/test_groups_repository.py
+++ b/tests/plans/groups/test_groups_repository.py
@@ -8,6 +8,7 @@ from pecha_api.plans.groups.groups_repository import (
     get_group_id_for_series,
     get_group_ids_by_plan_ids,
     get_group_ids_by_series_ids,
+    get_groups_paginated,
     update_group,
 )
 
@@ -80,3 +81,26 @@ def test_update_group_commits_without_re_adding_instance():
     db.commit.assert_called_once()
     db.refresh.assert_called_once_with(group)
     assert result is group
+
+
+def test_get_groups_paginated_with_exclude_group_ids():
+    db = _make_session_mock()
+    query = MagicMock()
+    db.query.return_value = query
+    query.options.return_value = query
+    query.filter.return_value = query
+    query.count.return_value = 0
+    query.order_by.return_value = query
+    query.offset.return_value = query
+    query.limit.return_value.all.return_value = []
+
+    groups, total = get_groups_paginated(
+        db=db,
+        skip=0,
+        limit=10,
+        exclude_group_ids=[uuid.uuid4()],
+    )
+
+    assert groups == []
+    assert total == 0
+    query.filter.assert_called_once()

--- a/tests/plans/groups/test_groups_service.py
+++ b/tests/plans/groups/test_groups_service.py
@@ -370,6 +370,103 @@ def test_list_public_groups_returns_paginated():
     assert mock_paginated.call_args.kwargs["group_type"] == AuthorGroupType.COMMUNITY
 
 
+def test_list_public_groups_without_token_does_not_exclude_joined_groups():
+    group = _make_group(group_type=AuthorGroupType.COMMUNITY)
+    group.metadata_entries = []
+    with patch("pecha_api.plans.groups.groups_service.SessionLocal") as mock_session, patch(
+        "pecha_api.plans.groups.groups_service.get_groups_paginated",
+        return_value=([group], 1),
+    ) as mock_paginated, patch(
+        "pecha_api.plans.groups.groups_service.get_followers_count_map",
+        return_value={},
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_joiners_count_map",
+        return_value={},
+    ):
+        _session_local_context(mock_session)
+        list_public_groups(skip=0, limit=10)
+
+    assert mock_paginated.call_args.kwargs["exclude_group_ids"] is None
+
+
+def test_list_public_groups_with_token_excludes_joined_groups():
+    group = _make_group(group_type=AuthorGroupType.COMMUNITY)
+    group.metadata_entries = []
+    user_id = uuid4()
+    joined_group_id = uuid4()
+    user = MagicMock()
+    user.id = user_id
+    with patch("pecha_api.plans.groups.groups_service.SessionLocal") as mock_session, patch(
+        "pecha_api.plans.groups.groups_service.validate_and_extract_user_details",
+        return_value=user,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_joined_group_ids_by_user",
+        return_value=[joined_group_id],
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_groups_paginated",
+        return_value=([group], 1),
+    ) as mock_paginated, patch(
+        "pecha_api.plans.groups.groups_service.get_followers_count_map",
+        return_value={},
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_joiners_count_map",
+        return_value={},
+    ):
+        _session_local_context(mock_session)
+        list_public_groups(skip=0, limit=10, token="valid-token")
+
+    assert mock_paginated.call_args.kwargs["exclude_group_ids"] == [joined_group_id]
+
+
+def test_list_public_groups_with_token_and_no_joined_groups_does_not_exclude():
+    group = _make_group(group_type=AuthorGroupType.COMMUNITY)
+    group.metadata_entries = []
+    user = MagicMock()
+    user.id = uuid4()
+    with patch("pecha_api.plans.groups.groups_service.SessionLocal") as mock_session, patch(
+        "pecha_api.plans.groups.groups_service.validate_and_extract_user_details",
+        return_value=user,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_joined_group_ids_by_user",
+        return_value=[],
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_groups_paginated",
+        return_value=([group], 1),
+    ) as mock_paginated, patch(
+        "pecha_api.plans.groups.groups_service.get_followers_count_map",
+        return_value={},
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_joiners_count_map",
+        return_value={},
+    ):
+        _session_local_context(mock_session)
+        list_public_groups(skip=0, limit=10, token="valid-token")
+
+    assert mock_paginated.call_args.kwargs["exclude_group_ids"] is None
+
+
+def test_list_public_groups_with_invalid_token_does_not_exclude_joined_groups():
+    group = _make_group(group_type=AuthorGroupType.COMMUNITY)
+    group.metadata_entries = []
+    with patch("pecha_api.plans.groups.groups_service.SessionLocal") as mock_session, patch(
+        "pecha_api.plans.groups.groups_service.validate_and_extract_user_details",
+        side_effect=HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token"),
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_groups_paginated",
+        return_value=([group], 1),
+    ) as mock_paginated, patch(
+        "pecha_api.plans.groups.groups_service.get_followers_count_map",
+        return_value={},
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_joiners_count_map",
+        return_value={},
+    ):
+        _session_local_context(mock_session)
+        list_public_groups(skip=0, limit=10, token="invalid-token")
+
+    assert mock_paginated.call_args.kwargs["exclude_group_ids"] is None
+
+
 def _make_series_with_metadata():
     meta_en = MagicMock()
     meta_en.id = uuid4()

--- a/tests/plans/groups/test_groups_views.py
+++ b/tests/plans/groups/test_groups_views.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone, timedelta
 from uuid import uuid4
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from fastapi.testclient import TestClient
 from starlette import status
@@ -90,9 +90,75 @@ def test_get_public_groups_success():
 
     assert response.status_code == status.HTTP_200_OK
     mock_service.assert_called_once_with(
-        search=None, language=None, tag_id=None, group_type=AuthorGroupType.COMMUNITY, skip=0, limit=20
+        search=None,
+        language=None,
+        tag_id=None,
+        group_type=AuthorGroupType.COMMUNITY,
+        skip=0,
+        limit=20,
+        token=None,
     )
     assert response.json()["total"] == 1
+
+
+def test_get_public_groups_with_auth_passes_token():
+    group_summary = AuthorGroupSummaryDTO(
+        id=uuid4(),
+        slug="bodhichitta-authors",
+        group_type=AuthorGroupType.PAGE,
+        is_public=True,
+        metadata=_metadata(),
+        tags=[],
+        follower_count=4,
+        member_count=2,
+    )
+    response_model = AuthorGroupListResponse(groups=[group_summary], skip=0, limit=20, total=1)
+    with patch(
+        "pecha_api.plans.groups.groups_views.list_public_groups",
+        return_value=response_model,
+    ) as mock_service:
+        response = client.get("/author/groups", headers={"Authorization": "Bearer dummy"})
+
+    assert response.status_code == status.HTTP_200_OK
+    mock_service.assert_called_once_with(
+        search=None,
+        language=None,
+        tag_id=None,
+        group_type=AuthorGroupType.COMMUNITY,
+        skip=0,
+        limit=20,
+        token="dummy",
+    )
+
+
+def test_get_public_groups_with_auth_excludes_joined_groups_through_service():
+    joined_group_id = uuid4()
+    user = MagicMock()
+    user.id = uuid4()
+    with patch("pecha_api.plans.groups.groups_service.SessionLocal") as mock_session, patch(
+        "pecha_api.plans.groups.groups_service.validate_and_extract_user_details",
+        return_value=user,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_joined_group_ids_by_user",
+        return_value=[joined_group_id],
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_groups_paginated",
+        return_value=([], 0),
+    ) as mock_paginated, patch(
+        "pecha_api.plans.groups.groups_service.get_followers_count_map",
+        return_value={},
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_joiners_count_map",
+        return_value={},
+    ):
+        mock_db = MagicMock()
+        mock_session.return_value.__enter__.return_value = mock_db
+        mock_session.return_value.__exit__.return_value = False
+        response = client.get("/author/groups", headers={"Authorization": "Bearer dummy"})
+
+    assert response.status_code == status.HTTP_200_OK
+    assert mock_paginated.call_args.kwargs["exclude_group_ids"] == [joined_group_id]
+    assert response.json()["total"] == 0
 
 
 def test_create_group_invite_success():


### PR DESCRIPTION
…lated services and views

- Enhanced get_groups_paginated to accept exclude_group_ids for filtering out specific groups.
- Updated list_public_groups to handle token validation and exclude joined groups based on the user's token.
- Modified get_public_groups view to accept and pass the token for group filtering.
- Added tests to ensure correct behavior for excluding joined groups based on user authentication.