### PR TITLE
Implement timezone-aware event retrieval and enhance response models

### DIFF
--- a/pecha_api/events/cms_event_views.py
+++ b/pecha_api/events/cms_event_views.py
@@ -16,7 +16,7 @@ cms_events_router = APIRouter(
 )
 
 
-@cms_events_router.post("", status_code=status.HTTP_201_CREATED, response_model=EventDTO)
+@cms_events_router.post("", status_code=status.HTTP_201_CREATED, response_model=EventDTO, response_model_exclude_none=True)
 async def create_event_endpoint(
     request: CreateEventRequest,
     credentials: Annotated[HTTPAuthorizationCredentials, Depends(oauth2_scheme)],
@@ -24,7 +24,7 @@ async def create_event_endpoint(
     return create_event_service(token=credentials.credentials, request=request)
 
 
-@cms_events_router.put("/{event_id}", status_code=status.HTTP_200_OK, response_model=EventDTO)
+@cms_events_router.put("/{event_id}", status_code=status.HTTP_200_OK, response_model=EventDTO, response_model_exclude_none=True)
 async def update_event_endpoint(
     event_id: UUID,
     request: UpdateEventRequest,

--- a/pecha_api/events/event_response_models.py
+++ b/pecha_api/events/event_response_models.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 from typing import Optional, List, Union
 from datetime import datetime
 from uuid import UUID
@@ -8,6 +8,8 @@ from pecha_api.plans.media.media_response_models import ImageUrlModel
 
 
 class EventMetadataDTO(BaseModel):
+    model_config = ConfigDict(ser_json_exclude_none=True)
+
     id: UUID
     name: str
     description: Optional[str] = None
@@ -36,6 +38,8 @@ def _validate_date_range(start_date: datetime, end_date: datetime) -> None:
 
 
 class EventDTO(BaseModel):
+    model_config = ConfigDict(ser_json_exclude_none=True)
+
     id: UUID
     plan_id: Optional[UUID] = None
     accumulator_id: Optional[UUID] = None

--- a/pecha_api/events/event_service.py
+++ b/pecha_api/events/event_service.py
@@ -6,6 +6,7 @@ from fastapi import HTTPException
 from starlette import status
 
 from pecha_api.db.database import SessionLocal
+from pecha_api.timezone_utils import get_day_bounds_in_timezone
 from pecha_api.plans.authors.plan_authors_service import (
     safe_get_image_url,
     validate_cms_author_details,
@@ -144,6 +145,24 @@ def get_events_service(
             skip=skip,
             limit=limit,
         )
+
+
+def get_events_today_service(
+    timezone: Optional[str] = None,
+    group_id: Optional[UUID] = None,
+    language: Optional[str] = None,
+    skip: int = 0,
+    limit: int = 20,
+) -> EventsResponse:
+    from_date, to_date = get_day_bounds_in_timezone(timezone)
+    return get_events_service(
+        group_id=group_id,
+        from_date=from_date,
+        to_date=to_date,
+        language=language,
+        skip=skip,
+        limit=limit,
+    )
 
 
 def get_event_by_id_service(event_id: UUID, language: Optional[str] = None) -> EventDTO:

--- a/pecha_api/events/event_views.py
+++ b/pecha_api/events/event_views.py
@@ -2,11 +2,15 @@ from datetime import datetime
 from typing import Annotated, Optional
 from uuid import UUID
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Header, Query
 from starlette import status
 
 from .event_response_models import EventsResponse, EventDTO
-from .event_service import get_events_service, get_event_by_id_service
+from .event_service import (
+    get_events_service,
+    get_events_today_service,
+    get_event_by_id_service,
+)
 
 events_router = APIRouter(
     prefix="/events",
@@ -14,7 +18,7 @@ events_router = APIRouter(
 )
 
 
-@events_router.get("", status_code=status.HTTP_200_OK, response_model=EventsResponse)
+@events_router.get("", status_code=status.HTTP_200_OK, response_model=EventsResponse, response_model_exclude_none=True)
 def get_events_endpoint(
     group_id: Annotated[Optional[UUID], Query(description="Filter by group ID")] = None,
     plan_id: Annotated[Optional[UUID], Query(description="Filter by plan ID")] = None,
@@ -41,7 +45,27 @@ def get_events_endpoint(
     )
 
 
-@events_router.get("/{event_id}", status_code=status.HTTP_200_OK, response_model=EventDTO)
+@events_router.get("/today", status_code=status.HTTP_200_OK, response_model=EventsResponse, response_model_exclude_none=True)
+def get_events_today_endpoint(
+    group_id: Annotated[Optional[UUID], Query(description="Filter by group ID")] = None,
+    language: Annotated[Optional[str], Query(description="Filter metadata by language code")] = None,
+    skip: Annotated[int, Query(ge=0)] = 0,
+    limit: Annotated[int, Query(ge=1, le=100)] = 20,
+    x_timezone: Annotated[
+        Optional[str],
+        Header(alias="X-Timezone", description="IANA timezone for determining today's date."),
+    ] = None,
+) -> EventsResponse:
+    return get_events_today_service(
+        timezone=x_timezone,
+        group_id=group_id,
+        language=language,
+        skip=skip,
+        limit=limit,
+    )
+
+
+@events_router.get("/{event_id}", status_code=status.HTTP_200_OK, response_model=EventDTO, response_model_exclude_none=True)
 def get_event_by_id_endpoint(
     event_id: UUID,
     language: Annotated[Optional[str], Query(description="Filter metadata by language code")] = None,

--- a/pecha_api/timezone_utils.py
+++ b/pecha_api/timezone_utils.py
@@ -1,5 +1,5 @@
-from datetime import date, datetime, timezone
-from typing import Optional, Union
+from datetime import date, datetime, time, timezone
+from typing import Optional, Tuple, Union
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from fastapi import HTTPException
@@ -15,6 +15,18 @@ def get_date_in_timezone(
     moment = at or datetime.now(timezone.utc)
     tz = _resolve_timezone(timezone_name)
     return moment.astimezone(tz).date()
+
+
+def get_day_bounds_in_timezone(
+    timezone_name: Optional[str],
+    at: Optional[datetime] = None,
+) -> Tuple[datetime, datetime]:
+    moment = at or datetime.now(timezone.utc)
+    tz = _resolve_timezone(timezone_name)
+    local_date = moment.astimezone(tz).date()
+    start = datetime.combine(local_date, time.min, tzinfo=tz)
+    end = datetime.combine(local_date, time.max, tzinfo=tz)
+    return start, end
 
 
 def _resolve_timezone(timezone_name: Optional[str]) -> TimezoneInfo:

--- a/tests/events/test_event_response_serialization.py
+++ b/tests/events/test_event_response_serialization.py
@@ -1,0 +1,40 @@
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+from unittest.mock import patch
+
+from pecha_api.app import api
+from pecha_api.events.event_response_models import EventDTO, EventsResponse
+
+client = TestClient(api)
+
+
+def test_event_response_omits_null_fields():
+    now = datetime.now(timezone.utc)
+    event = EventDTO(
+        id=uuid4(),
+        group_id=uuid4(),
+        start_date=now,
+        end_date=now,
+        is_one_day=True,
+        metadata=[],
+        created_at=now,
+        created_by="author@example.com",
+    )
+    payload = EventsResponse(events=[event], total=1, skip=0, limit=20)
+
+    with patch(
+        "pecha_api.events.event_views.get_events_today_service",
+        return_value=payload,
+    ):
+        response = client.get("/events/today")
+
+    event_body = response.json()["events"][0]
+    assert "plan_id" not in event_body
+    assert "accumulator_id" not in event_body
+    assert "mantra_id" not in event_body
+    assert "timer_id" not in event_body
+    assert "image" not in event_body
+    assert "image_url" not in event_body
+    assert "updated_at" not in event_body

--- a/tests/events/test_event_service.py
+++ b/tests/events/test_event_service.py
@@ -1,0 +1,43 @@
+from datetime import datetime, timezone
+from unittest.mock import patch
+from uuid import uuid4
+
+from pecha_api.events.event_response_models import EventDTO, EventsResponse
+from pecha_api.events.event_service import get_events_today_service
+
+
+def test_get_events_today_service_uses_day_bounds():
+    start = datetime(2026, 6, 23, 0, 0, tzinfo=timezone.utc)
+    end = datetime(2026, 6, 23, 23, 59, 59, 999999, tzinfo=timezone.utc)
+    now = datetime.now(timezone.utc)
+    event = EventDTO(
+        id=uuid4(),
+        group_id=uuid4(),
+        start_date=now,
+        end_date=now,
+        is_one_day=True,
+        metadata=[],
+        created_at=now,
+        created_by="author@example.com",
+    )
+    expected = EventsResponse(events=[event], total=1, skip=0, limit=20)
+
+    with patch(
+        "pecha_api.events.event_service.get_day_bounds_in_timezone",
+        return_value=(start, end),
+    ) as mock_bounds, patch(
+        "pecha_api.events.event_service.get_events_service",
+        return_value=expected,
+    ) as mock_get_events:
+        result = get_events_today_service(timezone="Asia/Kathmandu", language="en")
+
+    mock_bounds.assert_called_once_with("Asia/Kathmandu")
+    mock_get_events.assert_called_once_with(
+        group_id=None,
+        from_date=start,
+        to_date=end,
+        language="en",
+        skip=0,
+        limit=20,
+    )
+    assert result == expected

--- a/tests/events/test_event_views.py
+++ b/tests/events/test_event_views.py
@@ -1,0 +1,79 @@
+from datetime import datetime, timezone
+from unittest.mock import patch
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+from starlette import status
+
+from pecha_api.app import api
+from pecha_api.events.event_response_models import EventDTO, EventsResponse
+
+client = TestClient(api)
+
+
+def _sample_event_dto() -> EventDTO:
+    now = datetime.now(timezone.utc)
+    return EventDTO(
+        id=uuid4(),
+        group_id=uuid4(),
+        start_date=now,
+        end_date=now,
+        is_one_day=True,
+        metadata=[],
+        created_at=now,
+        created_by="author@example.com",
+    )
+
+
+def test_get_events_today_success():
+    event = _sample_event_dto()
+    response_payload = EventsResponse(events=[event], total=1, skip=0, limit=20)
+
+    with patch(
+        "pecha_api.events.event_views.get_events_today_service",
+        return_value=response_payload,
+    ) as mock_service:
+        response = client.get("/events/today")
+
+    assert response.status_code == status.HTTP_200_OK
+    body = response.json()
+    assert body["total"] == 1
+    assert len(body["events"]) == 1
+    mock_service.assert_called_once_with(
+        timezone=None,
+        group_id=None,
+        language=None,
+        skip=0,
+        limit=20,
+    )
+
+
+def test_get_events_today_with_timezone_header():
+    response_payload = EventsResponse(events=[], total=0, skip=0, limit=20)
+
+    with patch(
+        "pecha_api.events.event_views.get_events_today_service",
+        return_value=response_payload,
+    ) as mock_service:
+        response = client.get(
+            "/events/today",
+            headers={"X-Timezone": "America/New_York"},
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    mock_service.assert_called_once_with(
+        timezone="America/New_York",
+        group_id=None,
+        language=None,
+        skip=0,
+        limit=20,
+    )
+
+
+def test_get_events_today_invalid_timezone():
+    response = client.get(
+        "/events/today",
+        headers={"X-Timezone": "Not/A_Timezone"},
+    )
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY

--- a/tests/test_timezone_utils.py
+++ b/tests/test_timezone_utils.py
@@ -5,7 +5,7 @@ import pytest
 from fastapi import HTTPException
 from starlette import status
 
-from pecha_api.timezone_utils import get_date_in_timezone
+from pecha_api.timezone_utils import get_date_in_timezone, get_day_bounds_in_timezone
 
 
 def test_get_date_in_timezone_defaults_to_utc():
@@ -35,3 +35,22 @@ def test_get_date_in_timezone_rejects_invalid_timezone():
 
     assert exc_info.value.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
     assert "Invalid timezone" in exc_info.value.detail
+
+
+def test_get_day_bounds_in_timezone_defaults_to_utc():
+    moment = datetime(2026, 6, 23, 15, 30, tzinfo=timezone.utc)
+    start, end = get_day_bounds_in_timezone(None, at=moment)
+
+    assert start == datetime(2026, 6, 23, 0, 0, tzinfo=timezone.utc)
+    assert end == datetime(2026, 6, 23, 23, 59, 59, 999999, tzinfo=timezone.utc)
+
+
+def test_get_day_bounds_in_timezone_uses_client_timezone():
+    moment = datetime(2026, 6, 23, 2, 0, tzinfo=timezone.utc)
+    los_angeles = timezone(timedelta(hours=-7))
+
+    with patch("pecha_api.timezone_utils._resolve_timezone", return_value=los_angeles):
+        start, end = get_day_bounds_in_timezone("America/Los_Angeles", at=moment)
+
+    assert start == datetime(2026, 6, 22, 0, 0, tzinfo=los_angeles)
+    assert end == datetime(2026, 6, 22, 23, 59, 59, 999999, tzinfo=los_angeles)


### PR DESCRIPTION
- Added `get_day_bounds_in_timezone` function to calculate start and end of the day in a specified timezone.
- Introduced `get_events_today_service` to fetch events for the current day based on the provided timezone.
- Updated event endpoints to include `response_model_exclude_none=True` for cleaner responses.
- Enhanced `EventMetadataDTO` and `EventDTO` models to exclude None values in JSON responses.
- Added tests for the new timezone functionality and validated behavior with different timezone inputs.