### PR TITLE
Add clear_user_series_partner_ids_for_group function and integrate it…

### DIFF
--- a/pecha_api/accumulator/accumulator_service.py
+++ b/pecha_api/accumulator/accumulator_service.py
@@ -3,6 +3,7 @@ from uuid import UUID, uuid4
 import logging
 
 from fastapi import HTTPException
+from sqlalchemy.orm import Session
 from starlette import status
 from ..db.database import SessionLocal
 from ..config import get
@@ -29,7 +30,7 @@ from .accumulator_repository import (
 )
 from ..mantra.mantra_model import Mantra
 from ..mantra.mantra_metadata_model import MantraMetadata
-from ..mantra.mantra_repository import get_mantras_by_ids
+from ..mantra.mantra_repository import get_mantra_by_id, get_mantras_by_ids
 from .accumulator_response_models import (
     AccumulatorsResponse,
     AccumulatorDTO,
@@ -98,6 +99,32 @@ def resolve_mala_image_fields(accumulator: Accumulator) -> tuple[Optional[UUID],
     if mala is None:
         return None, None
     return mala.id, generate_mala_image_presigned_url(mala.url)
+
+
+def resolve_accumulator_bookmark_mala_image_url(
+    db: Session,
+    accumulator: Accumulator,
+) -> Optional[str]:
+    """Presigned mala image URL for bookmark display.
+
+    Preset accumulators prefer the linked mantra's default mala image over
+    the mala image stored on the accumulator row itself.
+    """
+    accumulator_type = (
+        accumulator.type.value
+        if hasattr(accumulator.type, "value")
+        else accumulator.type
+    )
+    if (
+        accumulator_type == AccumulatorType.PRESET.value
+        and accumulator.mantra_id is not None
+    ):
+        mantra = get_mantra_by_id(db, accumulator.mantra_id)
+        if mantra is not None and mantra.mala is not None:
+            return generate_mala_image_presigned_url(mantra.mala.url)
+
+    _, mala_image_url = resolve_mala_image_fields(accumulator)
+    return mala_image_url
 
 
 def convert_accumulator_to_dto(accumulator: Accumulator) -> AccumulatorDTO:

--- a/pecha_api/bookmarks/bookmark_utils.py
+++ b/pecha_api/bookmarks/bookmark_utils.py
@@ -40,7 +40,9 @@ from pecha_api.plans.series.series_service import (
     _to_plan_status,
 )
 from pecha_api.accumulator.accumulator_models import Accumulator
-from pecha_api.accumulator.accumulator_service import resolve_mala_image_fields
+from pecha_api.accumulator.accumulator_service import (
+    resolve_accumulator_bookmark_mala_image_url,
+)
 from pecha_api.timers.timer_repository import get_timer_by_id
 
 DEFAULT_FALLBACK_LANGUAGE = "EN"
@@ -335,7 +337,7 @@ def enrich_accumulator_bookmark(
     if not accumulator:
         return {}
 
-    _, mala_image_url = resolve_mala_image_fields(accumulator)
+    mala_image_url = resolve_accumulator_bookmark_mala_image_url(db, accumulator)
     metadata_entries = list(accumulator.metadata_entries)
     if language:
         metadata_entries = filter_by_language_with_fallback(

--- a/pecha_api/plans/groups/groups_repository.py
+++ b/pecha_api/plans/groups/groups_repository.py
@@ -122,6 +122,38 @@ def get_user_series_enrollment_partner_map(
     return dict(rows)
 
 
+def clear_user_series_partner_ids_for_group(
+    db: Session,
+    user_id: UUID,
+    group_id: UUID,
+) -> int:
+    partner_ids = [
+        row[0]
+        for row in db.execute(
+            select(SeriesPartner.id).where(SeriesPartner.group_id == group_id)
+        ).all()
+    ]
+    if not partner_ids:
+        return 0
+
+    updated_count = (
+        db.query(UserSeriesEnrollment)
+        .filter(
+            UserSeriesEnrollment.user_id == user_id,
+            UserSeriesEnrollment.series_partner_id.in_(partner_ids),
+        )
+        .update(
+            {
+                UserSeriesEnrollment.series_partner_id: None,
+                UserSeriesEnrollment.updated_at: datetime.now(timezone.utc),
+            },
+            synchronize_session=False,
+        )
+    )
+    db.commit()
+    return updated_count
+
+
 def get_series_by_group_id(db: Session, group_id: UUID) -> List[Series]:
     return (
         db.query(Series)

--- a/pecha_api/plans/groups/groups_repository.py
+++ b/pecha_api/plans/groups/groups_repository.py
@@ -122,7 +122,7 @@ def get_user_series_enrollment_partner_map(
     return dict(rows)
 
 
-def clear_user_series_partner_ids_for_group(
+def _clear_user_series_partner_ids_for_group(
     db: Session,
     user_id: UUID,
     group_id: UUID,
@@ -136,7 +136,7 @@ def clear_user_series_partner_ids_for_group(
     if not partner_ids:
         return 0
 
-    updated_count = (
+    return (
         db.query(UserSeriesEnrollment)
         .filter(
             UserSeriesEnrollment.user_id == user_id,
@@ -150,8 +150,35 @@ def clear_user_series_partner_ids_for_group(
             synchronize_session=False,
         )
     )
+
+
+def clear_user_series_partner_ids_for_group(
+    db: Session,
+    user_id: UUID,
+    group_id: UUID,
+) -> int:
+    updated_count = _clear_user_series_partner_ids_for_group(
+        db=db, user_id=user_id, group_id=group_id
+    )
     db.commit()
     return updated_count
+
+
+def leave_group_membership(
+    db: Session,
+    user_id: UUID,
+    group_id: UUID,
+) -> None:
+    db.execute(
+        delete(author_group_joins).where(
+            author_group_joins.c.group_id == group_id,
+            author_group_joins.c.user_id == user_id,
+        )
+    )
+    _clear_user_series_partner_ids_for_group(
+        db=db, user_id=user_id, group_id=group_id
+    )
+    db.commit()
 
 
 def get_series_by_group_id(db: Session, group_id: UUID) -> List[Series]:

--- a/pecha_api/plans/groups/groups_service.py
+++ b/pecha_api/plans/groups/groups_service.py
@@ -48,10 +48,10 @@ from pecha_api.plans.groups.groups_repository import (
     get_plans_by_group_id,
     get_plans_by_ids,
     get_series_by_group_id,
-    clear_user_series_partner_ids_for_group,
     get_series_partner_id_map_for_group,
     get_user_series_enrollment_partner_map,
     has_pending_invite,
+    leave_group_membership,
     list_invites_by_group,
     list_group_joiners_paginated,
     list_pending_invites_by_email,
@@ -59,7 +59,6 @@ from pecha_api.plans.groups.groups_repository import (
     get_tags_by_ids,
     save_invite,
     remove_group_follow,
-    remove_group_join,
     remove_group_member,
     replace_group_metadata,
     replace_group_relation_ids,
@@ -999,10 +998,7 @@ def join_group(token: str, group_id: UUID) -> None:
 def leave_group(token: str, group_id: UUID) -> None:
     user = validate_and_extract_user_details(token=token)
     with SessionLocal() as db:
-        remove_group_join(db=db, group_id=group_id, user_id=user.id)
-        clear_user_series_partner_ids_for_group(
-            db=db, user_id=user.id, group_id=group_id
-        )
+        leave_group_membership(db=db, user_id=user.id, group_id=group_id)
 
 
 def get_joined_group(

--- a/pecha_api/plans/groups/groups_service.py
+++ b/pecha_api/plans/groups/groups_service.py
@@ -48,6 +48,7 @@ from pecha_api.plans.groups.groups_repository import (
     get_plans_by_group_id,
     get_plans_by_ids,
     get_series_by_group_id,
+    clear_user_series_partner_ids_for_group,
     get_series_partner_id_map_for_group,
     get_user_series_enrollment_partner_map,
     has_pending_invite,
@@ -999,6 +1000,9 @@ def leave_group(token: str, group_id: UUID) -> None:
     user = validate_and_extract_user_details(token=token)
     with SessionLocal() as db:
         remove_group_join(db=db, group_id=group_id, user_id=user.id)
+        clear_user_series_partner_ids_for_group(
+            db=db, user_id=user.id, group_id=group_id
+        )
 
 
 def get_joined_group(

--- a/tests/accumulator/test_accumulator_service.py
+++ b/tests/accumulator/test_accumulator_service.py
@@ -18,6 +18,7 @@ from pecha_api.accumulator.accumulator_service import (
     convert_accumulator_to_public_dto,
     build_preset_mantra_dto,
     generate_mala_image_presigned_url,
+    resolve_accumulator_bookmark_mala_image_url,
     _create_accumulator_from_preset,
     is_user_created_accumulator,
     validate_mantra_exists,
@@ -1325,6 +1326,56 @@ class TestHelperFunctions:
     def test_generate_mala_image_presigned_url_handles_errors(self, _mock_get, _mock_presign):
         """S3 failures are swallowed and return None."""
         assert generate_mala_image_presigned_url("mala-images/default.png") is None
+
+    @patch(
+        "pecha_api.accumulator.accumulator_service.generate_mala_image_presigned_url",
+        side_effect=lambda url: f"https://signed/{url}",
+    )
+    @patch("pecha_api.accumulator.accumulator_service.get_mantra_by_id")
+    def test_resolve_accumulator_bookmark_mala_image_url_preset_uses_mantra(
+        self, mock_get_mantra, _mock_presign
+    ):
+        """Preset bookmark images prefer the mantra mala over the accumulator mala."""
+        mantra_id = uuid4()
+        mantra_mala = MagicMock()
+        mantra_mala.url = "mantra-mala.png"
+        accumulator_mala = MagicMock()
+        accumulator_mala.url = "accumulator-mala.png"
+
+        preset = TestDataFactory.create_mock_accumulator(
+            accumulator_type=AccumulatorType.PRESET,
+            mantra_id=mantra_id,
+            mala=accumulator_mala,
+        )
+        mock_get_mantra.return_value = TestDataFactory.create_mock_mantra(
+            mantra_id=mantra_id,
+            mala=mantra_mala,
+        )
+        mock_db = MagicMock()
+
+        result = resolve_accumulator_bookmark_mala_image_url(mock_db, preset)
+
+        assert result == "https://signed/mantra-mala.png"
+        mock_get_mantra.assert_called_once_with(mock_db, mantra_id)
+
+    @patch(
+        "pecha_api.accumulator.accumulator_service.generate_mala_image_presigned_url",
+        side_effect=lambda url: f"https://signed/{url}",
+    )
+    def test_resolve_accumulator_bookmark_mala_image_url_user_uses_accumulator(
+        self, _mock_presign
+    ):
+        """User accumulator bookmark images use the accumulator's chosen mala."""
+        accumulator_mala = MagicMock()
+        accumulator_mala.url = "user-mala.png"
+        accumulator = TestDataFactory.create_mock_accumulator(
+            accumulator_type=AccumulatorType.USER,
+            mala=accumulator_mala,
+        )
+
+        result = resolve_accumulator_bookmark_mala_image_url(MagicMock(), accumulator)
+
+        assert result == "https://signed/user-mala.png"
 
     @patch('pecha_api.accumulator.accumulator_service.commit_accumulator')
     @patch('pecha_api.accumulator.accumulator_service.add_accumulator')

--- a/tests/bookmarks/test_bookmark_utils.py
+++ b/tests/bookmarks/test_bookmark_utils.py
@@ -581,8 +581,8 @@ def test_enrich_accumulator_bookmark_success():
     )
 
     with patch(
-        "pecha_api.bookmarks.bookmark_utils.resolve_mala_image_fields",
-        return_value=(uuid4(), "https://example.com/mala.png"),
+        "pecha_api.bookmarks.bookmark_utils.resolve_accumulator_bookmark_mala_image_url",
+        return_value="https://example.com/mala.png",
     ):
         result = enrich_accumulator_bookmark(
             db=mock_db,
@@ -610,8 +610,8 @@ def test_enrich_accumulator_bookmark_filters_metadata_by_language():
     )
 
     with patch(
-        "pecha_api.bookmarks.bookmark_utils.resolve_mala_image_fields",
-        return_value=(None, None),
+        "pecha_api.bookmarks.bookmark_utils.resolve_accumulator_bookmark_mala_image_url",
+        return_value=None,
     ), patch(
         "pecha_api.bookmarks.bookmark_utils.filter_by_language_with_fallback",
         return_value=[metadata_entry],

--- a/tests/plans/groups/test_groups_repository.py
+++ b/tests/plans/groups/test_groups_repository.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 from sqlalchemy.orm import Session
 
 from pecha_api.plans.groups.groups_repository import (
+    clear_user_series_partner_ids_for_group,
     get_group_id_for_plan,
     get_group_id_for_series,
     get_group_ids_by_plan_ids,
@@ -14,6 +15,7 @@ from pecha_api.plans.groups.groups_repository import (
     get_user_series_enrollment_partner_map,
     update_group,
 )
+from pecha_api.plans.users.plan_users_models import UserSeriesEnrollment
 
 
 def _make_session_mock() -> Session:
@@ -168,3 +170,38 @@ def test_get_groups_paginated_with_exclude_group_ids():
     assert groups == []
     assert total == 0
     query.filter.assert_called_once()
+
+
+def test_clear_user_series_partner_ids_for_group_returns_zero_when_no_partners():
+    db = _make_session_mock()
+    db.execute.return_value.all.return_value = []
+
+    result = clear_user_series_partner_ids_for_group(
+        db=db, user_id=uuid.uuid4(), group_id=uuid.uuid4()
+    )
+
+    assert result == 0
+    db.query.assert_not_called()
+    db.commit.assert_not_called()
+
+
+def test_clear_user_series_partner_ids_for_group_clears_matching_enrollments():
+    db = _make_session_mock()
+    user_id = uuid.uuid4()
+    group_id = uuid.uuid4()
+    partner_id = uuid.uuid4()
+    db.execute.return_value.all.return_value = [(partner_id,)]
+    query = MagicMock()
+    db.query.return_value = query
+    query.filter.return_value = query
+    query.update.return_value = 2
+
+    result = clear_user_series_partner_ids_for_group(
+        db=db, user_id=user_id, group_id=group_id
+    )
+
+    assert result == 2
+    query.update.assert_called_once()
+    update_values = query.update.call_args.args[0]
+    assert update_values[UserSeriesEnrollment.series_partner_id] is None
+    db.commit.assert_called_once()

--- a/tests/plans/groups/test_groups_repository.py
+++ b/tests/plans/groups/test_groups_repository.py
@@ -1,6 +1,7 @@
 import uuid
 from unittest.mock import MagicMock
 
+import pytest
 from sqlalchemy.orm import Session
 
 from pecha_api.plans.groups.groups_repository import (
@@ -13,6 +14,7 @@ from pecha_api.plans.groups.groups_repository import (
     get_series_by_group_id,
     get_series_partner_id_map_for_group,
     get_user_series_enrollment_partner_map,
+    leave_group_membership,
     update_group,
 )
 from pecha_api.plans.users.plan_users_models import UserSeriesEnrollment
@@ -182,7 +184,7 @@ def test_clear_user_series_partner_ids_for_group_returns_zero_when_no_partners()
 
     assert result == 0
     db.query.assert_not_called()
-    db.commit.assert_not_called()
+    db.commit.assert_called_once()
 
 
 def test_clear_user_series_partner_ids_for_group_clears_matching_enrollments():
@@ -205,3 +207,51 @@ def test_clear_user_series_partner_ids_for_group_clears_matching_enrollments():
     update_values = query.update.call_args.args[0]
     assert update_values[UserSeriesEnrollment.series_partner_id] is None
     db.commit.assert_called_once()
+
+
+def test_leave_group_membership_commits_once_after_join_removal_and_partner_cleanup():
+    db = _make_session_mock()
+    user_id = uuid.uuid4()
+    group_id = uuid.uuid4()
+    partner_id = uuid.uuid4()
+    db.execute.return_value.all.return_value = [(partner_id,)]
+    query = MagicMock()
+    db.query.return_value = query
+    query.filter.return_value = query
+    query.update.return_value = 1
+
+    leave_group_membership(db=db, user_id=user_id, group_id=group_id)
+
+    assert db.execute.call_count == 2
+    query.update.assert_called_once()
+    db.commit.assert_called_once()
+
+
+def test_leave_group_membership_commits_once_when_group_has_no_partner_series():
+    db = _make_session_mock()
+    user_id = uuid.uuid4()
+    group_id = uuid.uuid4()
+    db.execute.return_value.all.return_value = []
+
+    leave_group_membership(db=db, user_id=user_id, group_id=group_id)
+
+    assert db.execute.call_count == 2
+    db.query.assert_not_called()
+    db.commit.assert_called_once()
+
+
+def test_leave_group_membership_does_not_commit_when_partner_cleanup_fails():
+    db = _make_session_mock()
+    user_id = uuid.uuid4()
+    group_id = uuid.uuid4()
+    partner_id = uuid.uuid4()
+    db.execute.return_value.all.return_value = [(partner_id,)]
+    query = MagicMock()
+    db.query.return_value = query
+    query.filter.return_value = query
+    query.update.side_effect = RuntimeError("db error")
+
+    with pytest.raises(RuntimeError, match="db error"):
+        leave_group_membership(db=db, user_id=user_id, group_id=group_id)
+
+    db.commit.assert_not_called()

--- a/tests/plans/groups/test_groups_service.py
+++ b/tests/plans/groups/test_groups_service.py
@@ -1154,15 +1154,23 @@ def test_join_group_success():
 def test_leave_group_calls_repository():
     user = MagicMock()
     user.id = uuid4()
+    group_id = uuid4()
     with patch("pecha_api.plans.groups.groups_service.SessionLocal") as mock_session, patch(
         "pecha_api.plans.groups.groups_service.validate_and_extract_user_details",
         return_value=user,
     ), patch(
         "pecha_api.plans.groups.groups_service.remove_group_join",
-    ) as mock_leave:
-        _session_local_context(mock_session)
-        leave_group(token="t", group_id=uuid4())
-    mock_leave.assert_called_once()
+    ) as mock_leave, patch(
+        "pecha_api.plans.groups.groups_service.clear_user_series_partner_ids_for_group",
+    ) as mock_clear_partner:
+        mock_db = _session_local_context(mock_session)
+        leave_group(token="t", group_id=group_id)
+    mock_leave.assert_called_once_with(db=mock_db, group_id=group_id, user_id=user.id)
+    mock_clear_partner.assert_called_once_with(
+        db=mock_db,
+        user_id=user.id,
+        group_id=group_id,
+    )
 
 
 def test_list_joined_groups():

--- a/tests/plans/groups/test_groups_service.py
+++ b/tests/plans/groups/test_groups_service.py
@@ -1159,14 +1159,11 @@ def test_leave_group_calls_repository():
         "pecha_api.plans.groups.groups_service.validate_and_extract_user_details",
         return_value=user,
     ), patch(
-        "pecha_api.plans.groups.groups_service.remove_group_join",
-    ) as mock_leave, patch(
-        "pecha_api.plans.groups.groups_service.clear_user_series_partner_ids_for_group",
-    ) as mock_clear_partner:
+        "pecha_api.plans.groups.groups_service.leave_group_membership",
+    ) as mock_leave_membership:
         mock_db = _session_local_context(mock_session)
         leave_group(token="t", group_id=group_id)
-    mock_leave.assert_called_once_with(db=mock_db, group_id=group_id, user_id=user.id)
-    mock_clear_partner.assert_called_once_with(
+    mock_leave_membership.assert_called_once_with(
         db=mock_db,
         user_id=user.id,
         group_id=group_id,


### PR DESCRIPTION
… into leave_group

- Introduced `clear_user_series_partner_ids_for_group` to clear series partner IDs for a user in a specified group.
- Updated the `leave_group` function to call the new clearing function upon a user leaving a group.
- Added unit tests for the new function to ensure correct behavior when no partners exist and when partners are cleared.
- Enhanced existing tests to verify integration with the leave group functionality.