### PR TITLE
Add plan day cache invalidation and retrieval enhancements

### DIFF
--- a/migrations/versions/c7d8e9f0a1b2_backfill_series_creator_partners.py
+++ b/migrations/versions/c7d8e9f0a1b2_backfill_series_creator_partners.py
@@ -1,0 +1,44 @@
+"""backfill series creator group into series_partner
+
+Revision ID: c7d8e9f0a1b2
+Revises: a6b7c8d9e0f1
+Create Date: 2026-06-29 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+from migrations.idempotency import table_exists
+
+revision: str = "c7d8e9f0a1b2"
+down_revision: Union[str, None] = "a6b7c8d9e0f1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    if not table_exists("series_partner") or not table_exists("series"):
+        return
+
+    op.execute(
+        sa.text(
+            """
+            INSERT INTO series_partner (id, series_id, group_id, created_at, updated_at)
+            SELECT gen_random_uuid(), s.id, s.group_id, NOW(), NOW()
+            FROM series s
+            WHERE s.deleted_at IS NULL
+              AND NOT EXISTS (
+                SELECT 1
+                FROM series_partner sp
+                WHERE sp.series_id = s.id
+                  AND sp.group_id = s.group_id
+              )
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    pass

--- a/pecha_api/app.py
+++ b/pecha_api/app.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from starlette import status
 from fastapi.middleware.cors import CORSMiddleware
-
+from scalar_fastapi import get_scalar_api_reference
 from pecha_api.auth.auth_service import retrieve_client_info
 from pecha_api.middleware.request_observability import RequestObservabilityMiddleware
 
@@ -74,7 +74,9 @@ api = FastAPI(
     title="Pecha API",
     description="This is the API documentation for Pecha application",
     root_path="/api/v1",
-    redoc_url="/docs",
+    docs_url=None,  
+    openapi_url="/openapi.json",
+    redoc_url=None,  
     lifespan=lifespan
 )
 api.include_router(auth_views.auth_router)
@@ -157,6 +159,13 @@ api.add_middleware(
     allow_headers=["*"],
 )
 api.add_middleware(RequestObservabilityMiddleware)
+
+@api.get("/docs", include_in_schema=False)
+async def scalar_docs():
+    return get_scalar_api_reference(
+        openapi_url=api.openapi_url,
+        title="WeBuddhist API Documentation",
+    )
 
 @api.get("/props", status_code=status.HTTP_200_OK)
 async def get_props():

--- a/pecha_api/cache/cache_enums.py
+++ b/pecha_api/cache/cache_enums.py
@@ -32,4 +32,7 @@ class CacheType(Enum):
     # Collection-specific cache types
     COLLECTIONS = "collections"
     COLLECTION_DETAIL = "collection_detail"
+
+    # Plan-specific cache types
+    PLAN_DAY_DETAIL = "plan_day_detail"
     

--- a/pecha_api/plans/audio/plan_subtask_audio_service.py
+++ b/pecha_api/plans/audio/plan_subtask_audio_service.py
@@ -26,6 +26,7 @@ from pecha_api.plans.shared.permissions import require_can_edit_content
 from pecha_api.plans.tasks.plan_tasks_repository import get_task_by_id
 from pecha_api.plans.tasks.sub_tasks.plan_sub_tasks_models import PlanSubTask
 from pecha_api.plans.tasks.sub_tasks.plan_sub_tasks_repository import get_sub_task_by_subtask_id
+from pecha_api.plans.public.plans_cache_service import schedule_invalidate_plan_day_cache_for_task
 from pecha_api.uploads.S3_utils import delete_file, generate_presigned_access_url, upload_file
 
 
@@ -102,6 +103,7 @@ def upload_plan_subtask_audio(
         sub_task_id_str = str(sub_task_id)
         audio_key = s3_key
         stored_duration_ms = duration_ms
+        schedule_invalidate_plan_day_cache_for_task(db=db, task_id=subtask.task_id)
 
     audio_url = generate_presigned_access_url(
         bucket_name=get("AWS_BUCKET_NAME"),
@@ -127,3 +129,4 @@ def delete_plan_subtask_audio(token: str, sub_task_id: UUID) -> None:
         subtask.duration = None
         subtask.updated_by = current_author.email
         db.commit()
+        schedule_invalidate_plan_day_cache_for_task(db=db, task_id=subtask.task_id)

--- a/pecha_api/plans/cms/cms_plans_service.py
+++ b/pecha_api/plans/cms/cms_plans_service.py
@@ -19,6 +19,10 @@ from pecha_api.plans.tags.tag_helpers import tags_to_summary_dtos
 from pecha_api.plans.tags.tag_repository import set_plan_tags
 from pecha_api.plans.tags.tag_service import validate_tag_ids
 from pecha_api.plans.items.plan_items_repository import save_plan_items, get_plan_items_by_plan_id, get_plan_day_with_tasks_and_subtasks, get_plan_day_by_id_any_plan
+from pecha_api.plans.public.plans_cache_service import (
+    schedule_invalidate_plan_day_cache_for_day,
+    schedule_invalidate_plan_day_cache_for_task,
+)
 from pecha_api.plans.users.plan_users_progress_repository import get_plan_progress
 from pecha_api.plans.authors.plan_authors_model import Author
 from pecha_api.plans.authors.plan_authors_service import validate_cms_author_details
@@ -284,6 +288,7 @@ async def generate_plan_audio_service(
             plan_id=plan_item.plan_id,
             plan_item_id=plan_item.id,
         )
+        schedule_invalidate_plan_day_cache_for_day(db=db, day_id=plan_item.id)
 
     audio_url = generate_presigned_access_url(
         bucket_name=get("AWS_BUCKET_NAME"),
@@ -348,6 +353,7 @@ async def _generate_subtask_audio(
             end_ms=duration_ms,
             created_by="system",
         )
+        schedule_invalidate_plan_day_cache_for_task(db=db, task_id=subtask.task_id)
 
     return {
         "audio_url": audio_url,

--- a/pecha_api/plans/groups/groups_repository.py
+++ b/pecha_api/plans/groups/groups_repository.py
@@ -76,7 +76,11 @@ def get_author_group_ids(db: Session, author_id: UUID) -> List[UUID]:
 def get_plans_by_group_id(db: Session, group_id: UUID) -> List[Plan]:
     return (
         db.query(Plan)
-        .filter(Plan.group_id == group_id, Plan.deleted_at.is_(None))
+        .filter(
+            Plan.group_id == group_id,
+            Plan.deleted_at.is_(None),
+            Plan.series_id.is_(None),
+        )
         .all()
     )
 

--- a/pecha_api/plans/groups/groups_response_models.py
+++ b/pecha_api/plans/groups/groups_response_models.py
@@ -16,7 +16,7 @@ from pecha_api.plans.series.series_response_models import SeriesListItemDTO
 
 
 class GroupSeriesListItemDTO(SeriesListItemDTO):
-    series_partner_id: Optional[UUID] = None
+    series_partner_id: Optional[UUID] = None  # Partner group ID when series is partnered via this group
     is_enrolled: bool = False
 from pecha_api.plans.tags.tag_response_models import TagSummaryDTO
 

--- a/pecha_api/plans/groups/groups_response_models.py
+++ b/pecha_api/plans/groups/groups_response_models.py
@@ -16,7 +16,6 @@ from pecha_api.plans.series.series_response_models import SeriesListItemDTO
 
 
 class GroupSeriesListItemDTO(SeriesListItemDTO):
-    series_partner_id: Optional[UUID] = None  # Partner group ID when series is partnered via this group
     is_enrolled: bool = False
 from pecha_api.plans.tags.tag_response_models import TagSummaryDTO
 

--- a/pecha_api/plans/groups/groups_service.py
+++ b/pecha_api/plans/groups/groups_service.py
@@ -413,7 +413,11 @@ def _series_to_dtos(
                 language=language,
                 fallback=True,
             ).model_dump(),
-            series_partner_id=partner_id_map.get(series.id),
+            series_partner_id=(
+                group_id
+                if series.id in partner_id_map and series.group_id != group_id
+                else None
+            ),
             is_enrolled=_is_series_enrolled_for_group_context(
                 enrollment_partner_id=enrollment_partner_map.get(series.id),
                 expected_partner_id=partner_id_map.get(series.id),

--- a/pecha_api/plans/groups/groups_service.py
+++ b/pecha_api/plans/groups/groups_service.py
@@ -413,11 +413,6 @@ def _series_to_dtos(
                 language=language,
                 fallback=True,
             ).model_dump(),
-            series_partner_id=(
-                group_id
-                if series.id in partner_id_map and series.group_id != group_id
-                else None
-            ),
             is_enrolled=_is_series_enrolled_for_group_context(
                 enrollment_partner_id=enrollment_partner_map.get(series.id),
                 expected_partner_id=partner_id_map.get(series.id),

--- a/pecha_api/plans/groups/groups_views.py
+++ b/pecha_api/plans/groups/groups_views.py
@@ -1,7 +1,7 @@
 from typing import Annotated, Optional
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, Query, Response
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from starlette import status
 
@@ -324,11 +324,13 @@ def delete_group_member_by_id(
 @public_groups_router.get("/{group_id}", status_code=status.HTTP_200_OK, response_model=PublicAuthorGroupDetailDTO)
 def get_public_group(
     group_id: UUID,
+    response: Response,
     authentication_credential: Annotated[
         Optional[HTTPAuthorizationCredentials], Depends(optional_oauth2_scheme)
     ] = None,
     language: Annotated[Optional[str], Query(description=_LANGUAGE_QUERY_DESCRIPTION)] = None,
 ):
+    response.headers["Cache-Control"] = "no-store"
     return get_author_group_detail(
         group_id=group_id,
         require_public=True,

--- a/pecha_api/plans/public/plan_response_models.py
+++ b/pecha_api/plans/public/plan_response_models.py
@@ -88,6 +88,12 @@ class PlanDayDTO(BaseModel):
     videos: List[DayVideoSummaryDTO] = []
 
 
+class PlanDayCacheCleanupResponse(BaseModel):
+    plan_id: UUID
+    day_number: Optional[int] = None
+    keys_deleted: int
+
+
 class PlanWithDays(BaseModel):
     id: UUID
     title: str

--- a/pecha_api/plans/public/plan_response_models.py
+++ b/pecha_api/plans/public/plan_response_models.py
@@ -83,6 +83,8 @@ class PlanDayDTO(BaseModel):
     tasks: List[TaskDTO]
     audio_url: Optional[str] = None
     audio_duration_ms: Optional[int] = None
+    thumbnail_url: Optional[str] = None
+    shareable_image_url: Optional[str] = None
     videos: List[DayVideoSummaryDTO] = []
 
 

--- a/pecha_api/plans/public/plan_service.py
+++ b/pecha_api/plans/public/plan_service.py
@@ -41,6 +41,10 @@ from pecha_api.plans.shared.metadata_utils import (
     format_metadata_response,
     filter_by_language_with_fallback,
 )
+from pecha_api.plans.public.plans_cache_service import (
+    get_plan_day_detail_cache,
+    set_plan_day_detail_cache,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -412,12 +416,19 @@ def _build_plan_day_dto(plan_item) -> PlanDayDTO:
         ],
     )
 
-def get_plan_day_details(plan_id: UUID, day_number: int) -> PlanDayDTO:
+async def get_plan_day_details(plan_id: UUID, day_number: int) -> PlanDayDTO:
     """Get specific day's content with tasks"""
+
+    cached = await get_plan_day_detail_cache(plan_id=plan_id, day_number=day_number)
+    if cached is not None:
+        return cached
 
     with SessionLocal() as db:
         plan_item = get_plan_day_with_tasks_and_subtasks(db=db, plan_id=plan_id, day_number=day_number)
-        return _build_plan_day_dto(plan_item)
+        response = _build_plan_day_dto(plan_item)
+
+    await set_plan_day_detail_cache(plan_id=plan_id, day_number=day_number, data=response)
+    return response
 
 
 def _filter_series_metadata_by_language(metadata_entries, language: Optional[str]):

--- a/pecha_api/plans/public/plan_service.py
+++ b/pecha_api/plans/public/plan_service.py
@@ -357,6 +357,7 @@ async def get_plan_days(plan_id: UUID) -> PlanDaysResponse:
 
 from pecha_api.plans.audio.dto_helpers import (
     build_plan_day_audio_fields,
+    build_plan_day_shareable_image_fields,
     build_subtask_timestamp_fields,
     generate_subtask_content_url,
 )
@@ -398,12 +399,17 @@ def build_task_dto(task) -> TaskDTO:
 
 def _build_plan_day_dto(plan_item) -> PlanDayDTO:
     audio_url, audio_duration_ms, _, _ = build_plan_day_audio_fields(plan_item)
+    thumbnail_url, _, shareable_image_url, _ = build_plan_day_shareable_image_fields(
+        getattr(plan_item, "shareable_images", None)
+    )
     return PlanDayDTO(
         id=plan_item.id,
         day_number=plan_item.day_number,
         tasks=[build_task_dto(task) for task in sorted(plan_item.tasks, key=lambda t: t.display_order)],
         audio_url=audio_url,
         audio_duration_ms=audio_duration_ms,
+        thumbnail_url=thumbnail_url,
+        shareable_image_url=shareable_image_url,
         videos=[
             DayVideoSummaryDTO(
                 id=video.id,

--- a/pecha_api/plans/public/plan_views.py
+++ b/pecha_api/plans/public/plan_views.py
@@ -106,4 +106,4 @@ async def get_plan_days_list(
 @public_plans_router.get("/{plan_id}/days/{day_number}", status_code=status.HTTP_200_OK, response_model=PlanDayDTO)
 async def get_plan_day_content(plan_id: UUID, day_number: int):
     """Get specific day's content with tasks"""
-    return get_plan_day_details(plan_id=plan_id, day_number=day_number)
+    return await get_plan_day_details(plan_id=plan_id, day_number=day_number)

--- a/pecha_api/plans/public/plan_views.py
+++ b/pecha_api/plans/public/plan_views.py
@@ -1,12 +1,26 @@
-from fastapi import APIRouter, Query, Depends, Request
+from fastapi import APIRouter, HTTPException, Query, Depends, Request
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from typing import Annotated, Optional
 from uuid import UUID
 from datetime import date as DateType
 from starlette import status
 
+from pecha_api import config
+from pecha_api.db.database import SessionLocal
 from pecha_api.plans.language_constants import language_query_description
-from pecha_api.plans.public.plan_response_models import PublicPlansResponse, PublicPlanDTO,PlanDaysResponse , PlanDayDTO, TagsResponse, DailyPlanResponse
+from pecha_api.plans.public.plan_response_models import (
+    PublicPlansResponse,
+    PublicPlanDTO,
+    PlanDaysResponse,
+    PlanDayDTO,
+    PlanDayCacheCleanupResponse,
+    TagsResponse,
+    DailyPlanResponse,
+)
+from pecha_api.plans.public.plans_cache_service import (
+    invalidate_all_plan_day_detail_caches_for_plan,
+    invalidate_plan_day_detail_cache,
+)
 from pecha_api.plans.public.plan_service import (
     get_published_plans, 
     get_published_plan, 
@@ -19,6 +33,14 @@ from pecha_api.plans.public.plan_service import (
 from pecha_api.users.users_service import validate_and_extract_user_details
 
 optional_oauth2_scheme = HTTPBearer(auto_error=False)
+
+
+def _require_debug_deployment_mode() -> None:
+    if config.get("DEPLOYMENT_MODE").upper() != "DEBUG":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Cache cleanup is only available when DEPLOYMENT_MODE is DEBUG.",
+        )
 
 
 # Create router for public plan endpoints
@@ -84,6 +106,35 @@ async def get_plan_daily(
     ] = None,
 ):
     return await get_plan_daily_content(plan_id=plan_id, requested_date=date, language=language)
+
+
+@public_plans_router.delete(
+    "/{plan_id}/cache/plan-days",
+    status_code=status.HTTP_200_OK,
+    response_model=PlanDayCacheCleanupResponse,
+)
+async def cleanup_plan_days_cache(plan_id: UUID):
+    """Invalidate cached public plan day responses for every day in a plan (DEBUG only)."""
+    _require_debug_deployment_mode()
+    with SessionLocal() as db:
+        keys_deleted = await invalidate_all_plan_day_detail_caches_for_plan(db=db, plan_id=plan_id)
+    return PlanDayCacheCleanupResponse(plan_id=plan_id, keys_deleted=keys_deleted)
+
+
+@public_plans_router.delete(
+    "/{plan_id}/days/{day_number}/cache",
+    status_code=status.HTTP_200_OK,
+    response_model=PlanDayCacheCleanupResponse,
+)
+async def cleanup_plan_day_cache(plan_id: UUID, day_number: int):
+    """Invalidate the cached public plan day response for one day (DEBUG only)."""
+    _require_debug_deployment_mode()
+    keys_deleted = await invalidate_plan_day_detail_cache(plan_id=plan_id, day_number=day_number)
+    return PlanDayCacheCleanupResponse(
+        plan_id=plan_id,
+        day_number=day_number,
+        keys_deleted=keys_deleted,
+    )
 
 
 @public_plans_router.get("/{plan_id}/days", status_code=status.HTTP_200_OK, response_model=PlanDaysResponse)

--- a/pecha_api/plans/public/plans_cache_service.py
+++ b/pecha_api/plans/public/plans_cache_service.py
@@ -1,0 +1,102 @@
+import asyncio
+from typing import Optional
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from pecha_api import config
+from pecha_api.cache.cache_enums import CacheType
+from pecha_api.cache.cache_repository import delete_cache, get_cache_data, set_cache
+from pecha_api.plans.items.plan_items_repository import get_plan_item_by_id
+from pecha_api.plans.public.plan_response_models import PlanDayDTO
+from pecha_api.plans.tasks.plan_tasks_repository import get_task_by_id
+from pecha_api.utils import Utils
+
+
+def _plan_timeout() -> int:
+    return config.get_int("CACHE_PLAN_TIMEOUT")
+
+
+def _plan_day_detail_cache_keys(plan_id: UUID, day_number: int) -> list[str]:
+    """Build current and legacy Redis hash keys for a plan day."""
+    keys = []
+    for cache_type in (CacheType.PLAN_DAY_DETAIL, CacheType.PLAN_DAY_DETAIL.value):
+        payload = [str(plan_id), day_number, cache_type]
+        keys.append(Utils.generate_hash_key(payload=payload))
+    return list(dict.fromkeys(keys))
+
+
+async def get_plan_day_detail_cache(plan_id: UUID, day_number: int) -> Optional[PlanDayDTO]:
+    for hashed_key in _plan_day_detail_cache_keys(plan_id=plan_id, day_number=day_number):
+        data = await get_cache_data(hash_key=hashed_key)
+        if data and isinstance(data, dict):
+            return PlanDayDTO(**data)
+    return None
+
+
+async def set_plan_day_detail_cache(plan_id: UUID, day_number: int, data: PlanDayDTO) -> None:
+    hashed_key = _plan_day_detail_cache_keys(plan_id=plan_id, day_number=day_number)[0]
+    await set_cache(hash_key=hashed_key, value=data, cache_time_out=_plan_timeout())
+
+
+async def invalidate_plan_day_detail_cache(plan_id: UUID, day_number: int) -> None:
+    for hashed_key in _plan_day_detail_cache_keys(plan_id=plan_id, day_number=day_number):
+        await delete_cache(hash_key=hashed_key)
+
+
+def _resolve_plan_day_for_task(db: Session, task_id: UUID) -> Optional[tuple[UUID, int]]:
+    task = get_task_by_id(db=db, task_id=task_id)
+    if not task:
+        return None
+    plan_item = get_plan_item_by_id(db=db, day_id=task.plan_item_id)
+    if not plan_item:
+        return None
+    return plan_item.plan_id, plan_item.day_number
+
+
+def _resolve_plan_day_for_day(db: Session, day_id: UUID) -> Optional[tuple[UUID, int]]:
+    plan_item = get_plan_item_by_id(db=db, day_id=day_id)
+    if not plan_item:
+        return None
+    return plan_item.plan_id, plan_item.day_number
+
+
+async def invalidate_plan_day_cache_for_task(db: Session, task_id: UUID) -> None:
+    resolved = _resolve_plan_day_for_task(db=db, task_id=task_id)
+    if not resolved:
+        return
+    plan_id, day_number = resolved
+    await invalidate_plan_day_detail_cache(plan_id=plan_id, day_number=day_number)
+
+
+async def invalidate_plan_day_cache_for_day(db: Session, day_id: UUID) -> None:
+    resolved = _resolve_plan_day_for_day(db=db, day_id=day_id)
+    if not resolved:
+        return
+    plan_id, day_number = resolved
+    await invalidate_plan_day_detail_cache(plan_id=plan_id, day_number=day_number)
+
+
+def schedule_invalidate_plan_day_cache(plan_id: UUID, day_number: int) -> None:
+    """Invalidate plan day cache from sync callers without blocking."""
+    try:
+        loop = asyncio.get_running_loop()
+        loop.create_task(invalidate_plan_day_detail_cache(plan_id=plan_id, day_number=day_number))
+    except RuntimeError:
+        asyncio.run(invalidate_plan_day_detail_cache(plan_id=plan_id, day_number=day_number))
+
+
+def schedule_invalidate_plan_day_cache_for_task(db: Session, task_id: UUID) -> None:
+    resolved = _resolve_plan_day_for_task(db=db, task_id=task_id)
+    if not resolved:
+        return
+    plan_id, day_number = resolved
+    schedule_invalidate_plan_day_cache(plan_id=plan_id, day_number=day_number)
+
+
+def schedule_invalidate_plan_day_cache_for_day(db: Session, day_id: UUID) -> None:
+    resolved = _resolve_plan_day_for_day(db=db, day_id=day_id)
+    if not resolved:
+        return
+    plan_id, day_number = resolved
+    schedule_invalidate_plan_day_cache(plan_id=plan_id, day_number=day_number)

--- a/pecha_api/plans/public/plans_cache_service.py
+++ b/pecha_api/plans/public/plans_cache_service.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session
 from pecha_api import config
 from pecha_api.cache.cache_enums import CacheType
 from pecha_api.cache.cache_repository import delete_cache, get_cache_data, set_cache
-from pecha_api.plans.items.plan_items_repository import get_plan_item_by_id
+from pecha_api.plans.items.plan_items_repository import get_days_by_plan_id, get_plan_item_by_id
 from pecha_api.plans.public.plan_response_models import PlanDayDTO
 from pecha_api.plans.tasks.plan_tasks_repository import get_task_by_id
 from pecha_api.utils import Utils
@@ -39,9 +39,22 @@ async def set_plan_day_detail_cache(plan_id: UUID, day_number: int, data: PlanDa
     await set_cache(hash_key=hashed_key, value=data, cache_time_out=_plan_timeout())
 
 
-async def invalidate_plan_day_detail_cache(plan_id: UUID, day_number: int) -> None:
-    for hashed_key in _plan_day_detail_cache_keys(plan_id=plan_id, day_number=day_number):
+async def invalidate_plan_day_detail_cache(plan_id: UUID, day_number: int) -> int:
+    keys = _plan_day_detail_cache_keys(plan_id=plan_id, day_number=day_number)
+    for hashed_key in keys:
         await delete_cache(hash_key=hashed_key)
+    return len(keys)
+
+
+async def invalidate_all_plan_day_detail_caches_for_plan(db: Session, plan_id: UUID) -> int:
+    days = get_days_by_plan_id(db=db, plan_id=plan_id)
+    keys_deleted = 0
+    for day in days:
+        keys_deleted += await invalidate_plan_day_detail_cache(
+            plan_id=plan_id,
+            day_number=day.day_number,
+        )
+    return keys_deleted
 
 
 def _resolve_plan_day_for_task(db: Session, task_id: UUID) -> Optional[tuple[UUID, int]]:

--- a/pecha_api/plans/series/series_repository.py
+++ b/pecha_api/plans/series/series_repository.py
@@ -10,6 +10,7 @@ from pecha_api.plans.series.series_model import Series
 from pecha_api.plans.series.series_metadata_model import SeriesMetadata
 from pecha_api.plans.plans_models import Plan
 from pecha_api.plans.items.plan_items_models import PlanItem
+from pecha_api.plans.users.plan_user_series_repository import ensure_series_partner
 from pecha_api.plans.users.plan_users_models import SeriesPartner, UserSeriesEnrollment
 
 _REFERENCE_START_DATE_UNSET = object()
@@ -199,6 +200,7 @@ def save_series_with_plans(
 ) -> Series:
     db.add(series)
     db.flush()
+    ensure_series_partner(db, series.id, series.group_id)
     _persist_metadata_entries(db, series.id, metadata_entries)
     if plans_to_attach:
         for plan_id, display_order in plans_to_attach:
@@ -442,6 +444,7 @@ def clone_series_with_plans(
     )
     db.add(new_series)
     db.flush()
+    ensure_series_partner(db, new_series.id, target_group_id)
 
     for entry in parent_series.metadata_entries or []:
         db.add(

--- a/pecha_api/plans/shareable_images/day_shareable_image_service.py
+++ b/pecha_api/plans/shareable_images/day_shareable_image_service.py
@@ -27,6 +27,7 @@ from pecha_api.plans.shareable_images.day_shareable_image_repository import (
 from pecha_api.plans.shareable_images.day_shareable_image_response_models import (
     PlanDayShareableImageUploadResponse,
 )
+from pecha_api.plans.public.plans_cache_service import schedule_invalidate_plan_day_cache_for_day
 from pecha_api.plans.shared.permissions import require_can_edit_content
 from pecha_api.uploads.S3_utils import delete_file, generate_presigned_access_url, upload_bytes
 
@@ -119,6 +120,8 @@ def upload_plan_day_shareable_image(
         else:
             image_key = image_row.shareable_image_key
 
+        schedule_invalidate_plan_day_cache_for_day(db=db, day_id=day_id)
+
     image_url = generate_presigned_access_url(
         bucket_name=get("AWS_BUCKET_NAME"),
         s3_key=image_key,
@@ -162,3 +165,4 @@ def delete_plan_day_shareable_image(
             shareable_image_key=image_type == DayShareableImageType.SHAREABLE_IMAGE,
             updated_by=current_author.email,
         )
+        schedule_invalidate_plan_day_cache_for_day(db=db, day_id=day_id)

--- a/pecha_api/plans/tasks/plan_tasks_services.py
+++ b/pecha_api/plans/tasks/plan_tasks_services.py
@@ -19,6 +19,10 @@ from pecha_api.plans.auth.plan_auth_models import ResponseError
 from pecha_api.uploads.S3_utils import generate_presigned_access_url
 from pecha_api.config import get
 from pecha_api.plans.plans_enums import ContentType
+from pecha_api.plans.public.plans_cache_service import (
+    schedule_invalidate_plan_day_cache_for_day,
+    schedule_invalidate_plan_day_cache_for_task,
+)
 
 def _get_max_display_order(plan_item_id: UUID) -> int:
     with SessionLocal() as db:
@@ -51,6 +55,7 @@ async def create_new_task(token: str, create_task_request: CreateTaskRequest, pl
 
     saved_task = save_task(db=db,new_task=new_task)
 
+    schedule_invalidate_plan_day_cache_for_day(db=db, day_id=plan_item.id)
     return TaskDTO(
         id=saved_task.id,
         title=saved_task.title,
@@ -68,6 +73,7 @@ async def delete_task_by_id(task_id: UUID, token: str):
         tasks = get_tasks_by_plan_item_id(db=db, plan_item_id=task.plan_item_id)
         if tasks:
             _reorder_sequentially(db=db, tasks=tasks)
+        schedule_invalidate_plan_day_cache_for_task(db=db, task_id=task_id)
 
 async def change_task_day_service(token: str, task_id: UUID, update_task_request: UpdateTaskDayRequest) -> UpdatedTaskDayResponse:
     current_author = validate_cms_author_details(token=token)
@@ -81,6 +87,7 @@ async def change_task_day_service(token: str, task_id: UUID, update_task_request
             raise HTTPException(status_code=404, detail=ResponseError(error=BAD_REQUEST, message=PLAN_DAY_NOT_FOUND).model_dump())
         
         task = _get_author_task(db=db, task_id=task_id, current_author=current_author)
+        source_day_id = task.plan_item_id
         task.plan_item_id = update_task_request.target_day_id
         task.display_order = display_order
 
@@ -88,6 +95,9 @@ async def change_task_day_service(token: str, task_id: UUID, update_task_request
             db=db, 
             updated_task=task
         )
+
+        schedule_invalidate_plan_day_cache_for_day(db=db, day_id=source_day_id)
+        schedule_invalidate_plan_day_cache_for_day(db=db, day_id=task.plan_item_id)
 
         return UpdatedTaskDayResponse(
             task_id=task.id, 
@@ -110,6 +120,7 @@ async def update_task_title_service(token: str, task_id: UUID, update_request: U
 
         updated_task = update_task_title(db=db, updated_task=task)
 
+        schedule_invalidate_plan_day_cache_for_task(db=db, task_id=task_id)
         return UpdateTaskTitleResponse(
             task_id=updated_task.id,
             title=updated_task.title,
@@ -122,6 +133,7 @@ async def change_task_order_service(token: str, day_id: UUID, update_task_order_
     with SessionLocal() as db:
         _check_duplicate_task_order(update_task_orders=update_task_order_request.tasks)
         update_task_order(db=db, day_id=day_id, update_task_orders=update_task_order_request.tasks)
+        schedule_invalidate_plan_day_cache_for_day(db=db, day_id=day_id)
 
 
 async def get_task_subtasks_service(task_id: UUID, token: str) -> GetTaskResponse:

--- a/pecha_api/plans/tasks/sub_tasks/plan_sub_tasks_services.py
+++ b/pecha_api/plans/tasks/sub_tasks/plan_sub_tasks_services.py
@@ -34,6 +34,7 @@ from pecha_api.plans.tasks.sub_tasks.plan_sub_tasks_response_model import (
 from pecha_api.error_contants import ErrorConstants
 from pecha_api.plans.response_message import SUBTASK_ORDER_FAILED
 from pecha_api.plans.audio.timestamp_service import apply_sub_task_timestamp
+from pecha_api.plans.public.plans_cache_service import invalidate_plan_day_cache_for_task
 
 async def create_new_sub_tasks(token: str, create_task_request: SubTaskRequest) -> SubTaskResponse:
     current_author = validate_and_extract_author_details(token=token)
@@ -85,6 +86,7 @@ async def create_new_sub_tasks(token: str, create_task_request: SubTaskRequest) 
                     end_ms=end_ms,
                 )
             )
+        await invalidate_plan_day_cache_for_task(db=db, task_id=create_task_request.task_id)
         return SubTaskResponse(
             sub_tasks=created_sub_tasks,
         )
@@ -151,6 +153,8 @@ async def update_sub_task_by_task_id(token: str, update_sub_task_request: Update
                     author_email=current_author.email,
                 )
 
+        await invalidate_plan_day_cache_for_task(db=db, task_id=update_sub_task_request.task_id)
+
 
 async def change_subtask_order_service(token: str, task_id: UUID, update_subtask_order: SubTaskOrderRequest) -> None:
     current_author = validate_and_extract_author_details(token=token)
@@ -158,3 +162,4 @@ async def change_subtask_order_service(token: str, task_id: UUID, update_subtask
         task = _get_author_task(db=db, task_id=task_id, current_author=current_author)
         
         update_sub_task_order_in_bulk_by_task_id(db=db, sub_task_list=update_subtask_order.subtasks,task_id=task.id)
+        await invalidate_plan_day_cache_for_task(db=db, task_id=task_id)

--- a/pecha_api/plans/transfers/transfer_service.py
+++ b/pecha_api/plans/transfers/transfer_service.py
@@ -18,6 +18,7 @@ from pecha_api.plans.groups.groups_repository import get_group_by_id
 from pecha_api.plans.plans_models import Plan
 from pecha_api.plans.series.series_model import Series
 from pecha_api.plans.series.series_repository import get_series_by_id
+from pecha_api.plans.users.plan_user_series_repository import ensure_series_partner
 from pecha_api.plans.shared.permissions import (
     get_member_role,
     is_super_admin,
@@ -409,6 +410,7 @@ def _apply_transfer_accept(db: Session, transfer) -> None:
         if series:
             series.group_id = transfer.to_group_id
             db.add(series)
+            ensure_series_partner(db, series.id, transfer.to_group_id)
             for plan in series.plans or []:
                 if plan.deleted_at is None:
                     plan.group_id = transfer.to_group_id

--- a/pecha_api/plans/users/plan_user_series_repository.py
+++ b/pecha_api/plans/users/plan_user_series_repository.py
@@ -1,8 +1,8 @@
 from collections import defaultdict
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Sequence, Tuple
 from uuid import UUID
 from sqlalchemy.orm import Session
-from sqlalchemy import and_, desc, asc
+from sqlalchemy import and_, desc, asc, select
 from datetime import datetime, timezone
 
 from .plan_users_models import UserSeriesEnrollment, SeriesPartner
@@ -29,6 +29,24 @@ def get_user_series_enrollment_by_user_and_series(
             UserSeriesEnrollment.series_id == series_id
         )
     ).first()
+
+
+def get_group_ids_by_series_partner_ids(
+    db: Session,
+    series_partner_ids: Sequence[UUID],
+) -> Dict[UUID, UUID]:
+    """Map series_partner row IDs to the partner group ID for each enrollment."""
+    if not series_partner_ids:
+        return {}
+    rows = (
+        db.execute(
+            select(SeriesPartner.id, SeriesPartner.group_id).where(
+                SeriesPartner.id.in_(series_partner_ids),
+            )
+        )
+        .all()
+    )
+    return dict(rows)
 
 
 def get_series_partner(db: Session, series_id: UUID, group_id: UUID) -> Optional[SeriesPartner]:

--- a/pecha_api/plans/users/plan_user_series_repository.py
+++ b/pecha_api/plans/users/plan_user_series_repository.py
@@ -41,6 +41,17 @@ def get_series_partner(db: Session, series_id: UUID, group_id: UUID) -> Optional
     ).first()
 
 
+def ensure_series_partner(db: Session, series_id: UUID, group_id: UUID) -> SeriesPartner:
+    """Create the series_partner row when missing (idempotent)."""
+    partner = get_series_partner(db, series_id, group_id)
+    if partner is not None:
+        return partner
+    partner = SeriesPartner(series_id=series_id, group_id=group_id)
+    db.add(partner)
+    db.flush()
+    return partner
+
+
 def get_user_series_enrollments_by_user_id(
     db: Session,
     user_id: UUID,

--- a/pecha_api/plans/users/plan_users_response_models.py
+++ b/pecha_api/plans/users/plan_users_response_models.py
@@ -132,7 +132,7 @@ class UserSeriesEnrollmentDTO(BaseModel):
     completed_plans: int
     progress_percentage: float
     group: Optional[AuthorGroupSummaryDTO] = None
-    series_partner_id: Optional[UUID] = None
+    series_partner_id: Optional[UUID] = None  # Partner group ID when enrolled via a partner group
 
 
 class UserSeriesEnrollmentsResponse(BaseModel):

--- a/pecha_api/plans/users/plan_users_response_models.py
+++ b/pecha_api/plans/users/plan_users_response_models.py
@@ -102,6 +102,8 @@ class UserPlanDayDetailsResponse(BaseModel):
     is_completed: bool
     audio_url: Optional[str] = None
     audio_duration_ms: Optional[int] = None
+    thumbnail_url: Optional[str] = None
+    shareable_image_url: Optional[str] = None
     videos: List[DayVideoSummaryDTO] = []
 
 

--- a/pecha_api/plans/users/plan_users_service.py
+++ b/pecha_api/plans/users/plan_users_service.py
@@ -627,9 +627,15 @@ def get_user_plan_day_details_service(token: str, plan_id: UUID, day_number: int
             user_subtask_completions = get_user_subtask_completions_by_user_id_and_sub_task_ids(db=db, user_id=current_user.id, sub_task_ids=sub_task_ids)
             completed_subtask_ids = [completion.sub_task_id for completion in user_subtask_completions]
 
-        from pecha_api.plans.audio.dto_helpers import build_plan_day_audio_fields
+        from pecha_api.plans.audio.dto_helpers import (
+            build_plan_day_audio_fields,
+            build_plan_day_shareable_image_fields,
+        )
 
         audio_url, audio_duration_ms, _, _ = build_plan_day_audio_fields(plan_item)
+        thumbnail_url, _, shareable_image_url, _ = build_plan_day_shareable_image_fields(
+            getattr(plan_item, "shareable_images", None)
+        )
         from pecha_api.plans.public.plan_response_models import DayVideoSummaryDTO
         user_day_details = UserPlanDayDetailsResponse(
             id=plan_item.id,
@@ -637,6 +643,8 @@ def get_user_plan_day_details_service(token: str, plan_id: UUID, day_number: int
             is_completed=is_day_completed(db=db, user_id=current_user.id, day_id=plan_item.id),
             audio_url=audio_url,
             audio_duration_ms=audio_duration_ms,
+            thumbnail_url=thumbnail_url,
+            shareable_image_url=shareable_image_url,
             tasks=[
                 UserTaskDTO(
                     id=task.id,

--- a/pecha_api/plans/users/plan_users_service.py
+++ b/pecha_api/plans/users/plan_users_service.py
@@ -98,6 +98,7 @@ from pecha_api.plans.users.plan_user_series_repository import (
     get_plans_by_series_ids,
     get_paginated_plans_from_enrolled_series,
     get_series_partner,
+    get_group_ids_by_series_partner_ids,
 )
 from pecha_api.plans.series.series_repository import get_series_by_ids, get_plans_by_ids
 from pecha_api.plans.shared.metadata_utils import filter_by_language_with_fallback
@@ -737,6 +738,7 @@ def _build_user_series_enrollment_dto(
     progress_by_plan_id: dict,
     group: Optional[AuthorGroupSummaryDTO] = None,
     language: Optional[str] = None,
+    partner_group_id: Optional[UUID] = None,
 ) -> UserSeriesEnrollmentDTO:
     series_metadata = _select_series_metadata(series.metadata_entries, language)
     series_image = safe_get_image_url(
@@ -769,7 +771,7 @@ def _build_user_series_enrollment_dto(
         completed_plans=completed_plans,
         progress_percentage=progress_percentage,
         group=group,
-        series_partner_id=getattr(enrollment, "series_partner_id", None),
+        series_partner_id=partner_group_id,
     )
 
 
@@ -920,8 +922,18 @@ def get_user_series_enrollments(
             for plan in get_plans_by_ids(db, current_plan_ids)
         }
         series_group_ids = get_group_ids_by_series_ids(db=db, series_ids=series_ids)
+        series_partner_ids = [
+            enrollment.series_partner_id
+            for enrollment in enrollments
+            if getattr(enrollment, "series_partner_id", None)
+        ]
+        partner_group_id_by_series_partner_id = get_group_ids_by_series_partner_ids(
+            db=db, series_partner_ids=series_partner_ids
+        )
+        group_ids_for_summaries = set(series_group_ids.values())
+        group_ids_for_summaries.update(partner_group_id_by_series_partner_id.values())
         group_summaries = get_group_summaries_by_ids(
-            db=db, group_ids=list(series_group_ids.values()), language=language
+            db=db, group_ids=list(group_ids_for_summaries), language=language
         )
 
         enrollment_dtos = [
@@ -932,10 +944,17 @@ def get_user_series_enrollments(
                 plans_by_series_id,
                 progress_by_plan_id,
                 group=_group_summary_for_id(
-                    series_group_ids.get(enrollment.series_id),
+                    partner_group_id_by_series_partner_id.get(enrollment.series_partner_id)
+                    if getattr(enrollment, "series_partner_id", None)
+                    else series_group_ids.get(enrollment.series_id),
                     group_summaries,
                 ),
                 language=language,
+                partner_group_id=(
+                    partner_group_id_by_series_partner_id.get(enrollment.series_partner_id)
+                    if getattr(enrollment, "series_partner_id", None)
+                    else None
+                ),
             )
             for enrollment in enrollments
             if (series := series_by_id.get(enrollment.series_id))

--- a/poetry.lock
+++ b/poetry.lock
@@ -1997,6 +1997,17 @@ botocore = ">=1.36.0,<2.0a.0"
 crt = ["botocore[crt] (>=1.36.0,<2.0a.0)"]
 
 [[package]]
+name = "scalar-fastapi"
+version = "1.8.2"
+description = "This plugin provides an easy way to render a beautiful API reference based on a OpenAPI/Swagger file with FastAPI."
+optional = false
+python-versions = "*"
+files = [
+    {file = "scalar_fastapi-1.8.2-py3-none-any.whl", hash = "sha256:d96e2c8b3676491eaebb4ec8d9f4de77adb2374d86f87d321546fa6f084e8cb8"},
+    {file = "scalar_fastapi-1.8.2.tar.gz", hash = "sha256:0de09b8c63f78c1052792faa200d740b2ccaeeb88ac54e7ea633ac4edc6fde82"},
+]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 description = "Tool to Detect Surrounding Shell"
@@ -2477,4 +2488,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "e8fc428244abcebffa8cf9cb536b4a66a1c643a1c4cbdc32bef0ece6bcf6b521"
+content-hash = "e55bc47074c068a1628644f98bf9fd4e1aa6d28fab0348f5dc84143bf2fccb61"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ toml = "^0.10.2"
 mailtrap = "^2.3.0"
 google-genai = "^2.0"
 
+scalar-fastapi = "^1.8.2"
 [tool.poetry.scripts]
 start = "uvicorn:main"
 

--- a/tests/plans/groups/test_groups_repository.py
+++ b/tests/plans/groups/test_groups_repository.py
@@ -11,6 +11,7 @@ from pecha_api.plans.groups.groups_repository import (
     get_group_ids_by_plan_ids,
     get_group_ids_by_series_ids,
     get_groups_paginated,
+    get_plans_by_group_id,
     get_series_by_group_id,
     get_series_partner_id_map_for_group,
     get_user_series_enrollment_partner_map,
@@ -116,6 +117,22 @@ def test_get_user_series_enrollment_partner_map():
     )
 
     assert result == {series_id: partner_id}
+
+
+def test_get_plans_by_group_id_excludes_series_plans():
+    db = _make_session_mock()
+    group_id = uuid.uuid4()
+    standalone_plan = MagicMock()
+    query = MagicMock()
+    db.query.return_value = query
+    query.filter.return_value = query
+    query.filter.return_value.all.return_value = [standalone_plan]
+
+    result = get_plans_by_group_id(db=db, group_id=group_id)
+
+    assert result == [standalone_plan]
+    db.query.assert_called_once()
+    query.filter.assert_called_once()
 
 
 def test_get_series_by_group_id_includes_owned_and_partner_series():

--- a/tests/plans/groups/test_groups_service.py
+++ b/tests/plans/groups/test_groups_service.py
@@ -682,7 +682,8 @@ def test_is_series_enrolled_for_group_context():
 def test_series_to_dtos_sets_partner_enrollment_for_authenticated_user():
     group_id = uuid4()
     series = _make_series_with_metadata()
-    partner_id = uuid4()
+    series.group_id = uuid4()
+    series_partner_row_id = uuid4()
     user_id = uuid4()
     mock_db = MagicMock()
     with patch(
@@ -693,10 +694,10 @@ def test_series_to_dtos_sets_partner_enrollment_for_authenticated_user():
         return_value={series.id: 5},
     ), patch(
         "pecha_api.plans.groups.groups_service.get_series_partner_id_map_for_group",
-        return_value={series.id: partner_id},
+        return_value={series.id: series_partner_row_id},
     ), patch(
         "pecha_api.plans.groups.groups_service.get_user_series_enrollment_partner_map",
-        return_value={series.id: partner_id},
+        return_value={series.id: series_partner_row_id},
     ):
         dtos = _series_to_dtos(
             db=mock_db,
@@ -705,14 +706,15 @@ def test_series_to_dtos_sets_partner_enrollment_for_authenticated_user():
             user_id=user_id,
         )
 
-    assert dtos[0].series_partner_id == partner_id
+    assert dtos[0].series_partner_id == group_id
     assert dtos[0].is_enrolled is True
 
 
 def test_series_to_dtos_is_not_enrolled_without_user():
     group_id = uuid4()
     series = _make_series_with_metadata()
-    partner_id = uuid4()
+    series.group_id = uuid4()
+    series_partner_row_id = uuid4()
     mock_db = MagicMock()
     with patch(
         "pecha_api.plans.groups.groups_service.get_active_plan_count_map_by_series_ids",
@@ -722,7 +724,7 @@ def test_series_to_dtos_is_not_enrolled_without_user():
         return_value={series.id: 5},
     ), patch(
         "pecha_api.plans.groups.groups_service.get_series_partner_id_map_for_group",
-        return_value={series.id: partner_id},
+        return_value={series.id: series_partner_row_id},
     ), patch(
         "pecha_api.plans.groups.groups_service.get_user_series_enrollment_partner_map",
     ) as mock_enrollment_map:
@@ -733,8 +735,29 @@ def test_series_to_dtos_is_not_enrolled_without_user():
         )
 
     mock_enrollment_map.assert_not_called()
-    assert dtos[0].series_partner_id == partner_id
+    assert dtos[0].series_partner_id == group_id
     assert dtos[0].is_enrolled is False
+
+
+def test_series_to_dtos_omits_series_partner_id_for_owned_series():
+    group_id = uuid4()
+    series = _make_series_with_metadata()
+    series.group_id = group_id
+    series_partner_row_id = uuid4()
+    mock_db = MagicMock()
+    with patch(
+        "pecha_api.plans.groups.groups_service.get_active_plan_count_map_by_series_ids",
+        return_value={series.id: 2},
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_enrolled_count_map_by_series_ids",
+        return_value={series.id: 5},
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_series_partner_id_map_for_group",
+        return_value={series.id: series_partner_row_id},
+    ):
+        dtos = _series_to_dtos(db=mock_db, series_list=[series], group_id=group_id)
+
+    assert dtos[0].series_partner_id is None
 
 
 def test_series_to_dtos_filters_metadata_by_language():

--- a/tests/plans/groups/test_groups_service.py
+++ b/tests/plans/groups/test_groups_service.py
@@ -11,6 +11,7 @@ from pecha_api.plans.groups.groups_response_models import (
     CreateAuthorGroupRequest,
     CreateGroupInviteRequest,
     GroupMetadataInput,
+    GroupSeriesListItemDTO,
     GroupSocialLinkInput,
     ReplaceGroupSocialLinksRequest,
     ReplaceGroupTagsRequest,
@@ -660,6 +661,11 @@ def test_series_to_dtos_returns_empty_for_empty_series_list():
     mock_db.assert_not_called()
 
 
+def test_group_series_list_item_dto_excludes_series_partner_id():
+    assert "series_partner_id" not in GroupSeriesListItemDTO.model_fields
+    assert "is_enrolled" in GroupSeriesListItemDTO.model_fields
+
+
 def test_is_series_enrolled_for_group_context():
     partner_id = uuid4()
     assert _is_series_enrolled_for_group_context(
@@ -682,8 +688,7 @@ def test_is_series_enrolled_for_group_context():
 def test_series_to_dtos_sets_partner_enrollment_for_authenticated_user():
     group_id = uuid4()
     series = _make_series_with_metadata()
-    series.group_id = uuid4()
-    series_partner_row_id = uuid4()
+    partner_id = uuid4()
     user_id = uuid4()
     mock_db = MagicMock()
     with patch(
@@ -694,10 +699,10 @@ def test_series_to_dtos_sets_partner_enrollment_for_authenticated_user():
         return_value={series.id: 5},
     ), patch(
         "pecha_api.plans.groups.groups_service.get_series_partner_id_map_for_group",
-        return_value={series.id: series_partner_row_id},
+        return_value={series.id: partner_id},
     ), patch(
         "pecha_api.plans.groups.groups_service.get_user_series_enrollment_partner_map",
-        return_value={series.id: series_partner_row_id},
+        return_value={series.id: partner_id},
     ):
         dtos = _series_to_dtos(
             db=mock_db,
@@ -706,15 +711,13 @@ def test_series_to_dtos_sets_partner_enrollment_for_authenticated_user():
             user_id=user_id,
         )
 
-    assert dtos[0].series_partner_id == group_id
     assert dtos[0].is_enrolled is True
 
 
 def test_series_to_dtos_is_not_enrolled_without_user():
     group_id = uuid4()
     series = _make_series_with_metadata()
-    series.group_id = uuid4()
-    series_partner_row_id = uuid4()
+    partner_id = uuid4()
     mock_db = MagicMock()
     with patch(
         "pecha_api.plans.groups.groups_service.get_active_plan_count_map_by_series_ids",
@@ -724,7 +727,7 @@ def test_series_to_dtos_is_not_enrolled_without_user():
         return_value={series.id: 5},
     ), patch(
         "pecha_api.plans.groups.groups_service.get_series_partner_id_map_for_group",
-        return_value={series.id: series_partner_row_id},
+        return_value={series.id: partner_id},
     ), patch(
         "pecha_api.plans.groups.groups_service.get_user_series_enrollment_partner_map",
     ) as mock_enrollment_map:
@@ -735,29 +738,7 @@ def test_series_to_dtos_is_not_enrolled_without_user():
         )
 
     mock_enrollment_map.assert_not_called()
-    assert dtos[0].series_partner_id == group_id
     assert dtos[0].is_enrolled is False
-
-
-def test_series_to_dtos_omits_series_partner_id_for_owned_series():
-    group_id = uuid4()
-    series = _make_series_with_metadata()
-    series.group_id = group_id
-    series_partner_row_id = uuid4()
-    mock_db = MagicMock()
-    with patch(
-        "pecha_api.plans.groups.groups_service.get_active_plan_count_map_by_series_ids",
-        return_value={series.id: 2},
-    ), patch(
-        "pecha_api.plans.groups.groups_service.get_enrolled_count_map_by_series_ids",
-        return_value={series.id: 5},
-    ), patch(
-        "pecha_api.plans.groups.groups_service.get_series_partner_id_map_for_group",
-        return_value={series.id: series_partner_row_id},
-    ):
-        dtos = _series_to_dtos(db=mock_db, series_list=[series], group_id=group_id)
-
-    assert dtos[0].series_partner_id is None
 
 
 def test_series_to_dtos_filters_metadata_by_language():

--- a/tests/plans/groups/test_groups_views.py
+++ b/tests/plans/groups/test_groups_views.py
@@ -404,6 +404,7 @@ def test_get_public_group_by_id():
     ) as mock_service:
         response = client.get(f"/author/groups/{group_id}")
     assert response.status_code == status.HTTP_200_OK
+    assert response.headers.get("Cache-Control") == "no-store"
     assert response.json()["slug"] == "bodhichitta-authors"
     mock_service.assert_called_once_with(group_id=group_id, require_public=True, language=None, token=None)
 

--- a/tests/plans/public/test_plan_public_service.py
+++ b/tests/plans/public/test_plan_public_service.py
@@ -1247,6 +1247,8 @@ async def test_get_plan_day_details_success():
     mock_plan_item.id = uuid4()
     mock_plan_item.day_number = day_number
     mock_plan_item.tasks = [mock_task]
+    mock_plan_item.shareable_images = None
+    mock_plan_item.videos = []
     
     with patch("pecha_api.plans.public.plan_service.SessionLocal") as mock_session_local, \
          patch("pecha_api.plans.public.plan_service.get_plan_day_with_tasks_and_subtasks") as mock_get_plan_day, \
@@ -1278,6 +1280,46 @@ async def test_get_plan_day_details_success():
         assert task.subtasks[0].content_type == ContentType.TEXT
         assert task.subtasks[0].content == "Subtask content 1"
         assert task.subtasks[0].display_order == 1
+        assert response.thumbnail_url is None
+        assert response.shareable_image_url is None
+
+
+@pytest.mark.asyncio
+async def test_get_plan_day_details_includes_shareable_image_urls():
+    plan_id = uuid4()
+    day_number = 1
+
+    mock_shareable_images = MagicMock()
+    mock_shareable_images.thumbnail_key = "images/day_shareable/thumb.webp"
+    mock_shareable_images.shareable_image_key = "images/day_shareable/share.webp"
+
+    mock_plan_item = MagicMock()
+    mock_plan_item.id = uuid4()
+    mock_plan_item.day_number = day_number
+    mock_plan_item.tasks = []
+    mock_plan_item.shareable_images = mock_shareable_images
+    mock_plan_item.videos = []
+
+    with patch("pecha_api.plans.public.plan_service.SessionLocal") as mock_session_local, \
+         patch("pecha_api.plans.public.plan_service.get_plan_day_with_tasks_and_subtasks") as mock_get_plan_day, \
+         patch("pecha_api.plans.public.plan_service.get_plan_day_detail_cache", return_value=None), \
+         patch("pecha_api.plans.public.plan_service.set_plan_day_detail_cache"), \
+         patch(
+             "pecha_api.plans.public.plan_service.build_plan_day_shareable_image_fields",
+             return_value=(
+                 "https://bucket.s3.amazonaws.com/thumb",
+                 "images/day_shareable/thumb.webp",
+                 "https://bucket.s3.amazonaws.com/share",
+                 "images/day_shareable/share.webp",
+             ),
+         ):
+        _mock_session_local(mock_session_local)
+        mock_get_plan_day.return_value = mock_plan_item
+
+        response = await get_plan_day_details(plan_id=plan_id, day_number=day_number)
+
+        assert response.thumbnail_url == "https://bucket.s3.amazonaws.com/thumb"
+        assert response.shareable_image_url == "https://bucket.s3.amazonaws.com/share"
 
 def test_get_tags_success(mock_db_session):
     """Test successful retrieval of tags."""

--- a/tests/plans/public/test_plan_public_service.py
+++ b/tests/plans/public/test_plan_public_service.py
@@ -1220,7 +1220,8 @@ def test_resolve_daily_plan_raises_when_date_resolution_fails():
     assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
 
 
-def test_get_plan_day_details_success():
+@pytest.mark.asyncio
+async def test_get_plan_day_details_success():
     """Test successful retrieval of plan day details with tasks and subtasks"""
     plan_id = uuid4()
     day_number = 1
@@ -1248,14 +1249,18 @@ def test_get_plan_day_details_success():
     mock_plan_item.tasks = [mock_task]
     
     with patch("pecha_api.plans.public.plan_service.SessionLocal") as mock_session_local, \
-         patch("pecha_api.plans.public.plan_service.get_plan_day_with_tasks_and_subtasks") as mock_get_plan_day:
+         patch("pecha_api.plans.public.plan_service.get_plan_day_with_tasks_and_subtasks") as mock_get_plan_day, \
+         patch("pecha_api.plans.public.plan_service.get_plan_day_detail_cache", return_value=None) as mock_get_cache, \
+         patch("pecha_api.plans.public.plan_service.set_plan_day_detail_cache") as mock_set_cache:
         
         db_session = _mock_session_local(mock_session_local)
         mock_get_plan_day.return_value = mock_plan_item
 
-        response = get_plan_day_details(plan_id=plan_id, day_number=day_number)
+        response = await get_plan_day_details(plan_id=plan_id, day_number=day_number)
 
+        mock_get_cache.assert_awaited_once_with(plan_id=plan_id, day_number=day_number)
         mock_get_plan_day.assert_called_once_with(db=db_session, plan_id=plan_id, day_number=day_number)
+        mock_set_cache.assert_awaited_once()
 
         assert isinstance(response, PlanDayDTO)
         assert response.id == mock_plan_item.id

--- a/tests/plans/public/test_plan_public_views.py
+++ b/tests/plans/public/test_plan_public_views.py
@@ -793,3 +793,72 @@ async def test_get_plans_with_group_filter(sample_plans_response):
             skip=0,
             limit=20,
         )
+
+
+def test_cleanup_plan_day_cache_success():
+    plan_id = uuid4()
+    day_number = 1
+    from pecha_api.config import get as real_config_get
+
+    def _config_get(key: str) -> str:
+        if key == "DEPLOYMENT_MODE":
+            return "DEBUG"
+        return real_config_get(key)
+
+    with patch("pecha_api.plans.public.plan_views.config.get", side_effect=_config_get), patch(
+        "pecha_api.plans.public.plan_views.invalidate_plan_day_detail_cache",
+        new_callable=AsyncMock,
+        return_value=2,
+    ) as mock_invalidate:
+        response = client.delete(f"/api/v1/plans/{plan_id}/days/{day_number}/cache")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {
+        "plan_id": str(plan_id),
+        "day_number": day_number,
+        "keys_deleted": 2,
+    }
+    mock_invalidate.assert_awaited_once_with(plan_id=plan_id, day_number=day_number)
+
+
+def test_cleanup_plan_days_cache_success():
+    plan_id = uuid4()
+    from pecha_api.config import get as real_config_get
+
+    def _config_get(key: str) -> str:
+        if key == "DEPLOYMENT_MODE":
+            return "DEBUG"
+        return real_config_get(key)
+
+    with patch("pecha_api.plans.public.plan_views.config.get", side_effect=_config_get), patch(
+        "pecha_api.plans.public.plan_views.SessionLocal"
+    ) as mock_session_local, patch(
+        "pecha_api.plans.public.plan_views.invalidate_all_plan_day_detail_caches_for_plan",
+        new_callable=AsyncMock,
+        return_value=6,
+    ) as mock_invalidate:
+        mock_session_local.return_value.__enter__.return_value = MagicMock()
+        response = client.delete(f"/api/v1/plans/{plan_id}/cache/plan-days")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {
+        "plan_id": str(plan_id),
+        "day_number": None,
+        "keys_deleted": 6,
+    }
+    mock_invalidate.assert_awaited_once()
+
+
+def test_cleanup_plan_day_cache_forbidden_outside_debug():
+    plan_id = uuid4()
+    from pecha_api.config import get as real_config_get
+
+    def _config_get(key: str) -> str:
+        if key == "DEPLOYMENT_MODE":
+            return "PRODUCTION"
+        return real_config_get(key)
+
+    with patch("pecha_api.plans.public.plan_views.config.get", side_effect=_config_get):
+        response = client.delete(f"/api/v1/plans/{plan_id}/days/1/cache")
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/tests/plans/public/test_plans_cache_service.py
+++ b/tests/plans/public/test_plans_cache_service.py
@@ -1,0 +1,61 @@
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from pecha_api.cache.cache_enums import CacheType
+from pecha_api.plans.public.plans_cache_service import (
+    _plan_day_detail_cache_keys,
+    invalidate_plan_day_detail_cache,
+    schedule_invalidate_plan_day_cache_for_task,
+)
+from pecha_api.utils import Utils
+
+
+@pytest.mark.asyncio
+async def test_invalidate_plan_day_detail_cache_deletes_legacy_and_current_keys():
+    plan_id = uuid.uuid4()
+    day_number = 1
+    expected_keys = _plan_day_detail_cache_keys(plan_id=plan_id, day_number=day_number)
+
+    with patch(
+        "pecha_api.plans.public.plans_cache_service.delete_cache",
+        new_callable=AsyncMock,
+    ) as mock_delete:
+        await invalidate_plan_day_detail_cache(plan_id=plan_id, day_number=day_number)
+
+    assert mock_delete.await_count == len(expected_keys)
+    deleted_keys = [call.kwargs["hash_key"] for call in mock_delete.await_args_list]
+    assert deleted_keys == expected_keys
+
+
+def test_plan_day_detail_cache_keys_include_legacy_enum_format():
+    plan_id = uuid.uuid4()
+    day_number = 3
+
+    keys = _plan_day_detail_cache_keys(plan_id=plan_id, day_number=day_number)
+    legacy_key = Utils.generate_hash_key(
+        payload=[str(plan_id), day_number, CacheType.PLAN_DAY_DETAIL]
+    )
+
+    assert legacy_key in keys
+
+
+def test_schedule_invalidate_plan_day_cache_for_task_resolves_plan_day():
+    task_id = uuid.uuid4()
+    plan_item_id = uuid.uuid4()
+    plan_id = uuid.uuid4()
+    db = MagicMock()
+
+    with patch(
+        "pecha_api.plans.public.plans_cache_service.get_task_by_id",
+        return_value=MagicMock(plan_item_id=plan_item_id),
+    ), patch(
+        "pecha_api.plans.public.plans_cache_service.get_plan_item_by_id",
+        return_value=MagicMock(plan_id=plan_id, day_number=2),
+    ), patch(
+        "pecha_api.plans.public.plans_cache_service.schedule_invalidate_plan_day_cache",
+    ) as mock_schedule:
+        schedule_invalidate_plan_day_cache_for_task(db=db, task_id=task_id)
+
+    mock_schedule.assert_called_once_with(plan_id=plan_id, day_number=2)

--- a/tests/plans/public/test_plans_cache_service.py
+++ b/tests/plans/public/test_plans_cache_service.py
@@ -6,6 +6,7 @@ import pytest
 from pecha_api.cache.cache_enums import CacheType
 from pecha_api.plans.public.plans_cache_service import (
     _plan_day_detail_cache_keys,
+    invalidate_all_plan_day_detail_caches_for_plan,
     invalidate_plan_day_detail_cache,
     schedule_invalidate_plan_day_cache_for_task,
 )
@@ -22,8 +23,9 @@ async def test_invalidate_plan_day_detail_cache_deletes_legacy_and_current_keys(
         "pecha_api.plans.public.plans_cache_service.delete_cache",
         new_callable=AsyncMock,
     ) as mock_delete:
-        await invalidate_plan_day_detail_cache(plan_id=plan_id, day_number=day_number)
+        keys_deleted = await invalidate_plan_day_detail_cache(plan_id=plan_id, day_number=day_number)
 
+    assert keys_deleted == len(expected_keys)
     assert mock_delete.await_count == len(expected_keys)
     deleted_keys = [call.kwargs["hash_key"] for call in mock_delete.await_args_list]
     assert deleted_keys == expected_keys
@@ -59,3 +61,22 @@ def test_schedule_invalidate_plan_day_cache_for_task_resolves_plan_day():
         schedule_invalidate_plan_day_cache_for_task(db=db, task_id=task_id)
 
     mock_schedule.assert_called_once_with(plan_id=plan_id, day_number=2)
+
+
+@pytest.mark.asyncio
+async def test_invalidate_all_plan_day_detail_caches_for_plan():
+    plan_id = uuid.uuid4()
+    db = MagicMock()
+
+    with patch(
+        "pecha_api.plans.public.plans_cache_service.get_days_by_plan_id",
+        return_value=[MagicMock(day_number=1), MagicMock(day_number=2)],
+    ), patch(
+        "pecha_api.plans.public.plans_cache_service.invalidate_plan_day_detail_cache",
+        new_callable=AsyncMock,
+        side_effect=[2, 2],
+    ) as mock_invalidate:
+        keys_deleted = await invalidate_all_plan_day_detail_caches_for_plan(db=db, plan_id=plan_id)
+
+    assert keys_deleted == 4
+    assert mock_invalidate.await_count == 2

--- a/tests/plans/sub_tasks/test_plan_sub_tasks_services.py
+++ b/tests/plans/sub_tasks/test_plan_sub_tasks_services.py
@@ -1,7 +1,7 @@
 import uuid
 import pytest
 from types import SimpleNamespace
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, AsyncMock
 
 from pecha_api.plans.tasks.sub_tasks.plan_sub_tasks_response_model import (
     SubTaskDTO,
@@ -221,7 +221,10 @@ async def test_update_sub_task_by_task_id_deletes_missing_and_updates_existing_a
         "pecha_api.plans.tasks.sub_tasks.plan_sub_tasks_services.delete_sub_tasks_bulk",
     ) as mock_delete_bulk, patch(
         "pecha_api.plans.tasks.sub_tasks.plan_sub_tasks_services.update_sub_tasks_bulk",
-    ) as mock_update_bulk:
+    ) as mock_update_bulk, patch(
+        "pecha_api.plans.tasks.sub_tasks.plan_sub_tasks_services.invalidate_plan_day_cache_for_task",
+        new_callable=AsyncMock,
+    ) as mock_invalidate:
         resp = await update_sub_task_by_task_id(
             token="token123",
             update_sub_task_request=request,
@@ -246,6 +249,7 @@ async def test_update_sub_task_by_task_id_deletes_missing_and_updates_existing_a
         assert update_kwargs["db"] is db_mock
         assert update_kwargs["sub_tasks"] == request.sub_tasks
 
+        mock_invalidate.assert_awaited_once_with(db=db_mock, task_id=task_id)
         assert resp is None
 
 

--- a/tests/plans/tasks/test_plan_tasks_repository.py
+++ b/tests/plans/tasks/test_plan_tasks_repository.py
@@ -78,9 +78,6 @@ def test_get_task_by_id_queries_by_id():
     db.query.return_value.options.return_value.filter.return_value.first.return_value = expected
 
     task_id = uuid.uuid4()
-    from pecha_api.plans.tasks.plan_tasks_repository import PlanTask as _RepoPlanTask
-    setattr(_RepoPlanTask, "sub_tasks", object())
-    setattr(PlanSubTask, "timestamp", object())
     with patch("pecha_api.plans.tasks.plan_tasks_repository.joinedload") as mock_joined:
         mock_chain = MagicMock()
         mock_joined.return_value = mock_chain
@@ -113,9 +110,6 @@ def test_get_task_by_id_not_found_raises_http_404_with_payload():
 
     from fastapi import HTTPException
 
-    from pecha_api.plans.tasks.plan_tasks_repository import PlanTask as _RepoPlanTask
-    setattr(_RepoPlanTask, "sub_tasks", object())
-    setattr(PlanSubTask, "timestamp", object())
     with patch("pecha_api.plans.tasks.plan_tasks_repository.joinedload") as mock_joined:
         mock_chain = MagicMock()
         mock_joined.return_value = mock_chain

--- a/tests/plans/users/test_plan_users_series_service.py
+++ b/tests/plans/users/test_plan_users_series_service.py
@@ -46,6 +46,13 @@ def _mock_series_query(db_mock, series):
     db_mock.query.return_value = mock_query
 
 
+def _enroll_series(series_id, *, creator_group_id=None):
+    return SimpleNamespace(
+        id=series_id,
+        group_id=creator_group_id if creator_group_id is not None else uuid.uuid4(),
+    )
+
+
 def _plan_for_date_filter(*, plan_id, series_id, display_order, start_date):
     return SimpleNamespace(
         id=plan_id,
@@ -346,7 +353,7 @@ def test_enroll_user_in_series_success():
     enroll_request = UserSeriesEnrollRequest(series_id=series_id)
 
     db_mock, session_cm = _mock_session_with_db()
-    _mock_series_query(db_mock, SimpleNamespace(id=series_id))
+    _mock_series_query(db_mock, _enroll_series(series_id))
 
     with patch(
         "pecha_api.plans.users.plan_users_service.validate_and_extract_user_details",
@@ -381,7 +388,7 @@ def test_enroll_user_in_series_start_immediately_auto_enrolls_first_plan():
     )
 
     db_mock, session_cm = _mock_session_with_db()
-    _mock_series_query(db_mock, SimpleNamespace(id=series_id))
+    _mock_series_query(db_mock, _enroll_series(series_id))
     first_plan = SimpleNamespace(id=plan_id)
 
     with patch(
@@ -439,7 +446,7 @@ def test_enroll_user_in_series_already_enrolled_without_group_id_is_noop():
     enroll_request = UserSeriesEnrollRequest(series_id=series_id)
 
     db_mock, session_cm = _mock_session_with_db()
-    _mock_series_query(db_mock, SimpleNamespace(id=series_id))
+    _mock_series_query(db_mock, _enroll_series(series_id))
     existing = SimpleNamespace(id=uuid.uuid4(), series_partner_id=uuid.uuid4())
 
     with patch(
@@ -471,7 +478,7 @@ def test_enroll_user_in_series_already_enrolled_updates_partner_when_group_chang
     enroll_request = UserSeriesEnrollRequest(series_id=series_id, group_id=group_id)
 
     db_mock, session_cm = _mock_session_with_db()
-    _mock_series_query(db_mock, SimpleNamespace(id=series_id))
+    _mock_series_query(db_mock, _enroll_series(series_id))
     existing = SimpleNamespace(id=uuid.uuid4(), series_partner_id=old_partner_id)
 
     with patch(
@@ -504,7 +511,7 @@ def test_enroll_user_in_series_already_enrolled_clears_partner_when_group_id_nul
     enroll_request = UserSeriesEnrollRequest(series_id=series_id, group_id=None)
 
     db_mock, session_cm = _mock_session_with_db()
-    _mock_series_query(db_mock, SimpleNamespace(id=series_id))
+    _mock_series_query(db_mock, _enroll_series(series_id))
     existing = SimpleNamespace(id=uuid.uuid4(), series_partner_id=uuid.uuid4())
 
     with patch(
@@ -539,7 +546,7 @@ def test_enroll_user_in_series_already_enrolled_same_partner_is_noop():
     enroll_request = UserSeriesEnrollRequest(series_id=series_id, group_id=group_id)
 
     db_mock, session_cm = _mock_session_with_db()
-    _mock_series_query(db_mock, SimpleNamespace(id=series_id))
+    _mock_series_query(db_mock, _enroll_series(series_id))
     existing = SimpleNamespace(id=uuid.uuid4(), series_partner_id=partner_id)
 
     with patch(
@@ -572,7 +579,7 @@ def test_enroll_user_in_series_already_enrolled_invalid_group_raises_400():
     enroll_request = UserSeriesEnrollRequest(series_id=series_id, group_id=group_id)
 
     db_mock, session_cm = _mock_session_with_db()
-    _mock_series_query(db_mock, SimpleNamespace(id=series_id))
+    _mock_series_query(db_mock, _enroll_series(series_id))
 
     with patch(
         "pecha_api.plans.users.plan_users_service.validate_and_extract_user_details",
@@ -605,7 +612,7 @@ def test_enroll_user_in_series_with_partner_group_stores_partner_and_joins_group
     enroll_request = UserSeriesEnrollRequest(series_id=series_id, group_id=group_id)
 
     db_mock, session_cm = _mock_session_with_db()
-    _mock_series_query(db_mock, SimpleNamespace(id=series_id))
+    _mock_series_query(db_mock, _enroll_series(series_id))
     series_partner = SimpleNamespace(id=partner_id, series_id=series_id, group_id=group_id)
 
     with patch(
@@ -638,6 +645,47 @@ def test_enroll_user_in_series_with_partner_group_stores_partner_and_joins_group
         mock_join.assert_called_once_with(db_mock, group_id, user_id)
 
 
+def test_enroll_user_in_series_with_creator_group_stores_partner_and_joins_group():
+    user_id = uuid.uuid4()
+    series_id = uuid.uuid4()
+    creator_group_id = uuid.uuid4()
+    partner_id = uuid.uuid4()
+    enroll_request = UserSeriesEnrollRequest(series_id=series_id, group_id=creator_group_id)
+
+    db_mock, session_cm = _mock_session_with_db()
+    _mock_series_query(db_mock, _enroll_series(series_id, creator_group_id=creator_group_id))
+    series_partner = SimpleNamespace(
+        id=partner_id, series_id=series_id, group_id=creator_group_id
+    )
+
+    with patch(
+        "pecha_api.plans.users.plan_users_service.validate_and_extract_user_details",
+        return_value=SimpleNamespace(id=user_id),
+    ), patch(
+        "pecha_api.plans.users.plan_users_service.SessionLocal",
+        return_value=session_cm,
+    ), patch(
+        "pecha_api.plans.users.plan_users_service.get_user_series_enrollment_by_user_and_series",
+        return_value=None,
+    ), patch(
+        "pecha_api.plans.users.plan_users_service.get_series_partner",
+        return_value=series_partner,
+    ) as mock_get_partner, patch(
+        "pecha_api.plans.users.plan_users_service.UserSeriesEnrollment",
+    ) as MockEnrollment, patch(
+        "pecha_api.plans.users.plan_users_service.save_user_series_enrollment",
+    ), patch(
+        "pecha_api.plans.users.plan_users_service.upsert_group_join",
+    ) as mock_join:
+        MockEnrollment.return_value = SimpleNamespace(id=uuid.uuid4())
+
+        enroll_user_in_series(token="tok", enroll_request=enroll_request)
+
+        mock_get_partner.assert_called_once_with(db_mock, series_id, creator_group_id)
+        assert MockEnrollment.call_args.kwargs["series_partner_id"] == partner_id
+        mock_join.assert_called_once_with(db_mock, creator_group_id, user_id)
+
+
 def test_enroll_user_in_series_with_non_partner_group_raises_400():
     user_id = uuid.uuid4()
     series_id = uuid.uuid4()
@@ -645,7 +693,7 @@ def test_enroll_user_in_series_with_non_partner_group_raises_400():
     enroll_request = UserSeriesEnrollRequest(series_id=series_id, group_id=group_id)
 
     db_mock, session_cm = _mock_session_with_db()
-    _mock_series_query(db_mock, SimpleNamespace(id=series_id))
+    _mock_series_query(db_mock, _enroll_series(series_id))
 
     with patch(
         "pecha_api.plans.users.plan_users_service.validate_and_extract_user_details",
@@ -681,7 +729,7 @@ def test_enroll_user_in_series_without_group_skips_partner_and_join():
     enroll_request = UserSeriesEnrollRequest(series_id=series_id)
 
     db_mock, session_cm = _mock_session_with_db()
-    _mock_series_query(db_mock, SimpleNamespace(id=series_id))
+    _mock_series_query(db_mock, _enroll_series(series_id))
 
     with patch(
         "pecha_api.plans.users.plan_users_service.validate_and_extract_user_details",

--- a/tests/plans/users/test_plan_users_series_service.py
+++ b/tests/plans/users/test_plan_users_series_service.py
@@ -152,6 +152,7 @@ def test_build_user_series_enrollment_dto_with_metadata_and_progress():
     current_plan_id = uuid.uuid4()
     plan_id = uuid.uuid4()
     series_partner_id = uuid.uuid4()
+    partner_group_id = uuid.uuid4()
 
     enrollment = SimpleNamespace(
         id=enrollment_id,
@@ -188,6 +189,7 @@ def test_build_user_series_enrollment_dto_with_metadata_and_progress():
             {current_plan_id: "Current Plan"},
             {series_id: [SimpleNamespace(id=plan_id)]},
             {plan_id: SimpleNamespace(is_completed=True)},
+            partner_group_id=partner_group_id,
         )
 
     assert dto.id == enrollment_id
@@ -198,7 +200,7 @@ def test_build_user_series_enrollment_dto_with_metadata_and_progress():
     assert dto.total_plans == 1
     assert dto.completed_plans == 1
     assert dto.progress_percentage == 100.0
-    assert dto.series_partner_id == series_partner_id
+    assert dto.series_partner_id == partner_group_id
 
 
 def test_build_user_series_enrollment_dto_renders_language_with_en_fallback():
@@ -786,6 +788,8 @@ def test_get_user_series_enrollments_success():
     enrollment_id = uuid.uuid4()
     current_plan_id = uuid.uuid4()
     plan_id = current_plan_id
+    series_partner_id = uuid.uuid4()
+    partner_group_id = uuid.uuid4()
 
     enrollment = SimpleNamespace(
         id=enrollment_id,
@@ -797,6 +801,7 @@ def test_get_user_series_enrollments_success():
         auto_enroll_next=True,
         is_completed=False,
         completed_at=None,
+        series_partner_id=series_partner_id,
     )
     series = SimpleNamespace(
         id=series_id,
@@ -829,6 +834,15 @@ def test_get_user_series_enrollments_success():
         "pecha_api.plans.users.plan_users_service.get_plans_by_ids",
         return_value=[plan],
     ), patch(
+        "pecha_api.plans.users.plan_users_service.get_group_ids_by_series_ids",
+        return_value={series_id: uuid.uuid4()},
+    ), patch(
+        "pecha_api.plans.users.plan_users_service.get_group_ids_by_series_partner_ids",
+        return_value={series_partner_id: partner_group_id},
+    ), patch(
+        "pecha_api.plans.users.plan_users_service.get_group_summaries_by_ids",
+        return_value={},
+    ), patch(
         "pecha_api.plans.users.plan_users_service.safe_get_image_url",
         return_value=ImageUrlModel(
             thumbnail="https://signed.example.com/series-thumb.jpg",
@@ -849,6 +863,7 @@ def test_get_user_series_enrollments_success():
     assert dto.progress_percentage == 100.0
     assert dto.image is not None
     assert dto.image.original == "https://signed.example.com/series.jpg"
+    assert dto.series_partner_id == partner_group_id
 
 
 def test_get_user_series_enrollments_skips_missing_series():

--- a/tests/plans/users/test_plan_users_service.py
+++ b/tests/plans/users/test_plan_users_service.py
@@ -1676,6 +1676,58 @@ def test_get_user_plan_day_details_service_success():
         assert set(mock_subtask_completions.call_args.kwargs["sub_task_ids"]) == {sub1_id, sub2_id}
 
 
+def test_get_user_plan_day_details_service_includes_shareable_image_urls():
+    user_id = uuid.uuid4()
+    plan_id = uuid.uuid4()
+    day_id = uuid.uuid4()
+
+    mock_shareable_images = SimpleNamespace(
+        thumbnail_key="images/day_shareable/thumb.webp",
+        shareable_image_key="images/day_shareable/share.webp",
+    )
+    plan_item = SimpleNamespace(
+        id=day_id,
+        day_number=1,
+        videos=[],
+        shareable_images=mock_shareable_images,
+        tasks=[],
+    )
+
+    db_mock, session_cm = _mock_session_with_db()
+
+    with patch(
+        "pecha_api.plans.users.plan_users_service.validate_and_extract_user_details",
+        return_value=SimpleNamespace(id=user_id),
+    ), patch(
+        "pecha_api.plans.users.plan_users_service.SessionLocal",
+        return_value=session_cm,
+    ), patch(
+        "pecha_api.plans.users.plan_users_service.get_plan_day_with_tasks_and_subtasks",
+        return_value=plan_item,
+    ), patch(
+        "pecha_api.plans.users.plan_users_service.is_day_completed",
+        return_value=False,
+    ), patch(
+        "pecha_api.plans.users.plan_users_service.get_user_task_completions_by_user_id_and_task_ids",
+        return_value=[],
+    ), patch(
+        "pecha_api.plans.users.plan_users_service.get_user_subtask_completions_by_user_id_and_sub_task_ids",
+        return_value=[],
+    ), patch(
+        "pecha_api.plans.audio.dto_helpers.build_plan_day_shareable_image_fields",
+        return_value=(
+            "https://bucket.s3.amazonaws.com/thumb",
+            "images/day_shareable/thumb.webp",
+            "https://bucket.s3.amazonaws.com/share",
+            "images/day_shareable/share.webp",
+        ),
+    ):
+        result = get_user_plan_day_details_service(token="tok", plan_id=plan_id, day_number=1)
+
+        assert result.thumbnail_url == "https://bucket.s3.amazonaws.com/thumb"
+        assert result.shareable_image_url == "https://bucket.s3.amazonaws.com/share"
+
+
 def test_is_completion_helpers_boolean_gateways():
     from pecha_api.plans.users.plan_users_service import is_day_completed
 


### PR DESCRIPTION
- Introduced new cache types for plan-specific details in `cache_enums.py`.
- Integrated cache invalidation logic in various services to ensure up-to-date plan day details.
- Updated `get_plan_day_details` to utilize caching for improved performance.
- Refactored related tests to cover new caching behavior and ensure correctness in plan day retrieval.