### PR TITLE
Add functionality to clone series plans between languages

### DIFF
--- a/pecha_api/plans/cms/cms_plans_service.py
+++ b/pecha_api/plans/cms/cms_plans_service.py
@@ -11,7 +11,11 @@ from pecha_api.plans.items.plan_items_models import PlanItem
 from pecha_api.plans.users.plan_users_models import UserPlanProgress
 from pecha_api.plans.cms.cms_plans_repository import save_plan, get_plan_by_id, get_plans_by_author_id, update_plan
 from pecha_api.plans.groups.groups_repository import get_group_id_for_plan, get_group_ids_by_plan_ids
-from pecha_api.plans.series.series_repository import get_series_by_id
+from pecha_api.plans.series.series_repository import (
+    get_series_by_id,
+    reference_start_date_for_series_plans,
+    _REFERENCE_START_DATE_UNSET,
+)
 from pecha_api.plans.tags.tag_helpers import tags_to_summary_dtos
 from pecha_api.plans.tags.tag_repository import set_plan_tags
 from pecha_api.plans.tags.tag_service import validate_tag_ids
@@ -492,6 +496,16 @@ def _apply_create_plan_series_fields(
 ) -> None:
     if not create_plan_request.series_id:
         return
+
+    series = get_series_by_id(db=db, series_id=create_plan_request.series_id)
+    if series:
+        reference_start_date = reference_start_date_for_series_plans(
+            series.plans,
+            exclude_plan_ids={plan.id},
+        )
+        if reference_start_date is not _REFERENCE_START_DATE_UNSET:
+            plan.start_date = reference_start_date
+
     _apply_series_attachment_to_plan(
         db=db,
         plan=plan,

--- a/pecha_api/plans/series/series_repository.py
+++ b/pecha_api/plans/series/series_repository.py
@@ -11,6 +11,8 @@ from pecha_api.plans.series.series_metadata_model import SeriesMetadata
 from pecha_api.plans.plans_models import Plan
 from pecha_api.plans.users.plan_users_models import UserSeriesEnrollment
 
+_REFERENCE_START_DATE_UNSET = object()
+
 
 def _series_active_plans_count_subquery(published_only: bool = False):
     conditions = [Plan.series_id == Series.id, Plan.deleted_at.is_(None)]
@@ -408,6 +410,31 @@ def clone_series_with_plans(
     return new_series
 
 
+def _sorted_active_plans_by_display_order(plans) -> List[Plan]:
+    active_plans = [plan for plan in plans if plan.deleted_at is None]
+    return sorted(
+        active_plans,
+        key=lambda plan: (plan.display_order is None, plan.display_order or 0),
+    )
+
+
+def reference_start_date_for_series_plans(
+    plans,
+    *,
+    exclude_plan_ids: Optional[set] = None,
+):
+    """Return canonical start_date from the first plan in the series, or _REFERENCE_START_DATE_UNSET."""
+    exclude = exclude_plan_ids or set()
+    reference_plans = [
+        plan
+        for plan in (plans or [])
+        if plan.deleted_at is None and plan.id not in exclude
+    ]
+    if not reference_plans:
+        return _REFERENCE_START_DATE_UNSET
+    return _sorted_active_plans_by_display_order(reference_plans)[0].start_date
+
+
 def replace_series_metadata(
     db: Session,
     series_id: UUID,
@@ -429,6 +456,8 @@ def update_series_with_plans(
     plan_ids_to_detach: List[UUID],
     updated_at,
     metadata_entries: Optional[List] = None,
+    newly_attached_plan_ids: Optional[List[UUID]] = None,
+    reference_start_date=_REFERENCE_START_DATE_UNSET,
 ) -> Series:
     series.image = image
     series.featured = featured
@@ -455,6 +484,14 @@ def update_series_with_plans(
                 },
                 synchronize_session=False,
             )
+    if (
+        newly_attached_plan_ids
+        and reference_start_date is not _REFERENCE_START_DATE_UNSET
+    ):
+        db.query(Plan).filter(Plan.id.in_(newly_attached_plan_ids)).update(
+            {Plan.start_date: reference_start_date},
+            synchronize_session=False,
+        )
 
     db.commit()
     db.refresh(series)

--- a/pecha_api/plans/series/series_repository.py
+++ b/pecha_api/plans/series/series_repository.py
@@ -260,6 +260,12 @@ def _clone_item(db: Session, src_item, new_plan_id: UUID, created_by: str) -> No
             _clone_task(db, src_task, new_item.id, created_by)
 
 
+def _plan_language_value(language) -> str:
+    if hasattr(language, "value"):
+        return language.value
+    return str(language)
+
+
 def _clone_plan(
     db: Session,
     src_plan,
@@ -267,14 +273,15 @@ def _clone_plan(
     target_group_id: UUID,
     author_id: UUID,
     created_by: str,
-) -> None:
+    target_language: Optional[str] = None,
+) -> Plan:
     new_plan = Plan(
         title=src_plan.title,
         description=src_plan.description,
         author_id=author_id,
         group_id=target_group_id,
         series_id=new_series_id,
-        language=src_plan.language,
+        language=target_language if target_language is not None else src_plan.language,
         difficulty_level=src_plan.difficulty_level,
         featured=src_plan.featured,
         display_order=src_plan.display_order,
@@ -291,6 +298,58 @@ def _clone_plan(
 
     for src_item in src_plan.items or []:
         _clone_item(db, src_item, new_plan.id, created_by)
+
+    return new_plan
+
+
+def clone_series_plans_for_language(
+    db: Session,
+    series_id: UUID,
+    source_language: str,
+    target_language: str,
+    created_by: str,
+) -> List[Plan]:
+    """Deep-copy all active plans in source_language to target_language within the same series."""
+    series = get_series_for_clone(db, series_id)
+    if not series:
+        return []
+
+    source_upper = source_language.upper()
+    target_upper = target_language.upper()
+    active_plans = [plan for plan in (series.plans or []) if plan.deleted_at is None]
+
+    source_plans = sorted(
+        [
+            plan
+            for plan in active_plans
+            if _plan_language_value(plan.language).upper() == source_upper
+        ],
+        key=lambda plan: (plan.display_order is None, plan.display_order or 0),
+    )
+    target_plans = [
+        plan
+        for plan in active_plans
+        if _plan_language_value(plan.language).upper() == target_upper
+    ]
+    if not source_plans or target_plans:
+        return []
+
+    new_plans: List[Plan] = []
+    for src_plan in source_plans:
+        new_plans.append(
+            _clone_plan(
+                db,
+                src_plan,
+                series_id,
+                src_plan.group_id,
+                src_plan.author_id,
+                created_by,
+                target_language=target_upper,
+            )
+        )
+
+    db.commit()
+    return new_plans
 
 
 def clone_series_with_plans(

--- a/pecha_api/plans/series/series_response_models.py
+++ b/pecha_api/plans/series/series_response_models.py
@@ -139,6 +139,7 @@ class SeriesDTO(BaseModel):
     image: Optional[ImageUrlModel] = None
     image_key: Optional[str] = None
     author_id: UUID
+    group_id: Optional[UUID] = None
     parent_series_id: Optional[UUID] = None
     featured: bool
     status: PlanStatus

--- a/pecha_api/plans/series/series_response_models.py
+++ b/pecha_api/plans/series/series_response_models.py
@@ -85,6 +85,17 @@ class UpdateSeriesRequest(BaseModel):
         return _validate_plan_language_keys(v)
 
 
+class CloneSeriesPlansRequest(BaseModel):
+    source_language: LanguageCode
+    target_language: LanguageCode
+
+    @model_validator(mode="after")
+    def _validate_languages(self):
+        if self.source_language == self.target_language:
+            raise ValueError("source_language and target_language must be different")
+        return self
+
+
 class UpdateSeriesStatusRequest(BaseModel):
     status: PlanStatus
 

--- a/pecha_api/plans/series/series_service.py
+++ b/pecha_api/plans/series/series_service.py
@@ -21,6 +21,7 @@ from pecha_api.plans.series.series_repository import (
     get_plans_by_ids,
     save_series_with_plans,
     clone_series_with_plans,
+    clone_series_plans_for_language as clone_series_language_plans,
     get_series_for_clone,
     update_series_with_plans,
     update_series_status,
@@ -38,6 +39,7 @@ from pecha_api.plans.series.series_response_models import (
     SeriesMetadataDTO,
     SeriesPlanDTO,
     SeriesListResponse,
+    CloneSeriesPlansRequest,
 )
 from pecha_api.plans.authors.plan_authors_service import (
     validate_cms_author_details,
@@ -844,6 +846,77 @@ def create_new_series(token: str, create_series_request: CreateSeriesRequest) ->
             saved = get_series_by_id(db=db_session, series_id=saved.id)
 
             return _series_detail_dto(db_session, saved, include_plans=bool(plan_ids))
+    except IntegrityError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Database integrity error: {exc.orig}",
+        ) from exc
+
+
+def clone_series_plans_for_language(
+    token: str,
+    series_id: UUID,
+    clone_request: CloneSeriesPlansRequest,
+) -> SeriesDTO:
+    current_author = validate_cms_author_details(token=token)
+    source_language = clone_request.source_language.value
+    target_language = clone_request.target_language.value
+
+    try:
+        with SessionLocal() as db_session:
+            series = get_series_by_id(db=db_session, series_id=series_id)
+            if not series:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail=f"Series with id '{series_id}' not found",
+                )
+            require_can_edit_content(
+                db=db_session,
+                group_id=series.group_id,
+                author=current_author,
+                content_status=series.status,
+            )
+
+            active_plans = [
+                plan for plan in (series.plans or []) if plan.deleted_at is None
+            ]
+            source_plans = [
+                plan
+                for plan in active_plans
+                if _language_value(plan.language).upper() == source_language
+            ]
+            target_plans = [
+                plan
+                for plan in active_plans
+                if _language_value(plan.language).upper() == target_language
+            ]
+
+            if not source_plans:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f"No plans found in language '{source_language}' for this series",
+                )
+            if target_plans:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f"Plans already exist in language '{target_language}' for this series",
+                )
+
+            cloned_plans = clone_series_language_plans(
+                db=db_session,
+                series_id=series_id,
+                source_language=source_language,
+                target_language=target_language,
+                created_by=current_author.email,
+            )
+            if not cloned_plans:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Could not clone plans for the requested languages",
+                )
+
+            refreshed = get_series_by_id(db=db_session, series_id=series_id)
+            return _series_detail_dto(db_session, refreshed, include_plans=True)
     except IntegrityError as exc:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/pecha_api/plans/series/series_service.py
+++ b/pecha_api/plans/series/series_service.py
@@ -24,6 +24,8 @@ from pecha_api.plans.series.series_repository import (
     clone_series_plans_for_language as clone_series_language_plans,
     get_series_for_clone,
     update_series_with_plans,
+    reference_start_date_for_series_plans,
+    _REFERENCE_START_DATE_UNSET,
     update_series_status,
     update_series_featured,
     soft_delete_series_with_plan_detach,
@@ -677,9 +679,23 @@ def update_existing_series(
                 # Every plan in the request gets its display_order (re)written,
                 # including ones already attached, since order may have changed.
                 plans_to_attach = plan_order_pairs
+                newly_attached = list(new_set - current_attached)
+                staying_ids = current_attached & new_set
+                reference_start_date = _REFERENCE_START_DATE_UNSET
+                if newly_attached and staying_ids:
+                    staying_plans = [
+                        plan
+                        for plan in (series.plans or [])
+                        if plan.deleted_at is None and plan.id in staying_ids
+                    ]
+                    reference_start_date = reference_start_date_for_series_plans(
+                        staying_plans
+                    )
             else:
                 to_detach = []
                 plans_to_attach = []
+                newly_attached = []
+                reference_start_date = _REFERENCE_START_DATE_UNSET
 
             _apply_series_field_updates(series, update_series_request)
 
@@ -693,6 +709,8 @@ def update_existing_series(
                 plan_ids_to_detach=to_detach,
                 updated_at=datetime.now(timezone.utc),
                 metadata_entries=update_series_request.metadata,
+                newly_attached_plan_ids=newly_attached or None,
+                reference_start_date=reference_start_date,
             )
 
             refreshed = get_series_by_id(db=db_session, series_id=series_id)

--- a/pecha_api/plans/series/series_service.py
+++ b/pecha_api/plans/series/series_service.py
@@ -353,6 +353,7 @@ def _series_to_dto(
         image=get_image_url(image_url=row.image),
         image_key=row.image,
         author_id=row.author_id,
+        group_id=row.group_id,
         parent_series_id=_optional_uuid(getattr(row, "parent_series_id", None)),
         featured=bool(row.featured),
         status=_to_plan_status(row.status),

--- a/pecha_api/plans/series/series_view.py
+++ b/pecha_api/plans/series/series_view.py
@@ -6,8 +6,8 @@ from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from starlette import status
 
 from pecha_api.plans.plans_enums import PlanStatus
-from pecha_api.plans.series.series_response_models import CreateSeriesRequest, UpdateSeriesRequest, UpdateSeriesStatusRequest, SeriesDTO, SeriesListResponse
-from pecha_api.plans.series.series_service import create_new_series, update_existing_series, update_existing_series_status, update_existing_series_featured, get_cms_filtered_series, get_cms_series_detail, delete_existing_series
+from pecha_api.plans.series.series_response_models import CreateSeriesRequest, UpdateSeriesRequest, UpdateSeriesStatusRequest, SeriesDTO, SeriesListResponse, CloneSeriesPlansRequest
+from pecha_api.plans.series.series_service import create_new_series, update_existing_series, update_existing_series_status, update_existing_series_featured, get_cms_filtered_series, get_cms_series_detail, delete_existing_series, clone_series_plans_for_language
 
 oauth2_scheme = HTTPBearer()
 
@@ -72,6 +72,23 @@ async def update_series_featured(
     return update_existing_series_featured(
         token=authentication_credential.credentials,
         series_id=series_id,
+    )
+
+
+@cms_series_router.post(
+    "/{series_id}/clone-plans",
+    status_code=status.HTTP_200_OK,
+    response_model=SeriesDTO,
+)
+async def clone_series_plans(
+    series_id: UUID,
+    authentication_credential: Annotated[HTTPAuthorizationCredentials, Depends(oauth2_scheme)],
+    clone_request: CloneSeriesPlansRequest,
+):
+    return clone_series_plans_for_language(
+        token=authentication_credential.credentials,
+        series_id=series_id,
+        clone_request=clone_request,
     )
 
 

--- a/tests/plans/series/test_series_repository.py
+++ b/tests/plans/series/test_series_repository.py
@@ -14,6 +14,7 @@ from pecha_api.plans.series.series_repository import (
     get_random_featured_published_series,
     save_series_with_plans,
     clone_series_with_plans,
+    clone_series_plans_for_language,
     update_series_with_plans,
     update_series_status,
     update_series_featured,
@@ -777,3 +778,65 @@ def test_clone_series_with_plans_skips_soft_deleted_plans_and_tasks():
     assert len(_added_of_type(db, PlanItem)) == 0
     # Series + its metadata are still created even with no plans.
     assert len(_added_of_type(db, Series)) == 1
+
+
+def test_clone_series_plans_for_language_deep_copies_with_target_language():
+    from unittest.mock import patch
+
+    db = _make_session_mock()
+    parent = _build_parent_series_for_clone()
+    series_id = parent.id
+
+    with patch(
+        "pecha_api.plans.series.series_repository.get_series_for_clone",
+        return_value=parent,
+    ):
+        result = clone_series_plans_for_language(
+            db=db,
+            series_id=series_id,
+            source_language="EN",
+            target_language="BO",
+            created_by="user@example.com",
+        )
+
+    assert len(result) == 1
+    cloned_plans = _added_of_type(db, Plan)
+    assert len(cloned_plans) == 1
+    assert cloned_plans[0].language == "BO"
+    assert cloned_plans[0].series_id == series_id
+    assert cloned_plans[0] is not parent.plans[0]
+    assert len(_added_of_type(db, PlanItem)) == 1
+    assert len(_added_of_type(db, PlanTask)) == 1
+    assert len(_added_of_type(db, PlanSubTask)) == 1
+    db.commit.assert_called_once()
+
+
+def test_clone_series_plans_for_language_returns_empty_when_target_exists():
+    from unittest.mock import patch
+
+    db = _make_session_mock()
+    parent = _build_parent_series_for_clone()
+    bo_plan = Plan(
+        id=uuid.uuid4(),
+        title="Plan B",
+        language="BO",
+        group_id=parent.group_id,
+        deleted_at=None,
+    )
+    parent.plans.append(bo_plan)
+
+    with patch(
+        "pecha_api.plans.series.series_repository.get_series_for_clone",
+        return_value=parent,
+    ):
+        result = clone_series_plans_for_language(
+            db=db,
+            series_id=parent.id,
+            source_language="EN",
+            target_language="BO",
+            created_by="user@example.com",
+        )
+
+    assert result == []
+    assert len(_added_of_type(db, Plan)) == 0
+    db.commit.assert_not_called()

--- a/tests/plans/series/test_series_service.py
+++ b/tests/plans/series/test_series_service.py
@@ -25,6 +25,7 @@ from pecha_api.plans.series.series_service import (
     get_cms_filtered_series,
     get_cms_series_detail,
     delete_existing_series,
+    clone_series_plans_for_language,
 )
 from pecha_api.plans.platform_enums import PlatformRole
 
@@ -42,6 +43,7 @@ from pecha_api.plans.series.series_response_models import (
     UpdateSeriesStatusRequest,
     SeriesListResponse,
     SeriesMetadataInput,
+    CloneSeriesPlansRequest,
 )
 
 
@@ -3022,3 +3024,111 @@ def test_get_cms_filtered_series_count_maps_to_plan_count():
         result = get_cms_filtered_series(token="dummy", search=None, skip=0, limit=10)
 
     assert result.series[0].plan_count == 9
+
+
+def _make_series_plan(language=LanguageCode.EN):
+    plan = MagicMock()
+    plan.id = uuid.uuid4()
+    plan.deleted_at = None
+    plan.language = language
+    plan.title = "Plan"
+    plan.description = None
+    plan.difficulty_level = DifficultyLevel.BEGINNER
+    plan.image_url = None
+    plan.tag_list = []
+    plan.status = PlanStatus.DRAFT
+    plan.featured = False
+    plan.display_order = 0
+    plan.start_date = None
+    plan.items = []
+    plan.group_id = FIXTURE_GROUP_ID
+    return plan
+
+
+def test_clone_series_plans_for_language_clones_and_returns_dto():
+    series_id = uuid.uuid4()
+    row = MagicMock()
+    row.id = series_id
+    row.group_id = FIXTURE_GROUP_ID
+    row.status = PlanStatus.DRAFT
+    row.plans = [_make_series_plan(LanguageCode.EN)]
+    row.metadata_entries = [_metadata_entry()]
+    row.image = None
+    row.author_id = uuid.uuid4()
+    row.featured = False
+
+    cloned_plan = MagicMock()
+    cloned_plan.id = uuid.uuid4()
+    mock_author = _make_mock_author(row.author_id, is_admin=False)
+
+    with patch("pecha_api.plans.series.series_service.SessionLocal") as mock_session_local, patch(
+        "pecha_api.plans.series.series_service.validate_cms_author_details",
+        return_value=mock_author,
+    ), patch(
+        "pecha_api.plans.series.series_service.get_series_by_id",
+        return_value=row,
+    ), patch(
+        "pecha_api.plans.series.series_service.require_can_edit_content",
+    ), patch(
+        "pecha_api.plans.series.series_service.clone_series_language_plans",
+        return_value=[cloned_plan],
+    ) as mock_clone, patch(
+        "pecha_api.plans.series.series_service.get_enrolled_count_map_by_series_ids",
+        return_value={},
+    ), patch(
+        "pecha_api.plans.series.series_service._group_summary_for_series",
+        return_value=None,
+    ):
+        _session_local_context(mock_session_local)
+
+        dto = clone_series_plans_for_language(
+            token="dummy",
+            series_id=series_id,
+            clone_request=CloneSeriesPlansRequest(
+                source_language=LanguageCode.EN,
+                target_language=LanguageCode.BO,
+            ),
+        )
+
+    mock_clone.assert_called_once()
+    assert dto.id == series_id
+
+
+def test_clone_series_plans_for_language_rejects_when_target_has_plans():
+    series_id = uuid.uuid4()
+    row = MagicMock()
+    row.id = series_id
+    row.group_id = FIXTURE_GROUP_ID
+    row.status = PlanStatus.DRAFT
+    row.plans = [
+        _make_series_plan(LanguageCode.EN),
+        _make_series_plan(LanguageCode.BO),
+    ]
+
+    mock_author = _make_mock_author(uuid.uuid4(), is_admin=False)
+
+    with patch("pecha_api.plans.series.series_service.SessionLocal") as mock_session_local, patch(
+        "pecha_api.plans.series.series_service.validate_cms_author_details",
+        return_value=mock_author,
+    ), patch(
+        "pecha_api.plans.series.series_service.get_series_by_id",
+        return_value=row,
+    ), patch(
+        "pecha_api.plans.series.series_service.require_can_edit_content",
+    ), patch(
+        "pecha_api.plans.series.series_service.clone_series_language_plans",
+    ) as mock_clone:
+        _session_local_context(mock_session_local)
+
+        with pytest.raises(HTTPException) as exc:
+            clone_series_plans_for_language(
+                token="dummy",
+                series_id=series_id,
+                clone_request=CloneSeriesPlansRequest(
+                    source_language=LanguageCode.EN,
+                    target_language=LanguageCode.BO,
+                ),
+            )
+
+    assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
+    mock_clone.assert_not_called()


### PR DESCRIPTION
- Introduced `clone_series_plans_for_language` to deep-copy active plans from a source language to a target language within the same series.
- Updated the `CloneSeriesPlansRequest` model to validate that source and target languages are different.
- Enhanced the `_clone_plan` function to support language-specific cloning.
- Added new endpoint in `series_view.py` for cloning plans via API.
- Implemented tests to verify cloning behavior and edge cases.