### PR TITLE
Add series partner and user enrollment mapping functionality

### DIFF
--- a/pecha_api/plans/groups/groups_repository.py
+++ b/pecha_api/plans/groups/groups_repository.py
@@ -19,7 +19,7 @@ from pecha_api.plans.groups.groups_models import (
 from pecha_api.plans.plans_models import Plan
 from pecha_api.plans.series.series_model import Series
 from pecha_api.plans.tags.tag_model import Tag
-from pecha_api.plans.users.plan_users_models import SeriesPartner
+from pecha_api.plans.users.plan_users_models import SeriesPartner, UserSeriesEnrollment
 
 
 def get_group_ids_by_plan_ids(db: Session, plan_ids: Sequence[UUID]) -> Dict[UUID, UUID]:
@@ -78,6 +78,47 @@ def get_plans_by_group_id(db: Session, group_id: UUID) -> List[Plan]:
         .filter(Plan.group_id == group_id, Plan.deleted_at.is_(None))
         .all()
     )
+
+
+def get_series_partner_id_map_for_group(
+    db: Session,
+    group_id: UUID,
+    series_ids: Sequence[UUID],
+) -> Dict[UUID, UUID]:
+    if not series_ids:
+        return {}
+    rows = (
+        db.execute(
+            select(SeriesPartner.series_id, SeriesPartner.id).where(
+                SeriesPartner.group_id == group_id,
+                SeriesPartner.series_id.in_(series_ids),
+            )
+        )
+        .all()
+    )
+    return dict(rows)
+
+
+def get_user_series_enrollment_partner_map(
+    db: Session,
+    user_id: UUID,
+    series_ids: Sequence[UUID],
+) -> Dict[UUID, Optional[UUID]]:
+    if not series_ids:
+        return {}
+    rows = (
+        db.execute(
+            select(
+                UserSeriesEnrollment.series_id,
+                UserSeriesEnrollment.series_partner_id,
+            ).where(
+                UserSeriesEnrollment.user_id == user_id,
+                UserSeriesEnrollment.series_id.in_(series_ids),
+            )
+        )
+        .all()
+    )
+    return dict(rows)
 
 
 def get_series_by_group_id(db: Session, group_id: UUID) -> List[Series]:

--- a/pecha_api/plans/groups/groups_response_models.py
+++ b/pecha_api/plans/groups/groups_response_models.py
@@ -13,6 +13,11 @@ from pecha_api.plans.groups.group_summary_models import (
 from pecha_api.plans.plans_enums import LanguageCode
 from pecha_api.plans.plans_response_models import PlanDTO
 from pecha_api.plans.series.series_response_models import SeriesListItemDTO
+
+
+class GroupSeriesListItemDTO(SeriesListItemDTO):
+    series_partner_id: Optional[UUID] = None
+    is_enrolled: bool = False
 from pecha_api.plans.tags.tag_response_models import TagSummaryDTO
 
 __all__ = [
@@ -28,6 +33,7 @@ __all__ = [
     "CreateAuthorGroupRequest",
     "UpdateAuthorGroupRequest",
     "ReplaceGroupTagsRequest",
+    "GroupSeriesListItemDTO",
     "ReplaceGroupSeriesRequest",
     "ReplaceGroupPlansRequest",
     "ReplaceGroupSocialLinksRequest",
@@ -80,7 +86,7 @@ class AuthorGroupDetailDTO(BaseModel):
     members: List[AuthorGroupMemberDTO] = []
     tags: List[TagSummaryDTO] = []
     social_links: List[GroupSocialLinkDTO] = []
-    series: List[SeriesListItemDTO] = []
+    series: List[GroupSeriesListItemDTO] = []
     plans: List[PlanDTO] = []
     follower_count: int = 0
     joiner_count: int = 0

--- a/pecha_api/plans/groups/groups_service.py
+++ b/pecha_api/plans/groups/groups_service.py
@@ -48,6 +48,8 @@ from pecha_api.plans.groups.groups_repository import (
     get_plans_by_group_id,
     get_plans_by_ids,
     get_series_by_group_id,
+    get_series_partner_id_map_for_group,
+    get_user_series_enrollment_partner_map,
     has_pending_invite,
     list_invites_by_group,
     list_pending_invites_by_email,
@@ -70,7 +72,6 @@ from pecha_api.plans.series.series_repository import (
     get_active_plan_count_map_by_series_ids,
     get_enrolled_count_map_by_series_ids,
 )
-from pecha_api.plans.series.series_response_models import SeriesListItemDTO
 from pecha_api.plans.series.series_service import _series_to_list_item_dto
 from pecha_api.plans.shared.metadata_utils import (
     format_metadata_response,
@@ -78,6 +79,7 @@ from pecha_api.plans.shared.metadata_utils import (
 )
 from pecha_api.plans.groups.groups_response_models import (
     AuthorGroupDetailDTO,
+    GroupSeriesListItemDTO,
     AuthorGroupListResponse,
     AuthorGroupMemberDTO,
     AuthorGroupSummaryDTO,
@@ -350,12 +352,25 @@ def _validate_group_links(db, tag_ids: Optional[List[UUID]], series_ids: Optiona
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="One or more plans do not exist")
 
 
+def _is_series_enrolled_for_group_context(
+    enrollment_partner_id: Optional[UUID],
+    expected_partner_id: Optional[UUID],
+    *,
+    is_enrolled_in_series: bool,
+) -> bool:
+    if not is_enrolled_in_series:
+        return False
+    return enrollment_partner_id == expected_partner_id
+
+
 def _series_to_dtos(
     db: Session,
     series_list: List[Series],
+    group_id: UUID,
     language: Optional[str] = None,
     published_only: bool = False,
-) -> List[SeriesListItemDTO]:
+    user_id: Optional[UUID] = None,
+) -> List[GroupSeriesListItemDTO]:
     if not series_list:
         return []
     series_ids = [series.id for series in series_list]
@@ -363,13 +378,29 @@ def _series_to_dtos(
         db=db, series_ids=series_ids, published_only=published_only
     )
     enrolled_count_map = get_enrolled_count_map_by_series_ids(db=db, series_ids=series_ids)
+    partner_id_map = get_series_partner_id_map_for_group(
+        db=db, group_id=group_id, series_ids=series_ids
+    )
+    enrollment_partner_map: Dict[UUID, Optional[UUID]] = {}
+    if user_id is not None:
+        enrollment_partner_map = get_user_series_enrollment_partner_map(
+            db=db, user_id=user_id, series_ids=series_ids
+        )
     return [
-        _series_to_list_item_dto(
-            series,
-            plan_count=plan_count_map.get(series.id, 0),
-            enrolled_count=enrolled_count_map.get(series.id, 0),
-            language=language,
-            fallback=True,
+        GroupSeriesListItemDTO(
+            **_series_to_list_item_dto(
+                series,
+                plan_count=plan_count_map.get(series.id, 0),
+                enrolled_count=enrolled_count_map.get(series.id, 0),
+                language=language,
+                fallback=True,
+            ).model_dump(),
+            series_partner_id=partner_id_map.get(series.id),
+            is_enrolled=_is_series_enrolled_for_group_context(
+                enrollment_partner_id=enrollment_partner_map.get(series.id),
+                expected_partner_id=partner_id_map.get(series.id),
+                is_enrolled_in_series=series.id in enrollment_partner_map,
+            ),
         )
         for series in series_list
     ]
@@ -515,11 +546,19 @@ def _group_to_detail(
     db: Optional[Session] = None,
     public: bool = False,
     language: Optional[str] = None,
+    user_id: Optional[UUID] = None,
 ) -> AuthorGroupDetailDTO:
     if db is not None:
         group_series = get_series_by_group_id(db=db, group_id=group.id)
         group_plans = get_plans_by_group_id(db=db, group_id=group.id)
-        series_dtos = _series_to_dtos(db=db, series_list=group_series, language=language, published_only=public)
+        series_dtos = _series_to_dtos(
+            db=db,
+            series_list=group_series,
+            group_id=group.id,
+            language=language,
+            published_only=public,
+            user_id=user_id,
+        )
         plans_dtos = _plans_to_dtos(db=db, plan_list=group_plans, group_id=group.id)
     else:
         series_dtos = []
@@ -642,7 +681,15 @@ def get_author_group_detail(
     group_id: UUID,
     require_public: bool = True,
     language: Optional[str] = None,
+    token: Optional[str] = None,
 ) -> PublicAuthorGroupDetailDTO:
+    user_id = None
+    if token:
+        try:
+            user = validate_and_extract_user_details(token=token)
+            user_id = user.id
+        except Exception:
+            pass
     with SessionLocal() as db:
         group = get_group_by_id(db=db, group_id=group_id)
         if not group:
@@ -657,6 +704,7 @@ def get_author_group_detail(
             joiner_count=joiner_count,
             db=db, public=True,
             language=language,
+            user_id=user_id,
         )
 
 

--- a/pecha_api/plans/groups/groups_views.py
+++ b/pecha_api/plans/groups/groups_views.py
@@ -321,9 +321,17 @@ def delete_group_member_by_id(
 @public_groups_router.get("/{group_id}", status_code=status.HTTP_200_OK, response_model=PublicAuthorGroupDetailDTO)
 def get_public_group(
     group_id: UUID,
+    authentication_credential: Annotated[
+        Optional[HTTPAuthorizationCredentials], Depends(optional_oauth2_scheme)
+    ] = None,
     language: Annotated[Optional[str], Query(description=_LANGUAGE_QUERY_DESCRIPTION)] = None,
 ):
-    return get_author_group_detail(group_id=group_id, require_public=True, language=language)
+    return get_author_group_detail(
+        group_id=group_id,
+        require_public=True,
+        language=language,
+        token=authentication_credential.credentials if authentication_credential else None,
+    )
 
 
 @public_groups_router.get("", status_code=status.HTTP_200_OK, response_model=PublicAuthorGroupListResponse)

--- a/tests/plans/groups/test_groups_repository.py
+++ b/tests/plans/groups/test_groups_repository.py
@@ -10,6 +10,8 @@ from pecha_api.plans.groups.groups_repository import (
     get_group_ids_by_series_ids,
     get_groups_paginated,
     get_series_by_group_id,
+    get_series_partner_id_map_for_group,
+    get_user_series_enrollment_partner_map,
     update_group,
 )
 
@@ -70,6 +72,46 @@ def test_get_group_ids_by_series_ids_empty_input():
 
     assert get_group_ids_by_series_ids(db=db, series_ids=[]) == {}
     db.execute.assert_not_called()
+
+
+def test_get_series_partner_id_map_for_group_empty_input():
+    db = _make_session_mock()
+    assert get_series_partner_id_map_for_group(db=db, group_id=uuid.uuid4(), series_ids=[]) == {}
+
+
+def test_get_series_partner_id_map_for_group():
+    db = _make_session_mock()
+    group_id = uuid.uuid4()
+    series_id = uuid.uuid4()
+    partner_id = uuid.uuid4()
+    db.execute.return_value.all.return_value = [(series_id, partner_id)]
+
+    result = get_series_partner_id_map_for_group(
+        db=db, group_id=group_id, series_ids=[series_id]
+    )
+
+    assert result == {series_id: partner_id}
+
+
+def test_get_user_series_enrollment_partner_map_empty_input():
+    db = _make_session_mock()
+    assert get_user_series_enrollment_partner_map(
+        db=db, user_id=uuid.uuid4(), series_ids=[]
+    ) == {}
+
+
+def test_get_user_series_enrollment_partner_map():
+    db = _make_session_mock()
+    user_id = uuid.uuid4()
+    series_id = uuid.uuid4()
+    partner_id = uuid.uuid4()
+    db.execute.return_value.all.return_value = [(series_id, partner_id)]
+
+    result = get_user_series_enrollment_partner_map(
+        db=db, user_id=user_id, series_ids=[series_id]
+    )
+
+    assert result == {series_id: partner_id}
 
 
 def test_get_series_by_group_id_includes_owned_and_partner_series():

--- a/tests/plans/groups/test_groups_service.py
+++ b/tests/plans/groups/test_groups_service.py
@@ -23,6 +23,7 @@ from pecha_api.plans.groups.groups_service import (
     _generate_group_asset_url,
     _get_member_or_403,
     _group_to_detail,
+    _is_series_enrolled_for_group_context,
     _series_to_dtos,
     _to_role_value,
     accept_group_invite_by_id,
@@ -614,20 +615,101 @@ def _make_series_with_metadata():
 
 def test_series_to_dtos_returns_empty_for_empty_series_list():
     mock_db = MagicMock()
-    assert _series_to_dtos(db=mock_db, series_list=[]) == []
+    assert _series_to_dtos(db=mock_db, series_list=[], group_id=uuid4()) == []
     mock_db.assert_not_called()
 
 
+def test_is_series_enrolled_for_group_context():
+    partner_id = uuid4()
+    assert _is_series_enrolled_for_group_context(
+        partner_id, partner_id, is_enrolled_in_series=True
+    )
+    assert not _is_series_enrolled_for_group_context(
+        partner_id, uuid4(), is_enrolled_in_series=True
+    )
+    assert _is_series_enrolled_for_group_context(
+        None, None, is_enrolled_in_series=True
+    )
+    assert not _is_series_enrolled_for_group_context(
+        partner_id, None, is_enrolled_in_series=True
+    )
+    assert not _is_series_enrolled_for_group_context(
+        None, None, is_enrolled_in_series=False
+    )
+
+
+def test_series_to_dtos_sets_partner_enrollment_for_authenticated_user():
+    group_id = uuid4()
+    series = _make_series_with_metadata()
+    partner_id = uuid4()
+    user_id = uuid4()
+    mock_db = MagicMock()
+    with patch(
+        "pecha_api.plans.groups.groups_service.get_active_plan_count_map_by_series_ids",
+        return_value={series.id: 2},
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_enrolled_count_map_by_series_ids",
+        return_value={series.id: 5},
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_series_partner_id_map_for_group",
+        return_value={series.id: partner_id},
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_user_series_enrollment_partner_map",
+        return_value={series.id: partner_id},
+    ):
+        dtos = _series_to_dtos(
+            db=mock_db,
+            series_list=[series],
+            group_id=group_id,
+            user_id=user_id,
+        )
+
+    assert dtos[0].series_partner_id == partner_id
+    assert dtos[0].is_enrolled is True
+
+
+def test_series_to_dtos_is_not_enrolled_without_user():
+    group_id = uuid4()
+    series = _make_series_with_metadata()
+    partner_id = uuid4()
+    mock_db = MagicMock()
+    with patch(
+        "pecha_api.plans.groups.groups_service.get_active_plan_count_map_by_series_ids",
+        return_value={series.id: 2},
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_enrolled_count_map_by_series_ids",
+        return_value={series.id: 5},
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_series_partner_id_map_for_group",
+        return_value={series.id: partner_id},
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_user_series_enrollment_partner_map",
+    ) as mock_enrollment_map:
+        dtos = _series_to_dtos(
+            db=mock_db,
+            series_list=[series],
+            group_id=group_id,
+        )
+
+    mock_enrollment_map.assert_not_called()
+    assert dtos[0].series_partner_id == partner_id
+    assert dtos[0].is_enrolled is False
+
+
 def test_series_to_dtos_filters_metadata_by_language():
+    group_id = uuid4()
     series = _make_series_with_metadata()
     mock_db = MagicMock()
     with patch(
         "pecha_api.plans.groups.groups_service.get_active_plan_count_map_by_series_ids",
         return_value={series.id: 2},
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_series_partner_id_map_for_group",
+        return_value={},
     ):
-        all_metadata = _series_to_dtos(db=mock_db, series_list=[series])
-        bo_metadata = _series_to_dtos(db=mock_db, series_list=[series], language="bo")
-        missing_metadata = _series_to_dtos(db=mock_db, series_list=[series], language="zh")
+        all_metadata = _series_to_dtos(db=mock_db, series_list=[series], group_id=group_id)
+        bo_metadata = _series_to_dtos(db=mock_db, series_list=[series], group_id=group_id, language="bo")
+        missing_metadata = _series_to_dtos(db=mock_db, series_list=[series], group_id=group_id, language="zh")
 
     assert len(all_metadata[0].metadata) == 2
     assert bo_metadata[0].metadata.title == "Tibetan Series"
@@ -652,6 +734,9 @@ def test_group_detail_series_metadata_filtered_by_language():
     ), patch(
         "pecha_api.plans.groups.groups_service.get_active_plan_count_map_by_series_ids",
         return_value={series.id: 0},
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_series_partner_id_map_for_group",
+        return_value={},
     ):
         detail_all = _group_to_detail(group, db=mock_db)
         detail_bo = _group_to_detail(group, db=mock_db, language="bo")

--- a/tests/plans/groups/test_groups_views.py
+++ b/tests/plans/groups/test_groups_views.py
@@ -403,7 +403,7 @@ def test_get_public_group_by_id():
         response = client.get(f"/author/groups/{group_id}")
     assert response.status_code == status.HTTP_200_OK
     assert response.json()["slug"] == "bodhichitta-authors"
-    mock_service.assert_called_once_with(group_id=group_id, require_public=True, language=None)
+    mock_service.assert_called_once_with(group_id=group_id, require_public=True, language=None, token=None)
 
 
 def test_get_public_group_by_id_with_language():
@@ -414,7 +414,7 @@ def test_get_public_group_by_id_with_language():
     ) as mock_service:
         response = client.get(f"/author/groups/{group_id}?language=bo")
     assert response.status_code == status.HTTP_200_OK
-    mock_service.assert_called_once_with(group_id=group_id, require_public=True, language="bo")
+    mock_service.assert_called_once_with(group_id=group_id, require_public=True, language="bo", token=None)
 
 
 def test_follow_and_unfollow_group():


### PR DESCRIPTION
- Introduced `get_series_partner_id_map_for_group` and `get_user_series_enrollment_partner_map` functions to retrieve mappings for series partners and user enrollments.
- Updated the `GroupSeriesListItemDTO` to include `series_partner_id` and `is_enrolled` fields.
- Refactored the `_series_to_dtos` function to utilize the new mappings for enhanced series detail retrieval.
- Modified the `get_author_group_detail` endpoint to support user authentication and pass user ID for enrollment checks.
- Added tests for the new mapping functions and updated existing tests to cover new functionality.