### PR TITLE
Add video details to user plan day response model

### DIFF
--- a/pecha_api/plans/users/plan_users_response_models.py
+++ b/pecha_api/plans/users/plan_users_response_models.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from pecha_api.plans.plans_enums import ContentType, SeriesStatus
 from pecha_api.plans.tags.tag_response_models import TagSummaryDTO
 from pecha_api.plans.groups.group_summary_models import AuthorGroupSummaryDTO
+from pecha_api.plans.public.plan_response_models import DayVideoSummaryDTO
 
 
 
@@ -101,6 +102,7 @@ class UserPlanDayDetailsResponse(BaseModel):
     is_completed: bool
     audio_url: Optional[str] = None
     audio_duration_ms: Optional[int] = None
+    videos: List[DayVideoSummaryDTO] = []
 
 
 # Series Enrollment Models

--- a/pecha_api/plans/users/plan_users_service.py
+++ b/pecha_api/plans/users/plan_users_service.py
@@ -610,6 +610,7 @@ def get_user_plan_day_details_service(token: str, plan_id: UUID, day_number: int
         from pecha_api.plans.audio.dto_helpers import build_plan_day_audio_fields
 
         audio_url, audio_duration_ms, _, _ = build_plan_day_audio_fields(plan_item)
+        from pecha_api.plans.public.plan_response_models import DayVideoSummaryDTO
         user_day_details = UserPlanDayDetailsResponse(
             id=plan_item.id,
             day_number=plan_item.day_number,
@@ -625,7 +626,17 @@ def get_user_plan_day_details_service(token: str, plan_id: UUID, day_number: int
                     is_completed=(task.id in completed_task_ids),
                     sub_tasks=_get_user_sub_tasks_dto_bulk(sub_tasks=task.sub_tasks, completed_subtask_ids=completed_subtask_ids)
                 ) for task in plan_item.tasks
-            ]
+            ],
+            videos=[
+                DayVideoSummaryDTO(
+                    id=video.id,
+                    url=video.url,
+                    video_id=video.video_id,
+                    title=video.title,
+                    display_order=video.display_order,
+                )
+                for video in sorted(plan_item.videos, key=lambda v: v.display_order)
+            ],
         )
         return user_day_details
 

--- a/tests/plans/users/test_plan_users_service.py
+++ b/tests/plans/users/test_plan_users_service.py
@@ -1596,6 +1596,7 @@ def test_get_user_plan_day_details_service_success():
     plan_item = SimpleNamespace(
         id=day_id,
         day_number=3,
+        videos=[],
         tasks=[
             SimpleNamespace(
                 id=task1_id,
@@ -1753,6 +1754,7 @@ def test_get_user_plan_day_details_service_image_subtask_presigned():
     plan_item = SimpleNamespace(
         id=day_id,
         day_number=1,
+        videos=[],
         tasks=[
             SimpleNamespace(
                 id=task_id,
@@ -1826,6 +1828,7 @@ def test_get_user_plan_day_details_service_with_segment_fields():
     plan_item = SimpleNamespace(
         id=day_id,
         day_number=1,
+        videos=[],
         tasks=[
             SimpleNamespace(
                 id=task_id,


### PR DESCRIPTION
- Introduced `videos` field in `UserPlanDayDetailsResponse` to include a list of video summaries.
- Updated `get_user_plan_day_details_service` to populate the new `videos` field with sorted video data from the plan item.