### PR TITLE
Refactor group enrollment logic and tradition handling

### DIFF
--- a/pecha_api/plans/groups/groups_response_models.py
+++ b/pecha_api/plans/groups/groups_response_models.py
@@ -13,11 +13,11 @@ from pecha_api.plans.groups.group_summary_models import (
 from pecha_api.plans.plans_enums import LanguageCode
 from pecha_api.plans.plans_response_models import PlanDTO
 from pecha_api.plans.series.series_response_models import SeriesListItemDTO
+from pecha_api.plans.tags.tag_response_models import TagSummaryDTO
 
 
 class GroupSeriesListItemDTO(SeriesListItemDTO):
-    is_group_enrolled: bool = False
-from pecha_api.plans.tags.tag_response_models import TagSummaryDTO
+    is_group_enrolled: Optional[bool] = None
 
 __all__ = [
     "AuthorGroupSummaryDTO",

--- a/pecha_api/plans/groups/groups_service.py
+++ b/pecha_api/plans/groups/groups_service.py
@@ -375,9 +375,11 @@ def _is_series_enrolled_for_group_context(
     expected_partner_id: Optional[UUID],
     *,
     is_enrolled_in_series: bool,
-) -> bool:
+) -> Optional[bool]:
     if not is_enrolled_in_series:
-        return False
+        return None
+    if enrollment_partner_id is None:
+        return None
     return enrollment_partner_id == expected_partner_id
 
 

--- a/pecha_api/traditions/tradition_repository.py
+++ b/pecha_api/traditions/tradition_repository.py
@@ -89,12 +89,34 @@ def ensure_tradition_exists(db: Session, tradition_code: str) -> UUID:
     return tradition_id
 
 
-def save_user_tradition(db: Session, user_id: UUID, tradition_code: str) -> UserTradition:
-    tradition_entry = get_tradition_entry(tradition_code)
-    if tradition_entry is None:
-        raise ValueError(f"Unknown tradition code: {tradition_code}")
+def ensure_custom_tradition_exists(db: Session, tradition_label: str) -> UUID:
+    tradition_id = tradition_id_from_code(tradition_label)
+    existing = db.query(Tradition).filter(Tradition.id == tradition_id).first()
+    if existing is not None:
+        return tradition_id
 
-    tradition_id = ensure_tradition_exists(db=db, tradition_code=tradition_code)
+    tradition = Tradition(
+        id=tradition_id,
+        parent_id=None,
+        regions=None,
+    )
+    db.add(tradition)
+    metadata = TraditionMetadata(
+        tradition_id=tradition_id,
+        language=LanguageCode.EN,
+        name=tradition_label,
+        other_names=None,
+    )
+    db.add(metadata)
+    db.commit()
+    return tradition_id
+
+
+def save_user_tradition(db: Session, user_id: UUID, tradition_code: str) -> UserTradition:
+    if get_tradition_entry(tradition_code) is not None:
+        tradition_id = ensure_tradition_exists(db=db, tradition_code=tradition_code)
+    else:
+        tradition_id = ensure_custom_tradition_exists(db=db, tradition_label=tradition_code)
 
     existing = (
         db.query(UserTradition)

--- a/pecha_api/traditions/tradition_response_models.py
+++ b/pecha_api/traditions/tradition_response_models.py
@@ -4,8 +4,6 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from pecha_api.traditions.tradition_taxonomy import list_tradition_codes
-
 
 class TraditionChatMessage(BaseModel):
     role: Literal["user", "assistant"]
@@ -38,10 +36,10 @@ class SaveUserTraditionRequest(BaseModel):
 
     @field_validator("tradition_code")
     @classmethod
-    def validate_tradition_code(cls, value: str) -> str:
+    def normalize_tradition_code(cls, value: str) -> str:
         normalized = value.strip()
-        if normalized not in list_tradition_codes():
-            raise ValueError("tradition_code must match a known tradition from the taxonomy")
+        if not normalized:
+            raise ValueError("tradition_code must not be empty")
         return normalized
 
 

--- a/pecha_api/traditions/tradition_service.py
+++ b/pecha_api/traditions/tradition_service.py
@@ -7,6 +7,7 @@ from fastapi import HTTPException
 from starlette import status
 
 from pecha_api.db.database import SessionLocal
+from pecha_api.plans.plans_enums import LanguageCode
 from pecha_api.traditions.llm_client import chat_with_worker
 from pecha_api.traditions.tradition_constants import DEFAULT_CHAT_LANGUAGE
 from pecha_api.traditions.tradition_llm_utils import parse_llm_json_response
@@ -155,17 +156,11 @@ async def save_user_tradition_service(
     current_user = validate_and_extract_user_details(token=token)
 
     with SessionLocal() as db:
-        try:
-            user_tradition = save_user_tradition(
-                db=db,
-                user_id=current_user.id,
-                tradition_code=save_request.tradition_code,
-            )
-        except ValueError as exc:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=str(exc),
-            ) from exc
+        user_tradition = save_user_tradition(
+            db=db,
+            user_id=current_user.id,
+            tradition_code=save_request.tradition_code,
+        )
 
         return _build_user_tradition_dto(
             user_tradition=user_tradition,
@@ -213,7 +208,7 @@ async def list_traditions_service(language: str = DEFAULT_CHAT_LANGUAGE) -> Trad
 
 
 def _build_user_tradition_dto_from_record(user_tradition, language: str) -> UserTraditionDTO:
-    tradition_code = _resolve_tradition_code(user_tradition.tradition_id)
+    tradition_code = _resolve_tradition_code(user_tradition)
     return _build_user_tradition_dto(
         user_tradition=user_tradition,
         tradition_code=tradition_code,
@@ -221,10 +216,18 @@ def _build_user_tradition_dto_from_record(user_tradition, language: str) -> User
     )
 
 
-def _resolve_tradition_code(tradition_id) -> str:
+def _resolve_tradition_code(user_tradition) -> str:
+    tradition_id = user_tradition.tradition_id
     for entry in load_tradition_taxonomy()["traditions"]:
         if tradition_id_from_code(entry["id"]) == tradition_id:
             return entry["id"]
+
+    if user_tradition.tradition and user_tradition.tradition.metadata_entries:
+        for metadata in user_tradition.tradition.metadata_entries:
+            if metadata.language == LanguageCode.EN:
+                return metadata.name
+        return user_tradition.tradition.metadata_entries[0].name
+
     return str(tradition_id)
 
 

--- a/tests/plans/groups/test_groups_service.py
+++ b/tests/plans/groups/test_groups_service.py
@@ -676,13 +676,13 @@ def test_is_series_enrolled_for_group_context():
     )
     assert _is_series_enrolled_for_group_context(
         None, None, is_enrolled_in_series=True
-    )
+    ) is None
     assert not _is_series_enrolled_for_group_context(
         partner_id, None, is_enrolled_in_series=True
     )
-    assert not _is_series_enrolled_for_group_context(
+    assert _is_series_enrolled_for_group_context(
         None, None, is_enrolled_in_series=False
-    )
+    ) is None
 
 
 def test_series_to_dtos_sets_partner_enrollment_for_authenticated_user():
@@ -738,7 +738,7 @@ def test_series_to_dtos_is_not_enrolled_without_user():
         )
 
     mock_enrollment_map.assert_not_called()
-    assert dtos[0].is_group_enrolled is False
+    assert dtos[0].is_group_enrolled is None
 
 
 def test_series_to_dtos_filters_metadata_by_language():


### PR DESCRIPTION
- Updated `is_group_enrolled` in `GroupSeriesListItemDTO` to be optional.
- Modified `_is_series_enrolled_for_group_context` to return `None` instead of `False` when not enrolled.
- Enhanced `save_user_tradition` to handle custom traditions and ensure existence checks.
- Renamed validation method in `SaveUserTraditionRequest` for clarity and improved error handling in tradition services.