### PR TITLE
Refactor bookmark services and models to support pagination and enhan…

### DIFF
--- a/pecha_api/bookmarks/bookmark_repository.py
+++ b/pecha_api/bookmarks/bookmark_repository.py
@@ -2,7 +2,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy.exc import IntegrityError
 from fastapi import HTTPException
 from starlette import status
-from typing import List, Optional
+from typing import List, Optional, Tuple
 from uuid import UUID
 
 from pecha_api.plans.auth.plan_auth_models import ResponseError
@@ -31,7 +31,9 @@ def get_bookmarks_by_user_id(
     db: Session,
     user_id: UUID,
     type: Optional[BookmarkFilterType] = None,
-) -> List[Bookmark]:
+    skip: int = 0,
+    limit: int = 20,
+) -> Tuple[List[Bookmark], int]:
     query = db.query(Bookmark).filter(Bookmark.user_id == user_id)
     if type is not None:
         if type == BookmarkFilterType.TEXT:
@@ -40,7 +42,14 @@ def get_bookmarks_by_user_id(
             )
         else:
             query = query.filter(Bookmark.type == BookmarkType[type.name])
-    return query.order_by(Bookmark.created_at.desc()).all()
+    total = query.count()
+    bookmarks = (
+        query.order_by(Bookmark.created_at.desc())
+        .offset(skip)
+        .limit(limit)
+        .all()
+    )
+    return bookmarks, total
 
 
 def get_bookmark_by_user_and_source(

--- a/pecha_api/bookmarks/bookmark_response_models.py
+++ b/pecha_api/bookmarks/bookmark_response_models.py
@@ -1,13 +1,55 @@
 from pydantic import BaseModel, ConfigDict, field_validator
 from uuid import UUID
-from typing import List, Optional
+from typing import List, Optional, Union
 from datetime import datetime
 
 from pecha_api.bookmarks.bookmark_enums import BookmarkType
-from pecha_api.plans.public.plan_response_models import PublicPlanDTO
-from pecha_api.plans.series.series_response_models import SeriesListItemDTO
-from pecha_api.accumulator.accumulator_response_models import AccumulatorDTO
-from pecha_api.timers.timer_response_models import TimerDTO
+from pecha_api.plans.series.series_response_models import SeriesMetadataResponse
+
+
+class BookmarkSegmentDTO(BaseModel):
+    id: str
+    content: str
+
+
+class BookmarkTextDTO(BaseModel):
+    id: str
+    title: str
+    segment: Optional[BookmarkSegmentDTO] = None
+
+
+class PlanBookmarkMetadataDTO(BaseModel):
+    title: str
+    description: str
+    language: str
+
+
+class BookmarkPlanDTO(BaseModel):
+    id: UUID
+    metadata: Optional[PlanBookmarkMetadataDTO] = None
+    image: Optional[str] = None
+    start_date: Optional[datetime] = None
+    end_date: Optional[datetime] = None
+
+
+class BookmarkSeriesDTO(BaseModel):
+    id: UUID
+    metadata: SeriesMetadataResponse = None
+    image: Optional[str] = None
+    start_date: Optional[datetime] = None
+    end_date: Optional[datetime] = None
+
+
+class BookmarkAccumulatorDTO(BaseModel):
+    id: UUID
+    title: str
+    image: Optional[str] = None
+
+
+class BookmarkTimerDTO(BaseModel):
+    id: UUID
+    title: str
+    duration: int
 
 
 class CreateBookmarkRequest(BaseModel):
@@ -40,21 +82,20 @@ class BookmarkDTO(BaseModel):
     name: Optional[str] = None
     created_at: datetime
     updated_at: datetime
-    text_id: Optional[str] = None
-    text_title: Optional[str] = None
-    segment_id: Optional[str] = None
-    verse_id: Optional[str] = None
-    segment_content: Optional[str] = None
-    plan: Optional[PublicPlanDTO] = None
-    series: Optional[SeriesListItemDTO] = None
-    accumulator: Optional[AccumulatorDTO] = None
-    timer: Optional[TimerDTO] = None
+    text: Optional[BookmarkTextDTO] = None
+    plan: Optional[BookmarkPlanDTO] = None
+    series: Optional[BookmarkSeriesDTO] = None
+    accumulator: Optional[BookmarkAccumulatorDTO] = None
+    timer: Optional[BookmarkTimerDTO] = None
 
 
 class BookmarksResponse(BaseModel):
     model_config = ConfigDict(ser_json_exclude_none=True)
 
     bookmarks: List[BookmarkDTO]
+    total: int
+    skip: int
+    limit: int
 
 
 class BookmarkExistsQuery(BaseModel):

--- a/pecha_api/bookmarks/bookmark_services.py
+++ b/pecha_api/bookmarks/bookmark_services.py
@@ -46,11 +46,19 @@ async def get_bookmarks_service(
     token: str,
     type: Optional[BookmarkFilterType] = None,
     language: Optional[str] = None,
+    skip: int = 0,
+    limit: int = 20,
 ) -> BookmarksResponse:
     current_user = validate_and_extract_user_details(token=token)
 
     with SessionLocal() as db:
-        bookmarks = get_bookmarks_by_user_id(db=db, user_id=current_user.id, type=type)
+        bookmarks, total = get_bookmarks_by_user_id(
+            db=db,
+            user_id=current_user.id,
+            type=type,
+            skip=skip,
+            limit=limit,
+        )
 
         bookmarks_dto = []
         for bookmark in bookmarks:
@@ -67,7 +75,12 @@ async def get_bookmarks_service(
             )
             bookmarks_dto.append(BookmarkDTO(**bookmark_data))
 
-        return BookmarksResponse(bookmarks=bookmarks_dto)
+        return BookmarksResponse(
+            bookmarks=bookmarks_dto,
+            total=total,
+            skip=skip,
+            limit=limit,
+        )
 
 
 async def delete_bookmark_service(token: str, bookmark_id: UUID) -> None:

--- a/pecha_api/bookmarks/bookmark_utils.py
+++ b/pecha_api/bookmarks/bookmark_utils.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from typing import Optional
 from uuid import UUID
 
@@ -5,6 +6,15 @@ from sqlalchemy.orm import Session, selectinload
 
 from pecha_api.bookmarks.bookmark_enums import BookmarkType
 from pecha_api.bookmarks.bookmark_models import Bookmark
+from pecha_api.bookmarks.bookmark_response_models import (
+    BookmarkAccumulatorDTO,
+    BookmarkPlanDTO,
+    BookmarkSegmentDTO,
+    BookmarkSeriesDTO,
+    BookmarkTextDTO,
+    BookmarkTimerDTO,
+    PlanBookmarkMetadataDTO,
+)
 from pecha_api.texts.segments.segments_models import Segment
 from pecha_api.texts.segments.segments_repository import (
     get_related_mapped_segments,
@@ -15,35 +25,23 @@ from pecha_api.texts.texts_repository import (
     get_first_segment_table_of_content,
     get_texts_by_id,
 )
-from pecha_api.plans.public.plan_response_models import PublicPlanDTO, AuthorDTO
 from pecha_api.plans.public.plan_repository import get_published_plan_by_id
 from pecha_api.plans.plans_enums import PlanStatus
 from pecha_api.plans.items.plan_items_models import PlanItem
-from pecha_api.plans.groups.groups_repository import get_group_id_for_plan
-from pecha_api.plans.tags.tag_helpers import tags_to_summary_dtos
-from pecha_api.plans.authors.plan_authors_service import get_image_url
+from pecha_api.plans.authors.plan_authors_service import safe_get_image_url
 from pecha_api.plans.shared.metadata_utils import filter_by_language_with_fallback
 from pecha_api.plans.users.plan_user_series_day_sync_repository import (
     get_sibling_plans_in_series_slot,
 )
-from pecha_api.plans.series.series_repository import (
-    get_series_by_id,
-    get_active_plan_count_map_by_series_ids,
-    get_enrolled_count_map_by_series_ids,
-)
+from pecha_api.plans.series.series_repository import get_series_by_id
 from pecha_api.plans.series.series_service import (
-    _group_summary_for_series,
+    _metadata_response,
     _series_schedule_from_plans,
-    _series_to_list_item_dto,
     _to_plan_status,
 )
 from pecha_api.accumulator.accumulator_models import Accumulator
-from pecha_api.accumulator.accumulator_service import (
-    convert_accumulator_to_dto,
-    convert_metadata_to_dto,
-)
+from pecha_api.accumulator.accumulator_service import resolve_mala_image_fields
 from pecha_api.timers.timer_repository import get_timer_by_id
-from pecha_api.timers.timer_service import convert_timer_to_dto
 
 DEFAULT_FALLBACK_LANGUAGE = "EN"
 
@@ -61,6 +59,22 @@ def _plan_language_code(plan) -> str:
 
 def _accumulator_metadata_language(entry) -> str:
     return entry.language.value if hasattr(entry.language, "value") else str(entry.language)
+
+
+def _bookmark_image_url(
+    image_key: Optional[str],
+    *,
+    resource_id: UUID,
+    resource_type: str,
+) -> Optional[str]:
+    image = safe_get_image_url(
+        image_key,
+        resource_id=resource_id,
+        resource_type=resource_type,
+    )
+    if not image:
+        return None
+    return image.medium or image.original
 
 
 def _text_language_code(text) -> str:
@@ -143,17 +157,20 @@ async def enrich_text_bookmark(
             segment = localized_segment
             segment_id = str(segment.id)
 
-    result = {
-        "text_id": text_id,
-        "text_title": text.title if text else None,
-        "segment_id": segment_id,
-        "segment_content": segment.content if segment else None,
+    segment_dto = None
+    if segment_id and segment:
+        segment_dto = BookmarkSegmentDTO(
+            id=segment_id,
+            content=segment.content,
+        )
+
+    return {
+        "text": BookmarkTextDTO(
+            id=text_id,
+            title=text.title if text else "",
+            segment=segment_dto,
+        )
     }
-
-    if verse_id:
-        result["verse_id"] = verse_id
-
-    return result
 
 
 async def _resolve_localized_text(text_id: str, language: Optional[str]):
@@ -230,35 +247,26 @@ def enrich_plan_bookmark(
     if not plan:
         return {}
 
-    tag_language = _normalize_language(language) or DEFAULT_FALLBACK_LANGUAGE
-    plan_image = get_image_url(image_url=plan.image_url)
-    author_dto = None
-    if plan.author:
-        author_image = get_image_url(image_url=plan.author.image_url)
-        author_dto = AuthorDTO(
-            id=plan.author.id,
-            firstname=plan.author.first_name,
-            lastname=plan.author.last_name,
-            image=author_image,
-        )
-
     total_days = db.query(PlanItem).filter(PlanItem.plan_id == plan.id).count()
-    group_id = get_group_id_for_plan(db=db, plan_id=plan.id)
+    end_date = None
+    if plan.start_date and total_days > 0:
+        end_date = plan.start_date + timedelta(days=total_days - 1)
 
     return {
-        "plan": PublicPlanDTO(
+        "plan": BookmarkPlanDTO(
             id=plan.id,
-            title=plan.title,
-            description=plan.description,
-            language=_plan_language_code(plan),
-            difficulty_level=plan.difficulty_level,
-            image=plan_image,
-            total_days=total_days,
-            tags=tags_to_summary_dtos(plan.tag_list, language=tag_language),
-            author=author_dto,
+            metadata=PlanBookmarkMetadataDTO(
+                title=plan.title,
+                description=plan.description,
+                language=_plan_language_code(plan),
+            ),
+            image=_bookmark_image_url(
+                plan.image_url,
+                resource_id=plan.id,
+                resource_type="plan",
+            ),
             start_date=plan.start_date,
-            display_order=plan.display_order,
-            group_id=group_id,
+            end_date=end_date,
         )
     }
 
@@ -276,28 +284,29 @@ def enrich_series_bookmark(
     if not series or _to_plan_status(series.status) != PlanStatus.PUBLISHED:
         return {}
 
-    plan_count = get_active_plan_count_map_by_series_ids(
-        db, [series_id], published_only=True
-    ).get(series_id, 0)
-    enrolled_count = get_enrolled_count_map_by_series_ids(db, [series_id]).get(series_id, 0)
-    start_date, end_date, total_days = _series_schedule_from_plans(
+    start_date, end_date, _ = _series_schedule_from_plans(
         series.plans,
         published_only=True,
         language=language,
         fallback=True,
     )
+    metadata_entries = getattr(series, "metadata_entries", None) or []
 
     return {
-        "series": _series_to_list_item_dto(
-            series,
-            plan_count=plan_count,
-            enrolled_count=enrolled_count,
-            language=language,
-            group=_group_summary_for_series(db=db, series=series, language=language),
+        "series": BookmarkSeriesDTO(
+            id=series.id,
+            metadata=_metadata_response(
+                metadata_entries,
+                language=language,
+                fallback=True,
+            ),
+            image=_bookmark_image_url(
+                series.image,
+                resource_id=series.id,
+                resource_type="series",
+            ),
             start_date=start_date,
             end_date=end_date,
-            total_days=total_days,
-            fallback=True,
         )
     }
 
@@ -326,17 +335,27 @@ def enrich_accumulator_bookmark(
     if not accumulator:
         return {}
 
-    dto = convert_accumulator_to_dto(accumulator)
+    _, mala_image_url = resolve_mala_image_fields(accumulator)
+    metadata_entries = list(accumulator.metadata_entries)
     if language:
-        matched_metadata = filter_by_language_with_fallback(
-            entries=list(accumulator.metadata_entries),
+        metadata_entries = filter_by_language_with_fallback(
+            entries=metadata_entries,
             language=language,
             language_of=_accumulator_metadata_language,
             fallback_language=DEFAULT_FALLBACK_LANGUAGE,
         )
-        dto.metadata = [convert_metadata_to_dto(entry) for entry in matched_metadata]
 
-    return {"accumulator": dto}
+    title = ""
+    if metadata_entries:
+        title = metadata_entries[0].name
+
+    return {
+        "accumulator": BookmarkAccumulatorDTO(
+            id=accumulator.id,
+            title=title,
+            image=mala_image_url,
+        )
+    }
 
 
 def enrich_timer_bookmark(db: Session, source_id: str) -> dict:
@@ -348,7 +367,13 @@ def enrich_timer_bookmark(db: Session, source_id: str) -> dict:
     if not timer:
         return {}
 
-    return {"timer": convert_timer_to_dto(timer)}
+    return {
+        "timer": BookmarkTimerDTO(
+            id=timer.id,
+            title=timer.name,
+            duration=timer.duration,
+        )
+    }
 
 
 def _parse_source_uuid(source_id: str) -> Optional[UUID]:

--- a/pecha_api/bookmarks/bookmark_views.py
+++ b/pecha_api/bookmarks/bookmark_views.py
@@ -72,11 +72,15 @@ async def get_bookmarks(
             )
         ),
     ] = None,
+    skip: int = Query(0, ge=0, description="Number of records to skip"),
+    limit: int = Query(20, ge=1, le=100, description="Maximum number of records to return"),
 ):
     return await get_bookmarks_service(
         token=authentication_credential.credentials,
         type=type,
         language=language,
+        skip=skip,
+        limit=limit,
     )
 
 

--- a/tests/bookmarks/test_bookmark_services.py
+++ b/tests/bookmarks/test_bookmark_services.py
@@ -140,12 +140,15 @@ async def test_get_bookmarks_service_success():
 
         mock_validate.return_value = mock_user
         mock_session.return_value = mock_db
-        mock_get.return_value = [mock_bookmark1, mock_bookmark2]
+        mock_get.return_value = ([mock_bookmark1, mock_bookmark2], 2)
         mock_enrich.return_value = {}
 
         result = await get_bookmarks_service(token="test_token")
 
         assert len(result.bookmarks) == 2
+        assert result.total == 2
+        assert result.skip == 0
+        assert result.limit == 20
         assert result.bookmarks[0].type == BookmarkType.SERIES
         assert result.bookmarks[1].source_id == "segment-ref-002"
         assert result.bookmarks[1].name is None
@@ -174,10 +177,14 @@ async def test_get_bookmarks_service_with_text_filter_enriches_bookmarks():
     mock_db.__exit__ = MagicMock(return_value=False)
 
     enrichment = {
-        "text_id": text_id,
-        "text_title": "Heart Sutra",
-        "segment_id": str(uuid4()),
-        "segment_content": "Introduction content",
+        "text": {
+            "id": text_id,
+            "title": "Heart Sutra",
+            "segment": {
+                "id": str(uuid4()),
+                "content": "Introduction content",
+            },
+        }
     }
 
     with patch("pecha_api.bookmarks.bookmark_services.validate_and_extract_user_details") as mock_validate, \
@@ -187,20 +194,26 @@ async def test_get_bookmarks_service_with_text_filter_enriches_bookmarks():
 
         mock_validate.return_value = mock_user
         mock_session.return_value = mock_db
-        mock_get.return_value = [mock_bookmark]
+        mock_get.return_value = ([mock_bookmark], 1)
         mock_enrich.return_value = enrichment
 
         result = await get_bookmarks_service(token="test_token", type=BookmarkFilterType.TEXT)
 
-        mock_get.assert_called_once_with(db=mock_db, user_id=user_id, type=BookmarkFilterType.TEXT)
+        mock_get.assert_called_once_with(
+            db=mock_db,
+            user_id=user_id,
+            type=BookmarkFilterType.TEXT,
+            skip=0,
+            limit=20,
+        )
         mock_enrich.assert_called_once_with(
             bookmark=mock_bookmark,
             db=mock_db,
             language=None,
         )
         assert len(result.bookmarks) == 1
-        assert result.bookmarks[0].text_title == "Heart Sutra"
-        assert result.bookmarks[0].segment_content == "Introduction content"
+        assert result.bookmarks[0].text.title == "Heart Sutra"
+        assert result.bookmarks[0].text.segment.content == "Introduction content"
 
 
 @pytest.mark.asyncio
@@ -230,11 +243,18 @@ async def test_get_bookmarks_service_passes_language_to_enrichment():
 
         mock_validate.return_value = mock_user
         mock_session.return_value = mock_db
-        mock_get.return_value = [mock_bookmark]
+        mock_get.return_value = ([mock_bookmark], 1)
         mock_enrich.return_value = {}
 
-        await get_bookmarks_service(token="test_token", language="bo")
+        await get_bookmarks_service(token="test_token", language="bo", skip=10, limit=5)
 
+        mock_get.assert_called_once_with(
+            db=mock_db,
+            user_id=user_id,
+            type=None,
+            skip=10,
+            limit=5,
+        )
         mock_enrich.assert_called_once_with(
             bookmark=mock_bookmark,
             db=mock_db,
@@ -259,11 +279,12 @@ async def test_get_bookmarks_service_empty():
 
         mock_validate.return_value = mock_user
         mock_session.return_value = mock_db
-        mock_get.return_value = []
+        mock_get.return_value = ([], 0)
 
         result = await get_bookmarks_service(token="test_token")
 
         assert len(result.bookmarks) == 0
+        assert result.total == 0
 
 
 @pytest.mark.asyncio

--- a/tests/bookmarks/test_bookmark_utils.py
+++ b/tests/bookmarks/test_bookmark_utils.py
@@ -194,11 +194,10 @@ async def test_enrich_text_bookmark_without_verse_uses_first_segment():
     ):
         result = await enrich_text_bookmark(bookmark)
 
-    assert result["text_id"] == text_id
-    assert result["text_title"] == "Heart Sutra"
-    assert result["segment_id"] == segment_id
-    assert result["segment_content"] == "Segment content"
-    assert "verse_id" not in result
+    assert result["text"].id == text_id
+    assert result["text"].title == "Heart Sutra"
+    assert result["text"].segment.id == segment_id
+    assert result["text"].segment.content == "Segment content"
 
 
 @pytest.mark.asyncio
@@ -231,8 +230,7 @@ async def test_enrich_text_bookmark_with_name_as_segment_ref():
     ):
         result = await enrich_text_bookmark(bookmark)
 
-    assert result["verse_id"] == verse_locator
-    assert result["segment_content"] == "Named segment content"
+    assert result["text"].segment.content == "Named segment content"
 
 
 @pytest.mark.asyncio
@@ -284,11 +282,10 @@ async def test_enrich_verse_bookmark_includes_segment_content():
     ):
         result = await enrich_text_bookmark(bookmark)
 
-    assert result["text_id"] == text_id
-    assert result["text_title"] == "Lotus Sutra"
-    assert result["segment_id"] == segment_id
-    assert result["segment_content"] == "Verse segment content"
-    assert result["verse_id"] == verse_locator
+    assert result["text"].id == text_id
+    assert result["text"].title == "Lotus Sutra"
+    assert result["text"].segment.id == segment_id
+    assert result["text"].segment.content == "Verse segment content"
 
 
 @pytest.mark.asyncio
@@ -344,9 +341,9 @@ async def test_enrich_text_bookmark_handles_missing_text_details():
     ):
         result = await enrich_text_bookmark(bookmark)
 
-    assert result["text_id"] == text_id
-    assert result["text_title"] is None
-    assert result["segment_content"] == "Segment content"
+    assert result["text"].id == text_id
+    assert result["text"].title == ""
+    assert result["text"].segment.content == "Segment content"
 
 
 @pytest.mark.asyncio
@@ -384,8 +381,8 @@ async def test_enrich_text_bookmark_with_language_uses_localized_text():
     ):
         result = await enrich_text_bookmark(bookmark, language="BO")
 
-    assert result["text_id"] == localized_text_id
-    assert result["text_title"] == "བོད་ཡིག་ཁ་བྱང་"
+    assert result["text"].id == localized_text_id
+    assert result["text"].title == "བོད་ཡིག་ཁ་བྱང་"
 
 
 def test_enrich_plan_bookmark_with_language_uses_matching_sibling():
@@ -419,15 +416,6 @@ def test_enrich_plan_bookmark_with_language_uses_matching_sibling():
     ), patch(
         "pecha_api.bookmarks.bookmark_utils.get_sibling_plans_in_series_slot",
         return_value=[bo_plan],
-    ), patch(
-        "pecha_api.bookmarks.bookmark_utils.get_group_id_for_plan",
-        return_value=None,
-    ), patch(
-        "pecha_api.bookmarks.bookmark_utils.get_image_url",
-        return_value=None,
-    ), patch(
-        "pecha_api.bookmarks.bookmark_utils.tags_to_summary_dtos",
-        return_value=[],
     ):
         mock_db.query.return_value.filter.return_value.count.return_value = 3
         result = enrich_plan_bookmark(
@@ -437,8 +425,8 @@ def test_enrich_plan_bookmark_with_language_uses_matching_sibling():
         )
 
     assert result["plan"].id == bo_plan_id
-    assert result["plan"].title == "བོད་ཡིག་ཐེངས་"
-    assert result["plan"].language == "BO"
+    assert result["plan"].metadata.title == "བོད་ཡིག་ཐེངས་"
+    assert result["plan"].metadata.language == "BO"
 
 
 def test_enrich_plan_bookmark_returns_empty_for_invalid_source_id():
@@ -464,60 +452,59 @@ def test_enrich_plan_bookmark_returns_empty_when_plan_not_found():
     assert result == {}
 
 
-def test_enrich_plan_bookmark_includes_author_details():
+def test_enrich_plan_bookmark_includes_dates_and_image():
+    from datetime import datetime, timedelta, timezone
     from pecha_api.bookmarks.bookmark_utils import enrich_plan_bookmark
 
     plan_id = uuid4()
-    author_id = uuid4()
     mock_db = MagicMock()
+    start_date = datetime(2026, 1, 1, tzinfo=timezone.utc)
 
     mock_plan = MagicMock()
     mock_plan.id = plan_id
     mock_plan.title = "Morning Practice"
     mock_plan.description = "Daily practice"
     mock_plan.language = "EN"
-    mock_plan.difficulty_level = None
-    mock_plan.image_url = "plan.png"
-    mock_plan.start_date = None
-    mock_plan.display_order = None
-    mock_plan.tag_list = []
-    mock_plan.author = MagicMock()
-    mock_plan.author.id = author_id
-    mock_plan.author.first_name = "Tenzin"
-    mock_plan.author.last_name = "Gyatso"
-    mock_plan.author.image_url = "author.png"
+    mock_plan.image_url = "plans/original/plan.png"
+    mock_plan.start_date = start_date
 
     with patch(
         "pecha_api.bookmarks.bookmark_utils.get_published_plan_by_id",
         return_value=mock_plan,
     ), patch(
-        "pecha_api.bookmarks.bookmark_utils.get_group_id_for_plan",
-        return_value=None,
-    ), patch(
-        "pecha_api.bookmarks.bookmark_utils.get_image_url",
-        return_value=None,
-    ), patch(
-        "pecha_api.bookmarks.bookmark_utils.tags_to_summary_dtos",
-        return_value=[],
+        "pecha_api.bookmarks.bookmark_utils._bookmark_image_url",
+        return_value="https://example.com/plan.png",
     ):
         mock_db.query.return_value.filter.return_value.count.return_value = 7
         result = enrich_plan_bookmark(db=mock_db, source_id=str(plan_id))
 
     assert result["plan"].id == plan_id
-    assert result["plan"].author.firstname == "Tenzin"
-    assert result["plan"].author.lastname == "Gyatso"
-    assert result["plan"].total_days == 7
+    assert result["plan"].metadata.title == "Morning Practice"
+    assert result["plan"].image == "https://example.com/plan.png"
+    assert result["plan"].start_date == start_date
+    assert result["plan"].end_date == start_date + timedelta(days=6)
 
 
 def test_enrich_series_bookmark_success():
+    from datetime import datetime, timezone
     from pecha_api.bookmarks.bookmark_utils import enrich_series_bookmark
+    from pecha_api.plans.series.series_response_models import SeriesMetadataDTO
 
     series_id = uuid4()
     mock_db = MagicMock()
     mock_series = MagicMock()
+    mock_series.id = series_id
     mock_series.status = "PUBLISHED"
     mock_series.plans = []
-    mock_dto = MagicMock()
+    mock_series.metadata_entries = []
+    mock_series.image = "series/original/series.png"
+    start_date = datetime.now(timezone.utc)
+    end_date = datetime.now(timezone.utc)
+    metadata = SeriesMetadataDTO(
+        id=uuid4(),
+        title="Series title",
+        language="BO",
+    )
 
     with patch(
         "pecha_api.bookmarks.bookmark_utils.get_series_by_id",
@@ -528,28 +515,36 @@ def test_enrich_series_bookmark_success():
             "pecha_api.plans.plans_enums", fromlist=["PlanStatus"]
         ).PlanStatus.PUBLISHED,
     ), patch(
-        "pecha_api.bookmarks.bookmark_utils.get_active_plan_count_map_by_series_ids",
-        return_value={series_id: 2},
-    ), patch(
-        "pecha_api.bookmarks.bookmark_utils.get_enrolled_count_map_by_series_ids",
-        return_value={series_id: 5},
-    ), patch(
         "pecha_api.bookmarks.bookmark_utils._series_schedule_from_plans",
-        return_value=(None, None, 10),
+        return_value=(start_date, end_date, 10),
     ), patch(
-        "pecha_api.bookmarks.bookmark_utils._group_summary_for_series",
-        return_value=None,
-    ), patch(
-        "pecha_api.bookmarks.bookmark_utils._series_to_list_item_dto",
-        return_value=mock_dto,
-    ):
+        "pecha_api.bookmarks.bookmark_utils._metadata_response",
+        return_value=metadata,
+    ) as mock_metadata_response, patch(
+        "pecha_api.bookmarks.bookmark_utils._bookmark_image_url",
+        return_value="https://example.com/series.png",
+    ) as mock_image_url:
         result = enrich_series_bookmark(
             db=mock_db,
             source_id=str(series_id),
             language="BO",
         )
 
-    assert result == {"series": mock_dto}
+    mock_metadata_response.assert_called_once_with(
+        [],
+        language="BO",
+        fallback=True,
+    )
+    mock_image_url.assert_called_once_with(
+        "series/original/series.png",
+        resource_id=series_id,
+        resource_type="series",
+    )
+    assert result["series"].id == series_id
+    assert result["series"].metadata == metadata
+    assert result["series"].image == "https://example.com/series.png"
+    assert result["series"].start_date == start_date
+    assert result["series"].end_date == end_date
 
 
 def test_enrich_series_bookmark_returns_empty_when_unpublished():
@@ -576,23 +571,27 @@ def test_enrich_accumulator_bookmark_success():
     accumulator_id = uuid4()
     mock_db = MagicMock()
     mock_accumulator = MagicMock()
-    mock_accumulator.metadata_entries = []
-    mock_dto = MagicMock()
+    mock_accumulator.id = accumulator_id
+    metadata_entry = MagicMock()
+    metadata_entry.name = "Mala Practice"
+    mock_accumulator.metadata_entries = [metadata_entry]
 
     mock_db.query.return_value.options.return_value.filter.return_value.first.return_value = (
         mock_accumulator
     )
 
     with patch(
-        "pecha_api.bookmarks.bookmark_utils.convert_accumulator_to_dto",
-        return_value=mock_dto,
+        "pecha_api.bookmarks.bookmark_utils.resolve_mala_image_fields",
+        return_value=(uuid4(), "https://example.com/mala.png"),
     ):
         result = enrich_accumulator_bookmark(
             db=mock_db,
             source_id=str(accumulator_id),
         )
 
-    assert result == {"accumulator": mock_dto}
+    assert result["accumulator"].id == accumulator_id
+    assert result["accumulator"].title == "Mala Practice"
+    assert result["accumulator"].image == "https://example.com/mala.png"
 
 
 def test_enrich_accumulator_bookmark_filters_metadata_by_language():
@@ -601,24 +600,22 @@ def test_enrich_accumulator_bookmark_filters_metadata_by_language():
     accumulator_id = uuid4()
     mock_db = MagicMock()
     mock_accumulator = MagicMock()
+    mock_accumulator.id = accumulator_id
     metadata_entry = MagicMock()
+    metadata_entry.name = "བོད་ཡིག་མཚན་"
     mock_accumulator.metadata_entries = [metadata_entry]
-    mock_dto = MagicMock()
 
     mock_db.query.return_value.options.return_value.filter.return_value.first.return_value = (
         mock_accumulator
     )
 
     with patch(
-        "pecha_api.bookmarks.bookmark_utils.convert_accumulator_to_dto",
-        return_value=mock_dto,
+        "pecha_api.bookmarks.bookmark_utils.resolve_mala_image_fields",
+        return_value=(None, None),
     ), patch(
         "pecha_api.bookmarks.bookmark_utils.filter_by_language_with_fallback",
         return_value=[metadata_entry],
-    ) as mock_filter, patch(
-        "pecha_api.bookmarks.bookmark_utils.convert_metadata_to_dto",
-        return_value=MagicMock(),
-    ) as mock_metadata_dto:
+    ) as mock_filter:
         result = enrich_accumulator_bookmark(
             db=mock_db,
             source_id=str(accumulator_id),
@@ -626,9 +623,7 @@ def test_enrich_accumulator_bookmark_filters_metadata_by_language():
         )
 
     mock_filter.assert_called_once()
-    mock_metadata_dto.assert_called_once_with(metadata_entry)
-    assert result == {"accumulator": mock_dto}
-    assert mock_dto.metadata == [mock_metadata_dto.return_value]
+    assert result["accumulator"].title == "བོད་ཡིག་མཚན་"
 
 
 def test_enrich_timer_bookmark_success():
@@ -636,18 +631,19 @@ def test_enrich_timer_bookmark_success():
 
     timer_id = uuid4()
     mock_timer = MagicMock()
-    mock_dto = MagicMock()
+    mock_timer.id = timer_id
+    mock_timer.name = "Meditation Timer"
+    mock_timer.duration = 600
 
     with patch(
         "pecha_api.bookmarks.bookmark_utils.get_timer_by_id",
         return_value=mock_timer,
-    ), patch(
-        "pecha_api.bookmarks.bookmark_utils.convert_timer_to_dto",
-        return_value=mock_dto,
     ):
         result = enrich_timer_bookmark(db=MagicMock(), source_id=str(timer_id))
 
-    assert result == {"timer": mock_dto}
+    assert result["timer"].id == timer_id
+    assert result["timer"].title == "Meditation Timer"
+    assert result["timer"].duration == 600
 
 
 def test_enrich_timer_bookmark_returns_empty_when_not_found():
@@ -754,7 +750,7 @@ async def test_enrich_text_bookmark_falls_back_when_localized_text_missing():
     ):
         result = await enrich_text_bookmark(bookmark, language="BO")
 
-    assert result["text_title"] == "Original title"
+    assert result["text"].title == "Original title"
 
 
 @pytest.mark.asyncio

--- a/tests/bookmarks/test_bookmark_views.py
+++ b/tests/bookmarks/test_bookmark_views.py
@@ -161,7 +161,10 @@ def test_get_bookmarks_success():
                 created_at=now,
                 updated_at=now
             )
-        ]
+        ],
+        total=2,
+        skip=0,
+        limit=20,
     )
 
     with patch("pecha_api.bookmarks.bookmark_views.get_bookmarks_service") as mock_service:
@@ -180,14 +183,14 @@ def test_get_bookmarks_success():
         assert "name" not in data["bookmarks"][1]
 
 
-def test_get_bookmarks_passes_language_to_service():
-    mock_response = BookmarksResponse(bookmarks=[])
+def test_get_bookmarks_passes_pagination_and_language_to_service():
+    mock_response = BookmarksResponse(bookmarks=[], total=0, skip=10, limit=5)
 
     with patch("pecha_api.bookmarks.bookmark_views.get_bookmarks_service") as mock_service:
         mock_service.return_value = mock_response
 
         response = client.get(
-            "/users/me/bookmarks?type=PLAN&language=bo",
+            "/users/me/bookmarks?type=PLAN&language=bo&skip=10&limit=5",
             headers={"Authorization": "Bearer test_token"},
         )
 
@@ -196,11 +199,13 @@ def test_get_bookmarks_passes_language_to_service():
             token="test_token",
             type=BookmarkFilterType.PLAN,
             language="bo",
+            skip=10,
+            limit=5,
         )
 
 
 def test_get_bookmarks_empty():
-    mock_response = BookmarksResponse(bookmarks=[])
+    mock_response = BookmarksResponse(bookmarks=[], total=0, skip=0, limit=20)
 
     with patch("pecha_api.bookmarks.bookmark_views.get_bookmarks_service") as mock_service:
         mock_service.return_value = mock_response


### PR DESCRIPTION
…ce response structure

- Updated `get_bookmarks_by_user_id` to return a tuple of bookmarks and total count, allowing for pagination.
- Modified `BookmarksResponse` to include total, skip, and limit fields for better client-side handling.
- Adjusted service and view layers to accept and pass pagination parameters (skip and limit).
- Enhanced tests to validate the new pagination functionality and ensure correct behavior across various scenarios.