### PR TITLE
Add migration to merge accumulator session and day shareable heads

### DIFF
--- a/migrations/versions/z2a3b4c5d6e7_merge_accumulator_session_and_day_shareable_heads.py
+++ b/migrations/versions/z2a3b4c5d6e7_merge_accumulator_session_and_day_shareable_heads.py
@@ -1,0 +1,26 @@
+"""merge accumulator session and day shareable heads
+
+Revision ID: z2a3b4c5d6e7
+Revises: z0a1b2c3d4e5, z1a2b3c4d5e6
+Create Date: 2026-06-26 14:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "z2a3b4c5d6e7"
+down_revision: Union[str, Sequence[str], None] = ("z0a1b2c3d4e5", "z1a2b3c4d5e6")
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/pecha_api/accumulator/accumulator_response_models.py
+++ b/pecha_api/accumulator/accumulator_response_models.py
@@ -29,7 +29,7 @@ class PresetMantraDTO(BaseModel):
 
 class AccumulatorDTO(BaseModel):
     id: UUID
-    user_id: UUID
+    user_id: Optional[UUID] = None
     group_id: Optional[UUID] = None
     parent_id: Optional[UUID] = Field(None, description="The preset this accumulator was created from")
     type: AccumulatorType

--- a/tests/accumulator/test_accumulator_service.py
+++ b/tests/accumulator/test_accumulator_service.py
@@ -1216,6 +1216,19 @@ class TestHelperFunctions:
 
         assert result.current_count == 0
 
+    def test_convert_accumulator_to_dto_preset_allows_null_user_id(self):
+        """Preset accumulators have no user_id and should still convert."""
+        accumulator = TestDataFactory.create_mock_accumulator(
+            accumulator_type=AccumulatorType.PRESET,
+        )
+        accumulator.user_id = None
+
+        result = convert_accumulator_to_dto(accumulator)
+
+        assert isinstance(result, AccumulatorDTO)
+        assert result.user_id is None
+        assert result.type == AccumulatorType.PRESET
+
     def test_convert_accumulator_to_public_dto_omits_user_id(self):
         """Public DTO should not carry user_id and exposes the row id as id."""
         accumulator = TestDataFactory.create_mock_accumulator()


### PR DESCRIPTION
- Created a new migration script to merge the accumulator session and day shareable heads.
- Defined revision identifiers and upgrade/downgrade functions for future database schema changes.