### PR TITLE
Add group members listing functionality

### DIFF
--- a/pecha_api/plans/groups/groups_repository.py
+++ b/pecha_api/plans/groups/groups_repository.py
@@ -20,6 +20,7 @@ from pecha_api.plans.plans_models import Plan
 from pecha_api.plans.series.series_model import Series
 from pecha_api.plans.tags.tag_model import Tag
 from pecha_api.plans.users.plan_users_models import SeriesPartner
+from pecha_api.users.users_models import Users
 
 
 def get_group_ids_by_plan_ids(db: Session, plan_ids: Sequence[UUID]) -> Dict[UUID, UUID]:
@@ -543,6 +544,27 @@ def is_user_joined_group(
         )
     ).first()
     return row is not None
+
+
+def list_group_joiners_paginated(
+    db: Session,
+    group_id: UUID,
+    skip: int,
+    limit: int,
+) -> Tuple[List[Users], int]:
+    query = (
+        db.query(Users)
+        .join(author_group_joins, Users.id == author_group_joins.c.user_id)
+        .filter(author_group_joins.c.group_id == group_id)
+    )
+    total = query.count()
+    users = (
+        query.order_by(author_group_joins.c.created_at.desc())
+        .offset(skip)
+        .limit(limit)
+        .all()
+    )
+    return users, total
 
 
 def get_joiners_count_map(db: Session, group_ids: Sequence[UUID]) -> dict[UUID, int]:

--- a/pecha_api/plans/groups/groups_response_models.py
+++ b/pecha_api/plans/groups/groups_response_models.py
@@ -37,6 +37,8 @@ __all__ = [
     "GroupInviteCreatedResponse",
     "UpdateGroupMemberRoleRequest",
     "TransferGroupOwnershipRequest",
+    "AuthorGroupMemberProfileDTO",
+    "AuthorGroupMembersListResponse",
 ]
 
 
@@ -218,3 +220,16 @@ class UpdateGroupMemberRoleRequest(BaseModel):
 
 class TransferGroupOwnershipRequest(BaseModel):
     new_owner_author_id: UUID
+
+
+class AuthorGroupMemberProfileDTO(BaseModel):
+    username: Optional[str] = None
+    fullname: str
+    avatar_url: Optional[str] = None
+
+
+class AuthorGroupMembersListResponse(BaseModel):
+    total_members: int
+    list: List[AuthorGroupMemberProfileDTO]
+    skip: int
+    limit: int

--- a/pecha_api/plans/groups/groups_service.py
+++ b/pecha_api/plans/groups/groups_service.py
@@ -50,6 +50,7 @@ from pecha_api.plans.groups.groups_repository import (
     get_series_by_group_id,
     has_pending_invite,
     list_invites_by_group,
+    list_group_joiners_paginated,
     list_pending_invites_by_email,
     get_series_by_ids,
     get_tags_by_ids,
@@ -80,6 +81,8 @@ from pecha_api.plans.groups.groups_response_models import (
     AuthorGroupDetailDTO,
     AuthorGroupListResponse,
     AuthorGroupMemberDTO,
+    AuthorGroupMemberProfileDTO,
+    AuthorGroupMembersListResponse,
     AuthorGroupSummaryDTO,
     CreateAuthorGroupRequest,
     CreateGroupInviteRequest,
@@ -105,6 +108,7 @@ from pecha_api.plans.groups.groups_response_models import (
 from pecha_api.plans.groups.groups_models import author_group_tags
 from pecha_api.plans.tags.tag_helpers import tags_to_summary_dtos
 from pecha_api.users.users_service import validate_and_extract_user_details
+from pecha_api.users.users_models import Users
 
 GROUP_NOT_FOUND = "Group not found"
 INVITE_NOT_FOUND = "Invite not found"
@@ -148,6 +152,20 @@ def _generate_group_asset_url(asset_key: Optional[str]) -> Optional[str]:
     return generate_presigned_access_url(
         bucket_name=get("AWS_BUCKET_NAME"),
         s3_key=asset_key,
+    )
+
+
+def _user_fullname(user: Users) -> str:
+    parts = [user.firstname, user.lastname]
+    return " ".join(part for part in parts if part).strip()
+
+
+def _user_avatar_url(user: Users) -> Optional[str]:
+    if not user.avatar_url:
+        return None
+    return generate_presigned_access_url(
+        bucket_name=get("AWS_BUCKET_NAME"),
+        s3_key=user.avatar_url,
     )
 
 
@@ -657,6 +675,36 @@ def get_author_group_detail(
             joiner_count=joiner_count,
             db=db, public=True,
             language=language,
+        )
+
+
+def list_group_members(
+    group_id: UUID,
+    skip: int,
+    limit: int,
+) -> AuthorGroupMembersListResponse:
+    with SessionLocal() as db:
+        group = get_group_by_id(db=db, group_id=group_id)
+        if not group or not group.is_public:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=GROUP_NOT_FOUND)
+        users, total = list_group_joiners_paginated(
+            db=db,
+            group_id=group_id,
+            skip=skip,
+            limit=limit,
+        )
+        return AuthorGroupMembersListResponse(
+            total_members=total,
+            list=[
+                AuthorGroupMemberProfileDTO(
+                    username=user.username,
+                    fullname=_user_fullname(user),
+                    avatar_url=_user_avatar_url(user),
+                )
+                for user in users
+            ],
+            skip=skip,
+            limit=limit,
         )
 
 

--- a/pecha_api/plans/groups/groups_views.py
+++ b/pecha_api/plans/groups/groups_views.py
@@ -26,6 +26,8 @@ from pecha_api.plans.groups.groups_response_models import (
     UserFollowedAuthorGroupListResponse,
     UserJoinedAuthorGroupDTO,
     UserJoinedAuthorGroupListResponse,
+    AuthorGroupMemberProfileDTO,
+    AuthorGroupMembersListResponse,
 )
 from pecha_api.plans.groups.groups_service import (
     accept_group_invite_by_id,
@@ -42,6 +44,7 @@ from pecha_api.plans.groups.groups_service import (
     list_cms_groups,
     list_followed_groups,
     list_joined_groups,
+    list_group_members,
     list_group_invites,
     list_my_pending_group_invites,
     list_public_groups,
@@ -324,6 +327,19 @@ def get_public_group(
     language: Annotated[Optional[str], Query(description=_LANGUAGE_QUERY_DESCRIPTION)] = None,
 ):
     return get_author_group_detail(group_id=group_id, require_public=True, language=language)
+
+
+@public_groups_router.get(
+    "/{group_id}/members",
+    status_code=status.HTTP_200_OK,
+    response_model=AuthorGroupMembersListResponse,
+)
+def get_public_group_members(
+    group_id: UUID,
+    skip: Annotated[int, Query(ge=0)] = 0,
+    limit: Annotated[int, Query(ge=1, le=100)] = 20,
+):
+    return list_group_members(group_id=group_id, skip=skip, limit=limit)
 
 
 @public_groups_router.get("", status_code=status.HTTP_200_OK, response_model=PublicAuthorGroupListResponse)

--- a/tests/plans/groups/test_groups_service.py
+++ b/tests/plans/groups/test_groups_service.py
@@ -38,6 +38,7 @@ from pecha_api.plans.groups.groups_service import (
     get_author_group_detail,
     get_cms_group_detail,
     list_cms_groups,
+    list_group_members,
     list_followed_groups,
     list_joined_groups,
     list_public_groups,
@@ -321,6 +322,46 @@ def test_get_author_group_detail_private_group_hidden():
         with pytest.raises(HTTPException) as exc:
             get_author_group_detail(group_id=private_group.id, require_public=True)
     assert exc.value.detail == GROUP_NOT_FOUND
+
+
+def test_list_group_members_not_found():
+    with patch("pecha_api.plans.groups.groups_service.SessionLocal") as mock_session, patch(
+        "pecha_api.plans.groups.groups_service.get_group_by_id",
+        return_value=None,
+    ):
+        _session_local_context(mock_session)
+        with pytest.raises(HTTPException) as exc:
+            list_group_members(group_id=uuid4(), skip=0, limit=20)
+    assert exc.value.detail == GROUP_NOT_FOUND
+
+
+def test_list_group_members_returns_paginated_profiles():
+    group = _make_group()
+    user = MagicMock()
+    user.username = "alice"
+    user.firstname = "Alice"
+    user.lastname = "Smith"
+    user.avatar_url = "images/profile_images/alice.webp"
+    with patch("pecha_api.plans.groups.groups_service.SessionLocal") as mock_session, patch(
+        "pecha_api.plans.groups.groups_service.get_group_by_id",
+        return_value=group,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.list_group_joiners_paginated",
+        return_value=([user], 1),
+    ), patch(
+        "pecha_api.plans.groups.groups_service._user_avatar_url",
+        return_value="https://example.com/avatar.webp",
+    ):
+        _session_local_context(mock_session)
+        result = list_group_members(group_id=group.id, skip=0, limit=20)
+
+    assert result.total_members == 1
+    assert result.skip == 0
+    assert result.limit == 20
+    assert len(result.list) == 1
+    assert result.list[0].username == "alice"
+    assert result.list[0].fullname == "Alice Smith"
+    assert result.list[0].avatar_url == "https://example.com/avatar.webp"
 
 
 def test_list_public_groups_defaults_to_community_type():

--- a/tests/plans/groups/test_groups_views.py
+++ b/tests/plans/groups/test_groups_views.py
@@ -17,6 +17,8 @@ from pecha_api.plans.groups.groups_response_models import (
     UserFollowedAuthorGroupListResponse,
     UserJoinedAuthorGroupDTO,
     UserJoinedAuthorGroupListResponse,
+    AuthorGroupMemberProfileDTO,
+    AuthorGroupMembersListResponse,
 )
 client = TestClient(api)
 
@@ -415,6 +417,34 @@ def test_get_public_group_by_id_with_language():
         response = client.get(f"/author/groups/{group_id}?language=bo")
     assert response.status_code == status.HTTP_200_OK
     mock_service.assert_called_once_with(group_id=group_id, require_public=True, language="bo")
+
+
+def test_get_public_group_members():
+    group_id = uuid4()
+    response_model = AuthorGroupMembersListResponse(
+        total_members=1,
+        list=[
+            AuthorGroupMemberProfileDTO(
+                username="alice",
+                fullname="Alice Smith",
+                avatar_url="https://example.com/avatar.webp",
+            )
+        ],
+        skip=0,
+        limit=20,
+    )
+    with patch(
+        "pecha_api.plans.groups.groups_views.list_group_members",
+        return_value=response_model,
+    ) as mock_service:
+        response = client.get(f"/author/groups/{group_id}/members?skip=0&limit=20")
+    assert response.status_code == status.HTTP_200_OK
+    mock_service.assert_called_once_with(group_id=group_id, skip=0, limit=20)
+    body = response.json()
+    assert body["total_members"] == 1
+    assert body["list"][0]["username"] == "alice"
+    assert body["list"][0]["fullname"] == "Alice Smith"
+    assert body["list"][0]["avatar_url"] == "https://example.com/avatar.webp"
 
 
 def test_follow_and_unfollow_group():


### PR DESCRIPTION
- Introduced `list_group_members` endpoint to retrieve paginated members of a group.
- Added `list_group_joiners_paginated` function in the repository to support member retrieval.
- Created response models `AuthorGroupMemberProfileDTO` and `AuthorGroupMembersListResponse` for structured member data.
- Implemented tests for group member listing and validation of responses.
- Updated relevant service and view files to integrate new functionality.