### PR TITLE
Enhance OpenAPI configuration and update API tags

### DIFF
--- a/pecha_api/app.py
+++ b/pecha_api/app.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI
 from starlette import status
 from fastapi.middleware.cors import CORSMiddleware
 from scalar_fastapi import get_scalar_api_reference
+from pecha_api.openapi_config import configure_openapi_tag_groups
 from pecha_api.auth.auth_service import retrieve_client_info
 from pecha_api.middleware.request_observability import RequestObservabilityMiddleware
 
@@ -74,9 +75,9 @@ api = FastAPI(
     title="Pecha API",
     description="This is the API documentation for Pecha application",
     root_path="/api/v1",
-    docs_url=None,  
+    docs_url="/doc",
     openapi_url="/openapi.json",
-    redoc_url=None,  
+    redoc_url="/redoc",
     lifespan=lifespan
 )
 api.include_router(auth_views.auth_router)
@@ -159,6 +160,7 @@ api.add_middleware(
     allow_headers=["*"],
 )
 api.add_middleware(RequestObservabilityMiddleware)
+configure_openapi_tag_groups(api)
 
 @api.get("/docs", include_in_schema=False)
 async def scalar_docs():

--- a/pecha_api/cataloger/cataloger_views.py
+++ b/pecha_api/cataloger/cataloger_views.py
@@ -11,7 +11,7 @@ from pecha_api.cataloger.cataloger_response_model import CatalogedTextsDetailsRe
 
 
 oauth2_scheme = HTTPBearer()
-cataloger_router = APIRouter(prefix="/cataloger", tags=["cataloger"])
+cataloger_router = APIRouter(prefix="/cataloger", tags=["CMS Cataloger"])
 
 
 @cataloger_router.get("/texts", status_code=status.HTTP_200_OK)

--- a/pecha_api/openapi_config.py
+++ b/pecha_api/openapi_config.py
@@ -1,0 +1,93 @@
+from collections import defaultdict
+
+from fastapi import FastAPI
+from fastapi.openapi.utils import get_openapi
+
+TAG_GROUP_ORDER = ("Texts", "Public", "User","CMS")
+
+TEXT_TAGS = frozenset(
+    {
+        "Segments",
+        "segments-v2",
+        "Texts",
+        "texts-v2",
+        "Terms",
+        "Sheets",
+        "Search",
+        "Topics",
+        "collections",
+        "collections-v2",
+        "Text Mapping",
+        "Groups",
+        "Share",
+        "Recitations",
+        "CMS Text Uploader",
+        "CMS Cataloger",
+    }
+)
+
+# Tags that live under /users paths but do not use a "User " prefix in the router.
+USER_TAGS = frozenset(
+    {
+        "Bookmarks",
+        "Push Devices",
+        "Mantra Counts",
+        "Recitation Collections",
+        "Daily Log",
+    }
+)
+
+
+def classify_openapi_tag(tag: str) -> str:
+    if tag.startswith("User "):
+        return "User"
+    if tag in USER_TAGS:
+        return "User"
+    if tag in TEXT_TAGS:
+        return "Texts"
+    if tag.startswith("CMS "):
+        return "CMS"
+    if tag.startswith("Public "):
+        return "Public"
+    return "Public"
+
+
+def collect_openapi_tags(schema: dict) -> list[str]:
+    tags: set[str] = set()
+    for tag_info in schema.get("tags", []):
+        tags.add(tag_info["name"])
+    for path_item in schema.get("paths", {}).values():
+        for operation in path_item.values():
+            if isinstance(operation, dict):
+                tags.update(operation.get("tags", []))
+    return sorted(tags)
+
+
+def build_x_tag_groups(schema: dict) -> list[dict]:
+    grouped: dict[str, list[str]] = defaultdict(list)
+    for tag in collect_openapi_tags(schema):
+        grouped[classify_openapi_tag(tag)].append(tag)
+    return [
+        {"name": group_name, "tags": grouped[group_name]}
+        for group_name in TAG_GROUP_ORDER
+        if grouped[group_name]
+    ]
+
+
+def configure_openapi_tag_groups(app: FastAPI) -> None:
+    def custom_openapi() -> dict:
+        if app.openapi_schema:
+            return app.openapi_schema
+
+        openapi_schema = get_openapi(
+            title=app.title,
+            version=app.version,
+            openapi_version=app.openapi_version,
+            description=app.description,
+            routes=app.routes,
+        )
+        openapi_schema["x-tagGroups"] = build_x_tag_groups(openapi_schema)
+        app.openapi_schema = openapi_schema
+        return app.openapi_schema
+
+    app.openapi = custom_openapi

--- a/pecha_api/plans/audio/tts_test_views.py
+++ b/pecha_api/plans/audio/tts_test_views.py
@@ -8,7 +8,7 @@ from starlette import status
 from pecha_api.plans.audio.tts_service import generate_tts_audio
 from pecha_api.plans.plans_enums import MonlamVoiceName, PlanAudioType
 
-tts_test_router = APIRouter(tags=["TTS Test"])
+tts_test_router = APIRouter(tags=["CMS TTS Test"])
 
 _TTS_TEST_HTML = Path(__file__).resolve().parent / "static" / "tts_test.html"
 

--- a/pecha_api/plans/auth/plan_auth_views.py
+++ b/pecha_api/plans/auth/plan_auth_views.py
@@ -28,7 +28,7 @@ from .plan_auth_services import (
 
 plan_auth_router = APIRouter(
     prefix="/cms/auth",
-    tags=["Plan Authentications"],
+    tags=["CMS Plan Authentications"],
 )
 
 

--- a/pecha_api/plans/groups/groups_views.py
+++ b/pecha_api/plans/groups/groups_views.py
@@ -66,14 +66,14 @@ _LANGUAGE_QUERY_DESCRIPTION = (
     "Render group metadata in this language; falls back to English (en) per group when missing. "
     "All groups are returned regardless of available metadata languages."
 )
-public_groups_router = APIRouter(prefix="/author/groups", tags=["Author Groups"])
+public_groups_router = APIRouter(prefix="/author/groups", tags=["Public Author Groups"])
 user_groups_router = APIRouter(
     prefix="/users/me/following/author/groups",
-    tags=["Author Groups"],
+    tags=["User Author Groups"],
 )
 user_joined_groups_router = APIRouter(
     prefix="/users/me/joined/author/groups",
-    tags=["Author Groups"],
+    tags=["User Author Groups"],
 )
 
 

--- a/pecha_api/plans/items/plan_items_views.py
+++ b/pecha_api/plans/items/plan_items_views.py
@@ -27,7 +27,7 @@ oauth2_scheme = HTTPBearer()
 
 items_router = APIRouter(
     prefix="/cms/plans",
-    tags=["Items"],
+    tags=["CMS Items"],
 )
 
 @items_router.post("/{plan_id}/days", status_code=status.HTTP_201_CREATED, response_model=List[ItemDTO])

--- a/pecha_api/plans/media/media_views.py
+++ b/pecha_api/plans/media/media_views.py
@@ -14,7 +14,7 @@ oauth2_scheme = HTTPBearer()
 
 media_router = APIRouter(
     prefix="/cms/media",
-    tags=["Media"]
+    tags=["CMS Media"]
 )
 
 

--- a/pecha_api/plans/notifications/day_notification_views.py
+++ b/pecha_api/plans/notifications/day_notification_views.py
@@ -21,7 +21,7 @@ oauth2_scheme = HTTPBearer()
 
 notifications_router = APIRouter(
     prefix="/cms/notifications",
-    tags=["Notifications"],
+    tags=["CMS Day Notifications"],
 )
 
 

--- a/pecha_api/plans/tasks/plan_tasks_views.py
+++ b/pecha_api/plans/tasks/plan_tasks_views.py
@@ -10,7 +10,7 @@ oauth2_scheme = HTTPBearer()
 # Create router for plan endpoints
 plans_router = APIRouter(
     prefix="/cms/tasks",
-    tags=["Task"]
+    tags=["CMS Tasks"]
 )
 
 

--- a/pecha_api/plans/tasks/sub_tasks/plan_sub_tasks_views.py
+++ b/pecha_api/plans/tasks/sub_tasks/plan_sub_tasks_views.py
@@ -11,7 +11,7 @@ from pecha_api.plans.audio.timestamp_service import delete_plan_subtask_timestam
 
 sub_tasks_router = APIRouter(
     prefix="/cms/sub-tasks",
-    tags=["Sub Tasks"]
+    tags=["CMS Sub Tasks"]
 )
 
 oauth2_scheme = HTTPBearer()

--- a/pecha_api/plans/tasks/sub_tasks/subtask_preset_views.py
+++ b/pecha_api/plans/tasks/sub_tasks/subtask_preset_views.py
@@ -15,7 +15,7 @@ from .subtask_preset_response_models import PresetRequest, PresetResponse
 oauth2_scheme = HTTPBearer()
 preset_router = APIRouter(
     prefix="/cms/sub-tasks",
-    tags=["SubTask Presets"]
+    tags=["CMS SubTask Presets"]
 )
 
 public_preset_router = APIRouter(

--- a/pecha_api/text_uploader/collections/uploader_collections_views.py
+++ b/pecha_api/text_uploader/collections/uploader_collections_views.py
@@ -5,7 +5,7 @@ from typing import Optional
 from pecha_api.collections.collections_service import get_collection_by_pecha_collection_id_service
 text_uploader_collections_router = APIRouter(
     prefix="/text-uploader/collections",
-    tags=["Text Uploader"]
+    tags=["CMS Text Uploader"]
 )
 
 @text_uploader_collections_router.get("/{pecha_collection_id}", status_code=status.HTTP_200_OK)

--- a/pecha_api/text_uploader/text_metadata/text_metadata_views.py
+++ b/pecha_api/text_uploader/text_metadata/text_metadata_views.py
@@ -8,7 +8,7 @@ from pecha_api.texts.texts_service import get_text_by_pecha_text_ids_service
 
 text_metadata_router = APIRouter(
     prefix="/text-uploader",
-    tags=["Text Uploader"]
+    tags=["CMS Text Uploader"]
 )
 
 @text_metadata_router.post("/list", status_code=status.HTTP_200_OK)

--- a/pecha_api/text_uploader/text_uploader_views.py
+++ b/pecha_api/text_uploader/text_uploader_views.py
@@ -9,7 +9,7 @@ oauth2_scheme = HTTPBearer()
 
 text_uploader_router = APIRouter(
     prefix="/text-uploader",
-    tags=["Text Uploader"]
+    tags=["CMS Text Uploader"]
 )
 
 @text_uploader_router.post("")


### PR DESCRIPTION
- Introduced `configure_openapi_tag_groups` function to organize OpenAPI tags into defined groups for better documentation clarity.
- Updated FastAPI configuration to set custom documentation URLs for OpenAPI and ReDoc.
- Modified various API routers to use more descriptive tags, including changing "cataloger" to "CMS Cataloger" and updating other tags to include "CMS" prefix for consistency.
- Added new `openapi_config.py` file to manage OpenAPI tag classification and grouping logic.