### PR TITLE
Enhance recitation models and services

### DIFF
--- a/pecha_api/recitations/recitations_response_models.py
+++ b/pecha_api/recitations/recitations_response_models.py
@@ -2,10 +2,15 @@ from typing import List, Dict, Optional
 from pydantic import BaseModel, Field
 from uuid import UUID
 
+class Segment(BaseModel):
+    id: UUID
+    content: str
+
 class RecitationDTO(BaseModel):
     title: str
     text_id: UUID
-    image_url: Optional[str] = None  
+    image_url: Optional[str] = None
+    first_segment: Optional[Segment] = None
 
 class RecitationsResponse(BaseModel):
     recitations: List[RecitationDTO]
@@ -16,10 +21,6 @@ class RecitationDetailsRequest(BaseModel):
     translations: List[str] = []
     transliterations: List[str] = []
     adaptations: List[str] = []
-
-class Segment(BaseModel):
-    id: UUID
-    content: str
 
 class RecitationSegment(BaseModel):
     recitation: Dict[str, Segment] = Field(default_factory=dict)

--- a/pecha_api/recitations/recitations_services.py
+++ b/pecha_api/recitations/recitations_services.py
@@ -4,8 +4,10 @@ from typing import List, Dict, Union,Optional
 from pecha_api.collections.collections_repository import get_all_collections_by_parent, get_collection_id_by_slug
 from pecha_api.collections.collections_service import get_collection
 from pecha_api.recitations.recitations_repository import apply_search_recitation_title_filter, get_text_images_by_text_ids
-from pecha_api.recitations.recitations_response_models import RecitationDTO, RecitationsResponse
-from pecha_api.texts.texts_repository import get_all_texts_by_collection
+from pecha_api.recitations.recitations_response_models import RecitationDTO, RecitationsResponse, Segment
+from pecha_api.texts.texts_repository import get_all_texts_by_collection, get_contents_by_text_ids
+from pecha_api.texts.segments.segments_repository import get_segment_contents_by_ids
+from pecha_api.texts.texts_toc_utils import get_first_segment_ids_by_text_ids
 from pecha_api.texts.texts_service import get_root_text_by_collection_id
 from fastapi import HTTPException
 from starlette import status
@@ -26,7 +28,6 @@ from pecha_api.recitations.recitations_response_models import (
     RecitationDetailsResponse,
     Segment,
     RecitationSegment,  
-    RecitationsResponse
 )
 from pecha_api.cache.cache_enums import CacheType
 from pecha_api.recitations.recication_cache_services import set_recitation_by_text_id_cache, get_recitation_by_text_id_cache
@@ -52,11 +53,46 @@ def get_recitations_with_image_urls(recitations: List[RecitationDTO]) -> List[Re
             title=recitation.title,
             text_id=recitation.text_id,
             image_url=image_url_map.get(str(recitation.text_id)),
+            first_segment=recitation.first_segment,
         )
         for recitation in recitations
     ]
 
     return recitations_with_images
+
+async def get_recitations_with_first_segments(recitations: List[RecitationDTO]) -> List[RecitationDTO]:
+    text_ids = [str(recitation.text_id) for recitation in recitations]
+    if not text_ids:
+        return recitations
+
+    table_of_contents_by_text_id = await get_contents_by_text_ids(text_ids=text_ids)
+    first_segment_ids = get_first_segment_ids_by_text_ids(table_of_contents_by_text_id)
+
+    if not first_segment_ids:
+        return recitations
+
+    segment_contents = await get_segment_contents_by_ids(
+        segment_ids=list(first_segment_ids.values())
+    )
+
+    first_segments_by_text_id: Dict[str, Segment] = {}
+    for text_id, segment_id in first_segment_ids.items():
+        content_data = segment_contents.get(segment_id)
+        if content_data:
+            first_segments_by_text_id[text_id] = Segment(
+                id=UUID(segment_id),
+                content=content_data[1],
+            )
+
+    return [
+        RecitationDTO(
+            title=recitation.title,
+            text_id=recitation.text_id,
+            image_url=recitation.image_url,
+            first_segment=first_segments_by_text_id.get(str(recitation.text_id)),
+        )
+        for recitation in recitations
+    ]
 
 async def get_list_of_recitations_service(search: Optional[str] = None, language: str = "en") -> RecitationsResponse:
     collection_id = await get_collection_id_by_slug(slug="Liturgy")
@@ -67,8 +103,9 @@ async def get_list_of_recitations_service(search: Optional[str] = None, language
 
     serched_texts=apply_search_recitation_title_filter(texts=recitation_list_text_response.recitations, search=search)
     recitations_with_images = get_recitations_with_image_urls(recitations=serched_texts)
+    recitations_with_first_segments = await get_recitations_with_first_segments(recitations=recitations_with_images)
     
-    return RecitationsResponse(recitations=recitations_with_images)
+    return RecitationsResponse(recitations=recitations_with_first_segments)
 
 
 async def get_recitation_details_service(text_id: str, recitation_details_request: RecitationDetailsRequest) -> RecitationDetailsResponse:

--- a/pecha_api/texts/texts_toc_utils.py
+++ b/pecha_api/texts/texts_toc_utils.py
@@ -25,6 +25,19 @@ def find_first_segment_in_sections(sections: List[Section]) -> Optional[str]:
     return None
 
 
+def get_first_segment_ids_by_text_ids(
+    table_of_contents_by_text_id: Dict[str, List[TableOfContent]],
+) -> Dict[str, str]:
+    result: Dict[str, str] = {}
+    for text_id, table_of_contents in table_of_contents_by_text_id.items():
+        for table_of_content in table_of_contents:
+            segment_id = find_first_segment_in_sections(table_of_content.sections)
+            if segment_id:
+                result[text_id] = segment_id
+                break
+    return result
+
+
 def iter_segment_positions(table_of_content: TableOfContent) -> Iterator[Tuple[str, int]]:
     position = 1
 

--- a/tests/recitations/test_recitations_services.py
+++ b/tests/recitations/test_recitations_services.py
@@ -7,6 +7,7 @@ from starlette import status
 from pecha_api.recitations.recitations_services import (
     get_list_of_recitations_service,
     get_recitation_details_service,
+    get_recitations_with_first_segments,
     segments_mapping_by_toc,
     filter_by_type_and_language,
     _filter_and_map_segments,
@@ -41,9 +42,11 @@ class TestGetListOfRecitationsService:
     @patch('pecha_api.recitations.recitations_services.get_root_text_by_collection_id')
     @patch('pecha_api.recitations.recitations_services.apply_search_recitation_title_filter')
     @patch('pecha_api.recitations.recitations_services.get_recitations_with_image_urls')
+    @patch('pecha_api.recitations.recitations_services.get_recitations_with_first_segments')
     @pytest.mark.asyncio
     async def test_get_list_of_recitations_service_success(
         self,
+        mock_get_recitations_with_first_segments,
         mock_get_recitations_with_image_urls,
         mock_apply_search_filter,
         mock_get_root_text,
@@ -61,6 +64,7 @@ class TestGetListOfRecitationsService:
         mock_get_root_text.return_value = mock_recitations_response
         mock_apply_search_filter.return_value = [recitation_dto]
         mock_get_recitations_with_image_urls.return_value = [recitation_dto]
+        mock_get_recitations_with_first_segments.return_value = [recitation_dto]
         
         # Execute
         result = await get_list_of_recitations_service(language="en")
@@ -78,6 +82,7 @@ class TestGetListOfRecitationsService:
         mock_get_collection_id.assert_called_once_with(slug="Liturgy")
         mock_get_root_text.assert_called_once_with(collection_id=liturgy_collection_id, language="en")
         mock_apply_search_filter.assert_called_once_with(texts=[recitation_dto], search=None)
+        mock_get_recitations_with_first_segments.assert_awaited_once_with(recitations=[recitation_dto])
 
     @patch('pecha_api.recitations.recitations_services.get_collection_id_by_slug')
     @pytest.mark.asyncio
@@ -130,9 +135,11 @@ class TestGetListOfRecitationsService:
     @patch('pecha_api.recitations.recitations_services.get_root_text_by_collection_id')
     @patch('pecha_api.recitations.recitations_services.apply_search_recitation_title_filter')
     @patch('pecha_api.recitations.recitations_services.get_recitations_with_image_urls')
+    @patch('pecha_api.recitations.recitations_services.get_recitations_with_first_segments')
     @pytest.mark.asyncio
     async def test_get_list_of_recitations_service_with_search_match(
         self,
+        mock_get_recitations_with_first_segments,
         mock_get_recitations_with_image_urls,
         mock_apply_search_filter,
         mock_get_root_text,
@@ -149,6 +156,7 @@ class TestGetListOfRecitationsService:
         mock_get_root_text.return_value = mock_recitations_response
         mock_apply_search_filter.return_value = [recitation_dto]
         mock_get_recitations_with_image_urls.return_value = [recitation_dto]
+        mock_get_recitations_with_first_segments.return_value = [recitation_dto]
         result = await get_list_of_recitations_service(search="morning", language="en")
         
         assert isinstance(result, RecitationsResponse)
@@ -164,9 +172,11 @@ class TestGetListOfRecitationsService:
     @patch('pecha_api.recitations.recitations_services.get_root_text_by_collection_id')
     @patch('pecha_api.recitations.recitations_services.apply_search_recitation_title_filter')
     @patch('pecha_api.recitations.recitations_services.get_recitations_with_image_urls')
+    @patch('pecha_api.recitations.recitations_services.get_recitations_with_first_segments')
     @pytest.mark.asyncio
     async def test_get_list_of_recitations_service_different_languages(
         self,   
+        mock_get_recitations_with_first_segments,
         mock_get_recitations_with_image_urls,
         mock_apply_search_filter,
         mock_get_root_text,
@@ -183,6 +193,7 @@ class TestGetListOfRecitationsService:
         mock_get_root_text.return_value = mock_recitations_response
         mock_apply_search_filter.return_value = [recitation_dto]
         mock_get_recitations_with_image_urls.return_value = [recitation_dto]
+        mock_get_recitations_with_first_segments.return_value = [recitation_dto]
         result = await get_list_of_recitations_service(language="bo")
         
         assert isinstance(result, RecitationsResponse)
@@ -191,6 +202,70 @@ class TestGetListOfRecitationsService:
         
         # Verify language is passed correctly
         mock_get_root_text.assert_called_once_with(collection_id=liturgy_collection_id, language="bo")
+
+
+class TestGetRecitationsWithFirstSegments:
+    """Test cases for get_recitations_with_first_segments function."""
+
+    @patch('pecha_api.recitations.recitations_services.get_segment_contents_by_ids')
+    @patch('pecha_api.recitations.recitations_services.get_contents_by_text_ids')
+    @pytest.mark.asyncio
+    async def test_get_recitations_with_first_segments_success(
+        self,
+        mock_get_contents_by_text_ids,
+        mock_get_segment_contents_by_ids,
+    ):
+        text_id = str(uuid4())
+        segment_id = str(uuid4())
+        recitation_dto = RecitationDTO(text_id=UUID(text_id), title="Test Recitation")
+
+        mock_get_contents_by_text_ids.return_value = {
+            text_id: [
+                TableOfContent(
+                    text_id=text_id,
+                    type=TableOfContentType.TEXT,
+                    sections=[
+                        Section(
+                            id=str(uuid4()),
+                            section_number=1,
+                            segments=[
+                                TextSegment(segment_id=segment_id, segment_number=1),
+                            ],
+                        )
+                    ],
+                )
+            ]
+        }
+        mock_get_segment_contents_by_ids.return_value = {
+            segment_id: (text_id, "First segment content"),
+        }
+
+        result = await get_recitations_with_first_segments(recitations=[recitation_dto])
+
+        assert len(result) == 1
+        assert result[0].first_segment is not None
+        assert str(result[0].first_segment.id) == segment_id
+        assert result[0].first_segment.content == "First segment content"
+
+    @pytest.mark.asyncio
+    async def test_get_recitations_with_first_segments_empty_list(self):
+        result = await get_recitations_with_first_segments(recitations=[])
+        assert result == []
+
+    @patch('pecha_api.recitations.recitations_services.get_contents_by_text_ids')
+    @pytest.mark.asyncio
+    async def test_get_recitations_with_first_segments_no_toc(
+        self,
+        mock_get_contents_by_text_ids,
+    ):
+        text_id = str(uuid4())
+        recitation_dto = RecitationDTO(text_id=UUID(text_id), title="Test Recitation")
+        mock_get_contents_by_text_ids.return_value = {text_id: []}
+
+        result = await get_recitations_with_first_segments(recitations=[recitation_dto])
+
+        assert len(result) == 1
+        assert result[0].first_segment is None
 
 
 class TestGetRecitationDetailsService:


### PR DESCRIPTION
- Introduced `first_segment` field in `RecitationDTO` to include the first segment of each recitation.
- Added `get_recitations_with_first_segments` function to retrieve and populate the first segments for a list of recitations.
- Updated `get_list_of_recitations_service` to utilize the new function for returning recitations with their first segments.
- Implemented `get_first_segment_ids_by_text_ids` utility to extract first segment IDs from the table of contents.
- Added tests for the new functionality in `test_recitations_services.py` to ensure correct behavior.