### PR TITLE
Enhance verse of the day service to support timezone

### DIFF
--- a/pecha_api/timezone_utils.py
+++ b/pecha_api/timezone_utils.py
@@ -1,0 +1,30 @@
+from datetime import date, datetime, timezone
+from typing import Optional, Union
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from fastapi import HTTPException
+from starlette import status
+
+TimezoneInfo = Union[ZoneInfo, timezone]
+
+
+def get_date_in_timezone(
+    timezone_name: Optional[str],
+    at: Optional[datetime] = None,
+) -> date:
+    moment = at or datetime.now(timezone.utc)
+    tz = _resolve_timezone(timezone_name)
+    return moment.astimezone(tz).date()
+
+
+def _resolve_timezone(timezone_name: Optional[str]) -> TimezoneInfo:
+    if not timezone_name or not timezone_name.strip():
+        return timezone.utc
+
+    try:
+        return ZoneInfo(timezone_name.strip())
+    except ZoneInfoNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Invalid timezone: {timezone_name}",
+        ) from exc

--- a/pecha_api/verse_of_day/verse_of_day_service.py
+++ b/pecha_api/verse_of_day/verse_of_day_service.py
@@ -2,6 +2,8 @@ from typing import Optional, Dict, List
 from uuid import UUID
 from datetime import date
 import logging
+
+from pecha_api.timezone_utils import get_date_in_timezone
 from fastapi import HTTPException
 from starlette import status
 
@@ -223,11 +225,12 @@ def get_verse_of_day_by_id_service(
 
 
 def get_verse_of_day_today_service(
-    lang: Optional[str] = None
+    lang: Optional[str] = None,
+    timezone: Optional[str] = None,
 ) -> VerseOfDayPublicResponse:
 
     with SessionLocal() as db:
-        today = date.today()
+        today = get_date_in_timezone(timezone)
         verse = get_verse_of_day_today(db, today=today)
         
         if verse is None:

--- a/pecha_api/verse_of_day/verse_of_day_views.py
+++ b/pecha_api/verse_of_day/verse_of_day_views.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Query, Depends
+from fastapi import APIRouter, Query, Depends, Header
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from typing import Annotated, Optional
 from uuid import UUID
@@ -43,9 +43,12 @@ def get_verse_of_day_endpoint(
 )
 def get_verse_of_day_today_endpoint(
     lang: Annotated[Optional[str], Query(description="Filter by language (en, bo, zh, hi, ne, mn). Returns all languages if not specified.")] = None,
+    x_timezone: Annotated[
+        Optional[str],
+        Header(alias="X-Timezone", description="IANA timezone for determining today's date."),
+    ] = None,
 ):
-
-    return get_verse_of_day_today_service(lang=lang)
+    return get_verse_of_day_today_service(lang=lang, timezone=x_timezone)
 
 
 @verse_of_day_router.get(

--- a/tests/test_timezone_utils.py
+++ b/tests/test_timezone_utils.py
@@ -1,0 +1,37 @@
+from datetime import date, datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+from starlette import status
+
+from pecha_api.timezone_utils import get_date_in_timezone
+
+
+def test_get_date_in_timezone_defaults_to_utc():
+    moment = datetime(2026, 6, 23, 2, 0, tzinfo=timezone.utc)
+    assert get_date_in_timezone(None, at=moment) == date(2026, 6, 23)
+
+
+def test_get_date_in_timezone_uses_client_timezone():
+    moment = datetime(2026, 6, 23, 2, 0, tzinfo=timezone.utc)
+    los_angeles = timezone(timedelta(hours=-7))
+
+    with patch("pecha_api.timezone_utils._resolve_timezone", return_value=los_angeles):
+        assert get_date_in_timezone("America/Los_Angeles", at=moment) == date(2026, 6, 22)
+
+
+def test_get_date_in_timezone_supports_positive_offset():
+    moment = datetime(2026, 6, 22, 20, 0, tzinfo=timezone.utc)
+    kathmandu = timezone(timedelta(hours=5, minutes=45))
+
+    with patch("pecha_api.timezone_utils._resolve_timezone", return_value=kathmandu):
+        assert get_date_in_timezone("Asia/Kathmandu", at=moment) == date(2026, 6, 23)
+
+
+def test_get_date_in_timezone_rejects_invalid_timezone():
+    with pytest.raises(HTTPException) as exc_info:
+        get_date_in_timezone("Not/A_Timezone")
+
+    assert exc_info.value.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert "Invalid timezone" in exc_info.value.detail

--- a/tests/verse_of_day/test_verse_of_day_service.py
+++ b/tests/verse_of_day/test_verse_of_day_service.py
@@ -522,10 +522,8 @@ async def test_get_verse_of_day_today_service_success(sample_verse_model, mock_d
     today = date(2025, 6, 5)
     
     with patch("pecha_api.verse_of_day.verse_of_day_service.SessionLocal", return_value=mock_db_session), \
-         patch("pecha_api.verse_of_day.verse_of_day_service.date") as mock_date, \
+         patch("pecha_api.verse_of_day.verse_of_day_service.get_date_in_timezone", return_value=today) as mock_today, \
          patch("pecha_api.verse_of_day.verse_of_day_service.get_verse_of_day_today", return_value=sample_verse_model) as mock_repo:
-        
-        mock_date.today.return_value = today
         
         result = get_verse_of_day_today_service()
         
@@ -535,7 +533,7 @@ async def test_get_verse_of_day_today_service_success(sample_verse_model, mock_d
         assert "en" in result.verse_of_day.verses
         assert result.verse_of_day.ref_id == sample_verse_model.ref_id
         
-        mock_date.today.assert_called_once()
+        mock_today.assert_called_once_with(None)
         mock_repo.assert_called_once_with(
             mock_db_session.__enter__.return_value,
             today=today
@@ -548,10 +546,8 @@ async def test_get_verse_of_day_today_service_with_lang(sample_verse_model, mock
     today = date(2025, 6, 5)
     
     with patch("pecha_api.verse_of_day.verse_of_day_service.SessionLocal", return_value=mock_db_session), \
-         patch("pecha_api.verse_of_day.verse_of_day_service.date") as mock_date, \
+         patch("pecha_api.verse_of_day.verse_of_day_service.get_date_in_timezone", return_value=today), \
          patch("pecha_api.verse_of_day.verse_of_day_service.get_verse_of_day_today", return_value=sample_verse_model):
-        
-        mock_date.today.return_value = today
         
         result = get_verse_of_day_today_service(lang="en")
         
@@ -566,10 +562,8 @@ async def test_get_verse_of_day_today_service_not_found(mock_db_session):
     today = date(2025, 6, 5)
     
     with patch("pecha_api.verse_of_day.verse_of_day_service.SessionLocal", return_value=mock_db_session), \
-         patch("pecha_api.verse_of_day.verse_of_day_service.date") as mock_date, \
+         patch("pecha_api.verse_of_day.verse_of_day_service.get_date_in_timezone", return_value=today), \
          patch("pecha_api.verse_of_day.verse_of_day_service.get_verse_of_day_today", return_value=None) as mock_repo:
-        
-        mock_date.today.return_value = today
         
         result = get_verse_of_day_today_service()
         
@@ -585,10 +579,8 @@ async def test_get_verse_of_day_today_service_database_error(mock_db_session):
     today = date(2025, 6, 5)
     
     with patch("pecha_api.verse_of_day.verse_of_day_service.SessionLocal", return_value=mock_db_session), \
-         patch("pecha_api.verse_of_day.verse_of_day_service.date") as mock_date, \
+         patch("pecha_api.verse_of_day.verse_of_day_service.get_date_in_timezone", return_value=today), \
          patch("pecha_api.verse_of_day.verse_of_day_service.get_verse_of_day_today", side_effect=Exception("Database error")):
-        
-        mock_date.today.return_value = today
         
         with pytest.raises(Exception, match="Database error"):
             get_verse_of_day_today_service()
@@ -600,11 +592,9 @@ async def test_get_verse_of_day_today_with_group_info_all_languages(sample_verse
     today = date(2025, 6, 5)
     
     with patch("pecha_api.verse_of_day.verse_of_day_service.SessionLocal", return_value=mock_db_session), \
-         patch("pecha_api.verse_of_day.verse_of_day_service.date") as mock_date, \
+         patch("pecha_api.verse_of_day.verse_of_day_service.get_date_in_timezone", return_value=today), \
          patch("pecha_api.verse_of_day.verse_of_day_service.get_verse_of_day_today", return_value=sample_verse_with_group_id), \
          patch("pecha_api.verse_of_day.verse_of_day_service.get_group_metadata_by_group_id", return_value=sample_group_metadata):
-        
-        mock_date.today.return_value = today
         
         result = get_verse_of_day_today_service()
         
@@ -619,11 +609,9 @@ async def test_get_verse_of_day_today_with_group_info_filtered(sample_verse_with
     today = date(2025, 6, 5)
     
     with patch("pecha_api.verse_of_day.verse_of_day_service.SessionLocal", return_value=mock_db_session), \
-         patch("pecha_api.verse_of_day.verse_of_day_service.date") as mock_date, \
+         patch("pecha_api.verse_of_day.verse_of_day_service.get_date_in_timezone", return_value=today), \
          patch("pecha_api.verse_of_day.verse_of_day_service.get_verse_of_day_today", return_value=sample_verse_with_group_id), \
          patch("pecha_api.verse_of_day.verse_of_day_service.get_group_metadata_by_group_id", return_value=sample_group_metadata):
-        
-        mock_date.today.return_value = today
         
         result = get_verse_of_day_today_service(lang="BO")
         
@@ -639,15 +627,32 @@ async def test_get_verse_of_day_today_without_group_id(sample_verse_without_grou
     today = date(2025, 6, 5)
     
     with patch("pecha_api.verse_of_day.verse_of_day_service.SessionLocal", return_value=mock_db_session), \
-         patch("pecha_api.verse_of_day.verse_of_day_service.date") as mock_date, \
+         patch("pecha_api.verse_of_day.verse_of_day_service.get_date_in_timezone", return_value=today), \
          patch("pecha_api.verse_of_day.verse_of_day_service.get_verse_of_day_today", return_value=sample_verse_without_group_id):
-        
-        mock_date.today.return_value = today
         
         result = get_verse_of_day_today_service()
         
         assert result.verse_of_day is not None
         assert result.verse_of_day.group_info is None
+
+
+@pytest.mark.asyncio
+async def test_get_verse_of_day_today_service_with_timezone(sample_verse_model, mock_db_session):
+    """Test today's verse uses the provided timezone."""
+    today = date(2025, 6, 4)
+
+    with patch("pecha_api.verse_of_day.verse_of_day_service.SessionLocal", return_value=mock_db_session), \
+         patch("pecha_api.verse_of_day.verse_of_day_service.get_date_in_timezone", return_value=today) as mock_today, \
+         patch("pecha_api.verse_of_day.verse_of_day_service.get_verse_of_day_today", return_value=sample_verse_model) as mock_repo:
+
+        result = get_verse_of_day_today_service(timezone="America/Los_Angeles")
+
+        assert result.verse_of_day is not None
+        mock_today.assert_called_once_with("America/Los_Angeles")
+        mock_repo.assert_called_once_with(
+            mock_db_session.__enter__.return_value,
+            today=today,
+        )
 
 
 # =============================================================================

--- a/tests/verse_of_day/test_verse_of_day_views.py
+++ b/tests/verse_of_day/test_verse_of_day_views.py
@@ -348,7 +348,7 @@ async def test_get_verse_of_day_today_success(sample_verse_public_response):
         assert "verses" in data["verse_of_day"]
         assert data["verse_of_day"]["ref_id"] == "text-123"
         
-        mock_service.assert_called_once_with(lang=None)
+        mock_service.assert_called_once_with(lang=None, timezone=None)
 
 
 @pytest.mark.asyncio
@@ -361,7 +361,7 @@ async def test_get_verse_of_day_today_not_found(sample_empty_response):
         data = response.json()
         
         assert data["verse_of_day"] is None
-        mock_service.assert_called_once_with(lang=None)
+        mock_service.assert_called_once_with(lang=None, timezone=None)
 
 
 @pytest.mark.asyncio
@@ -372,7 +372,67 @@ async def test_get_verse_of_day_today_database_error():
         
         assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
         assert response.json()["detail"] == "Database connection error"
-        mock_service.assert_called_once_with(lang=None)
+        mock_service.assert_called_once_with(lang=None, timezone=None)
+
+
+@pytest.mark.asyncio
+async def test_get_verse_of_day_today_with_timezone_header_america(sample_verse_public_response):
+    """Test today's verse uses X-Timezone header with an American timezone."""
+    with patch(
+        "pecha_api.verse_of_day.verse_of_day_views.get_verse_of_day_today_service",
+        return_value=sample_verse_public_response,
+    ) as mock_service:
+        response = client.get(
+            "/verse-of-day/today",
+            headers={"X-Timezone": "America/New_York"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        mock_service.assert_called_once_with(lang=None, timezone="America/New_York")
+
+
+@pytest.mark.asyncio
+async def test_get_verse_of_day_today_with_timezone_header(sample_verse_public_response):
+    """Test today's verse uses X-Timezone header."""
+    with patch(
+        "pecha_api.verse_of_day.verse_of_day_views.get_verse_of_day_today_service",
+        return_value=sample_verse_public_response,
+    ) as mock_service:
+        response = client.get(
+            "/verse-of-day/today",
+            headers={"X-Timezone": "Asia/Kathmandu"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        mock_service.assert_called_once_with(lang=None, timezone="Asia/Kathmandu")
+
+
+@pytest.mark.asyncio
+async def test_get_verse_of_day_today_ignores_timezone_query_param(sample_verse_public_response):
+    """Test X-Timezone header is used when a timezone query param is also sent."""
+    with patch(
+        "pecha_api.verse_of_day.verse_of_day_views.get_verse_of_day_today_service",
+        return_value=sample_verse_public_response,
+    ) as mock_service:
+        response = client.get(
+            "/verse-of-day/today?timezone=America/New_York",
+            headers={"X-Timezone": "Asia/Kathmandu"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        mock_service.assert_called_once_with(lang=None, timezone="Asia/Kathmandu")
+
+
+@pytest.mark.asyncio
+async def test_get_verse_of_day_today_invalid_timezone():
+    """Test invalid timezone returns 422."""
+    response = client.get(
+        "/verse-of-day/today",
+        headers={"X-Timezone": "Not/A_Timezone"},
+    )
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert "Invalid timezone" in response.json()["detail"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- Added timezone parameter to `get_verse_of_day_today_service` to allow fetching the verse based on the specified timezone.
- Updated the endpoint to accept an `X-Timezone` header for timezone specification.
- Modified tests to cover new timezone functionality, ensuring correct behavior with various timezone inputs and headers.
- Adjusted existing tests to reflect changes in service calls with the new timezone parameter.