### PR TITLE
Add internal routine notification views and configuration settings

### DIFF
--- a/pecha_api/app.py
+++ b/pecha_api/app.py
@@ -52,6 +52,7 @@ from pecha_api.collections import collections_openpecha_views
 from pecha_api.texts import texts_openpecha_views
 from pecha_api.texts.segments import segments_openpecha_views
 from pecha_api.routines import routines_views
+from pecha_api.routines.routine_notifications import internal_views as routine_notification_internal_views
 from pecha_api.notification import notification_views as cms_notification_views
 from pecha_api.verse_of_day import verse_of_day_views
 from pecha_api.calendar import calendar_views
@@ -134,6 +135,7 @@ api.include_router(cataloger_views.cataloger_router)
 api.include_router(text_metadata_views.text_metadata_router)
 api.include_router(uploader_collections_views.text_uploader_collections_router)
 api.include_router(routines_views.routines_router)
+api.include_router(routine_notification_internal_views.internal_routine_notifications_router)
 api.include_router(collections_openpecha_views.collections_v2_router)
 api.include_router(texts_openpecha_views.texts_v2_router)
 api.include_router(segments_openpecha_views.segments_v2_router)

--- a/pecha_api/config.py
+++ b/pecha_api/config.py
@@ -104,6 +104,11 @@ DEFAULTS = dict(
     WORKER_API_URL="",
     WORKER_LLM_MODEL="gemini-2.5-flash-lite",
 
+    # Internal routine notification dispatch (worker -> backend)
+    NOTIFICATION_DISPATCH_SECRET_TOKEN="",
+    NOTIFICATION_DEFAULT_TITLE="WebBuddhist",
+    NOTIFICATION_DEFAULT_BODY="Time for your daily practice.",
+
 )
 
 TIME_FORMAT_PATTERN = re.compile(r"^([01]\d|2[0-3]):[0-5]\d$")

--- a/pecha_api/routines/routine_notifications/dependencies.py
+++ b/pecha_api/routines/routine_notifications/dependencies.py
@@ -1,0 +1,22 @@
+import secrets
+
+from fastapi import Header, HTTPException
+from starlette import status
+
+from pecha_api.config import get
+
+
+async def verify_dispatch_token(
+    x_dispatch_token: str = Header(..., alias="X-Dispatch-Token"),
+) -> None:
+    expected = get("NOTIFICATION_DISPATCH_SECRET_TOKEN")
+    if not expected:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Dispatch endpoint is not configured",
+        )
+    if not secrets.compare_digest(x_dispatch_token, expected):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid dispatch token",
+        )

--- a/pecha_api/routines/routine_notifications/internal_views.py
+++ b/pecha_api/routines/routine_notifications/internal_views.py
@@ -1,0 +1,25 @@
+from fastapi import APIRouter, Depends
+from starlette import status
+
+from pecha_api.routines.routine_notifications.dependencies import verify_dispatch_token
+from pecha_api.routines.routine_notifications.routine_notification_response_models import (
+    RoutineNotificationTargetsResponse,
+)
+from pecha_api.routines.routine_notifications.routine_notification_service import (
+    get_routine_notification_targets,
+)
+
+internal_routine_notifications_router = APIRouter(
+    prefix="/internal",
+    tags=["Internal"],
+)
+
+
+@internal_routine_notifications_router.get(
+    "/routine-notification-targets",
+    status_code=status.HTTP_200_OK,
+)
+def routine_notification_targets(
+    _: None = Depends(verify_dispatch_token),
+) -> RoutineNotificationTargetsResponse:
+    return get_routine_notification_targets()

--- a/pecha_api/routines/routine_notifications/routine_notification_repository.py
+++ b/pecha_api/routines/routine_notifications/routine_notification_repository.py
@@ -1,0 +1,112 @@
+from dataclasses import dataclass
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from pecha_api.plans.items.plan_items_models import PlanItem
+from pecha_api.plans.notifications.day_notification_models import DayNotification
+from pecha_api.plans.notifications.day_notification_repository import get_notification_by_day_id
+from pecha_api.plans.plans_models import Plan
+from pecha_api.plans.series.series_metadata_model import SeriesMetadata
+from pecha_api.plans.series.series_model import Series
+from pecha_api.plans.users.plan_users_models import UserPlanProgress
+from pecha_api.plans.users.recitation_collection.recitation_collection_models import RecitationCollection
+from pecha_api.push_devices.push_device_models import PushDeviceToken
+from pecha_api.routines.routines_models import Routine, RoutineSession, RoutineTimeBlock
+
+
+@dataclass(frozen=True)
+class RoutineNotificationRow:
+    user_id: UUID
+    routine_timezone: str | None
+    time_block_id: UUID
+    time_block_time: str
+    time_block_created_at: datetime
+    session_type: str
+    source_id: UUID | None
+    device_token: str
+    platform: str
+
+
+def get_users_with_matching_timeblocks(db: Session) -> list[RoutineNotificationRow]:
+    stmt = (
+        select(
+            Routine.user_id,
+            Routine.timezone,
+            RoutineTimeBlock.id,
+            RoutineTimeBlock.time,
+            RoutineTimeBlock.created_at,
+            RoutineSession.session_type,
+            RoutineSession.source_id,
+            PushDeviceToken.token,
+            PushDeviceToken.platform,
+        )
+        .join(Routine, RoutineTimeBlock.routine_id == Routine.id)
+        .join(RoutineSession, RoutineSession.time_block_id == RoutineTimeBlock.id)
+        .join(PushDeviceToken, PushDeviceToken.user_id == Routine.user_id)
+        .where(
+            RoutineTimeBlock.notification_enabled.is_(True),
+            RoutineTimeBlock.deleted_at.is_(None),
+            Routine.deleted_at.is_(None),
+            PushDeviceToken.is_active.is_(True),
+        )
+    )
+
+    rows = db.execute(stmt).all()
+    return [
+        RoutineNotificationRow(
+            user_id=row.user_id,
+            routine_timezone=row.timezone,
+            time_block_id=row.id,
+            time_block_time=row.time,
+            time_block_created_at=row.created_at,
+            session_type=str(row.session_type),
+            source_id=row.source_id,
+            device_token=row.token,
+            platform=str(row.platform).lower(),
+        )
+        for row in rows
+    ]
+
+
+def get_plan_by_id(db: Session, plan_id: UUID) -> Plan | None:
+    return db.get(Plan, plan_id)
+
+
+def get_series_by_id(db: Session, series_id: UUID) -> Series | None:
+    return db.get(Series, series_id)
+
+
+def get_series_metadata(db: Session, series_id: UUID) -> SeriesMetadata | None:
+    stmt = (
+        select(SeriesMetadata)
+        .where(SeriesMetadata.series_id == series_id)
+        .limit(1)
+    )
+    return db.scalars(stmt).first()
+
+
+def get_user_plan_progress(db: Session, *, user_id: UUID, plan_id: UUID) -> UserPlanProgress | None:
+    stmt = select(UserPlanProgress).where(
+        UserPlanProgress.user_id == user_id,
+        UserPlanProgress.plan_id == plan_id,
+    )
+    return db.scalars(stmt).first()
+
+
+def get_plan_item_by_day_number(db: Session, *, plan_id: UUID, day_number: int) -> PlanItem | None:
+    stmt = select(PlanItem).where(
+        PlanItem.plan_id == plan_id,
+        PlanItem.day_number == day_number,
+    )
+    return db.scalars(stmt).first()
+
+
+def get_day_notification(db: Session, *, day_id: UUID) -> DayNotification | None:
+    return get_notification_by_day_id(db=db, day_id=day_id)
+
+
+def get_recitation_collection(db: Session, collection_id: UUID) -> RecitationCollection | None:
+    return db.get(RecitationCollection, collection_id)

--- a/pecha_api/routines/routine_notifications/routine_notification_response_models.py
+++ b/pecha_api/routines/routine_notifications/routine_notification_response_models.py
@@ -1,0 +1,34 @@
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+class PushDeviceTargetDTO(BaseModel):
+    token: str
+    platform: str
+
+
+class NotificationContentDTO(BaseModel):
+    title: str
+    body: str
+    custom_image_url: str | None = None
+
+
+class RoutineNotificationUserTargetDTO(BaseModel):
+    user_id: UUID
+    notification: NotificationContentDTO
+    push_devices: list[PushDeviceTargetDTO]
+
+
+class RoutineNotificationGroupDTO(BaseModel):
+    session_type: str
+    source_id: UUID | None
+    source_image_url: str | None = None
+    users: list[RoutineNotificationUserTargetDTO]
+
+
+class RoutineNotificationTargetsResponse(BaseModel):
+    generated_at: datetime
+    matched_time_utc: str
+    groups: list[RoutineNotificationGroupDTO]

--- a/pecha_api/routines/routine_notifications/routine_notification_service.py
+++ b/pecha_api/routines/routine_notifications/routine_notification_service.py
@@ -1,0 +1,297 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+from uuid import UUID
+
+from pecha_api.config import get
+from pecha_api.db.database import SessionLocal
+from pecha_api.routines.routine_notifications import routine_notification_repository as repo
+from pecha_api.routines.routine_notifications.routine_notification_repository import (
+    RoutineNotificationRow,
+)
+from pecha_api.routines.routine_notifications.routine_notification_response_models import (
+    NotificationContentDTO,
+    PushDeviceTargetDTO,
+    RoutineNotificationGroupDTO,
+    RoutineNotificationTargetsResponse,
+    RoutineNotificationUserTargetDTO,
+)
+
+SESSION_TYPE_PLAN = "PLAN"
+SESSION_TYPE_SERIES = "SERIES"
+SESSION_TYPE_RECITATION = "RECITATION"
+SESSION_TYPE_RECITATION_COLLECTION = "RECITATION_COLLECTION"
+SESSION_TYPE_ACCUMULATION = "ACCUMULATION"
+SESSION_TYPE_TIMER = "TIMER"
+IMAGE_TYPE_CUSTOM = "CUSTOM"
+
+
+def get_routine_notification_targets() -> RoutineNotificationTargetsResponse:
+    utc_now = datetime.now(timezone.utc)
+    with SessionLocal() as db:
+        rows = repo.get_users_with_matching_timeblocks(db)
+        filtered_rows = _filter_by_local_time(rows, utc_now)
+        groups = _build_groups(filtered_rows, db, utc_now)
+
+    return RoutineNotificationTargetsResponse(
+        generated_at=utc_now,
+        matched_time_utc=utc_now.strftime("%H:%M"),
+        groups=groups,
+    )
+
+
+def _filter_by_local_time(
+    rows: list[RoutineNotificationRow],
+    utc_now: datetime,
+) -> list[RoutineNotificationRow]:
+    matched: list[RoutineNotificationRow] = []
+    seen: set[tuple] = set()
+
+    for row in rows:
+        if not _local_time_matches(row.routine_timezone, row.time_block_created_at, row.time_block_time, utc_now):
+            continue
+
+        dedupe_key = (
+            row.user_id,
+            row.time_block_id,
+            row.session_type,
+            row.source_id,
+            row.device_token,
+        )
+        if dedupe_key in seen:
+            continue
+        seen.add(dedupe_key)
+        matched.append(row)
+
+    return matched
+
+
+def _local_time_matches(
+    routine_timezone: str | None,
+    time_block_created_at: datetime,
+    time_block_time: str,
+    utc_now: datetime,
+) -> bool:
+    local_hhmm = _local_hhmm(routine_timezone, time_block_created_at, utc_now)
+    if local_hhmm is None:
+        return False
+    return time_block_time == local_hhmm
+
+
+def _local_hhmm(
+    routine_timezone: str | None,
+    time_block_created_at: datetime,
+    utc_now: datetime,
+) -> str | None:
+    if routine_timezone:
+        try:
+            from pecha_api.timezone_utils import _resolve_timezone
+
+            local_now = utc_now.astimezone(_resolve_timezone(routine_timezone))
+            return local_now.strftime("%H:%M")
+        except Exception:
+            pass
+
+    offset = time_block_created_at.utcoffset()
+    if offset is None:
+        return None
+
+    local_now = utc_now + offset
+    return local_now.strftime("%H:%M")
+
+
+def _build_groups(
+    rows: list[RoutineNotificationRow],
+    db,
+    utc_now: datetime,
+) -> list[RoutineNotificationGroupDTO]:
+    grouped_rows: dict[tuple[str, UUID | None], list[RoutineNotificationRow]] = defaultdict(list)
+    for row in rows:
+        grouped_rows[(row.session_type, row.source_id)].append(row)
+
+    groups: list[RoutineNotificationGroupDTO] = []
+    for (session_type, source_id), session_rows in sorted(
+        grouped_rows.items(),
+        key=lambda item: (item[0][0], str(item[0][1])),
+    ):
+        source_image_url = _resolve_source_image_url(db, session_type, source_id)
+        users = _build_user_targets(db, session_type, source_id, session_rows, utc_now)
+        groups.append(
+            RoutineNotificationGroupDTO(
+                session_type=session_type,
+                source_id=source_id,
+                source_image_url=source_image_url,
+                users=users,
+            )
+        )
+
+    return groups
+
+
+def _build_user_targets(
+    db,
+    session_type: str,
+    source_id: UUID | None,
+    rows: list[RoutineNotificationRow],
+    utc_now: datetime,
+) -> list[RoutineNotificationUserTargetDTO]:
+    users_by_id: dict[UUID, list[RoutineNotificationRow]] = defaultdict(list)
+    for row in rows:
+        users_by_id[row.user_id].append(row)
+
+    user_targets: list[RoutineNotificationUserTargetDTO] = []
+    for user_id, user_rows in sorted(users_by_id.items(), key=lambda item: str(item[0])):
+        notification = _resolve_notification_content(
+            db,
+            session_type=session_type,
+            source_id=source_id,
+            user_id=user_id,
+            utc_now=utc_now,
+        )
+        devices = _collect_push_devices(user_rows)
+        user_targets.append(
+            RoutineNotificationUserTargetDTO(
+                user_id=user_id,
+                notification=notification,
+                push_devices=devices,
+            )
+        )
+
+    return user_targets
+
+
+def _collect_push_devices(rows: list[RoutineNotificationRow]) -> list[PushDeviceTargetDTO]:
+    devices: list[PushDeviceTargetDTO] = []
+    seen_tokens: set[str] = set()
+    for row in rows:
+        if row.device_token in seen_tokens:
+            continue
+        seen_tokens.add(row.device_token)
+        devices.append(
+            PushDeviceTargetDTO(
+                token=row.device_token,
+                platform=row.platform,
+            )
+        )
+    return devices
+
+
+def _resolve_source_image_url(db, session_type: str, source_id: UUID | None) -> str | None:
+    if source_id is None:
+        return None
+
+    if session_type == SESSION_TYPE_PLAN:
+        plan = repo.get_plan_by_id(db, source_id)
+        return plan.image_url if plan else None
+
+    if session_type == SESSION_TYPE_SERIES:
+        series = repo.get_series_by_id(db, source_id)
+        return series.image if series else None
+
+    if session_type == SESSION_TYPE_RECITATION_COLLECTION:
+        collection = repo.get_recitation_collection(db, source_id)
+        return collection.img_url if collection else None
+
+    return None
+
+
+def _resolve_notification_content(
+    db,
+    *,
+    session_type: str,
+    source_id: UUID | None,
+    user_id: UUID,
+    utc_now: datetime,
+) -> NotificationContentDTO:
+    default_title = get("NOTIFICATION_DEFAULT_TITLE")
+    default_body = get("NOTIFICATION_DEFAULT_BODY")
+
+    if session_type == SESSION_TYPE_PLAN and source_id is not None:
+        return _resolve_plan_notification(db, user_id=user_id, plan_id=source_id, utc_now=utc_now)
+
+    if session_type == SESSION_TYPE_SERIES and source_id is not None:
+        return _resolve_series_notification(db, series_id=source_id)
+
+    if session_type == SESSION_TYPE_RECITATION_COLLECTION and source_id is not None:
+        collection = repo.get_recitation_collection(db, source_id)
+        if collection:
+            return NotificationContentDTO(
+                title=collection.name,
+                body=default_body,
+                custom_image_url=collection.img_url,
+            )
+
+    if session_type in {
+        SESSION_TYPE_RECITATION,
+        SESSION_TYPE_ACCUMULATION,
+        SESSION_TYPE_TIMER,
+    }:
+        return NotificationContentDTO(
+            title=default_title,
+            body=default_body,
+            custom_image_url=None,
+        )
+
+    return NotificationContentDTO(
+        title=default_title,
+        body=default_body,
+        custom_image_url=None,
+    )
+
+
+def _resolve_plan_notification(
+    db,
+    *,
+    user_id: UUID,
+    plan_id: UUID,
+    utc_now: datetime,
+) -> NotificationContentDTO:
+    default_title = get("NOTIFICATION_DEFAULT_TITLE")
+    default_body = get("NOTIFICATION_DEFAULT_BODY")
+
+    plan = repo.get_plan_by_id(db, plan_id)
+    plan_title = plan.title if plan else default_title
+
+    day_number = _compute_current_day_number(
+        repo.get_user_plan_progress(db, user_id=user_id, plan_id=plan_id),
+        utc_now,
+    )
+    plan_item = repo.get_plan_item_by_day_number(db, plan_id=plan_id, day_number=day_number)
+    if plan_item is None:
+        return NotificationContentDTO(title=plan_title, body=default_body, custom_image_url=None)
+
+    day_notification = repo.get_day_notification(db, day_id=plan_item.id)
+    if day_notification is None:
+        return NotificationContentDTO(title=plan_title, body=default_body, custom_image_url=None)
+
+    custom_image_url = None
+    image_type = day_notification.image_type.value if day_notification.image_type else None
+    if image_type == IMAGE_TYPE_CUSTOM:
+        custom_image_url = day_notification.image_url
+
+    return NotificationContentDTO(
+        title=day_notification.title,
+        body=day_notification.body,
+        custom_image_url=custom_image_url,
+    )
+
+
+def _resolve_series_notification(db, *, series_id: UUID) -> NotificationContentDTO:
+    default_body = get("NOTIFICATION_DEFAULT_BODY")
+    metadata = repo.get_series_metadata(db, series_id)
+    title = metadata.title if metadata else get("NOTIFICATION_DEFAULT_TITLE")
+    return NotificationContentDTO(title=title, body=default_body, custom_image_url=None)
+
+
+def _compute_current_day_number(progress, utc_now: datetime) -> int:
+    if progress is None or progress.started_at is None:
+        return 1
+
+    started_at = progress.started_at
+    if started_at.tzinfo is None:
+        started_at = started_at.replace(tzinfo=timezone.utc)
+
+    started_date = started_at.date()
+    utc_today = utc_now.date()
+    return max(1, (utc_today - started_date).days + 1)

--- a/tests/routines/test_routine_notification_service.py
+++ b/tests/routines/test_routine_notification_service.py
@@ -1,0 +1,66 @@
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+from pecha_api.routines.routine_notifications.routine_notification_repository import (
+    RoutineNotificationRow,
+)
+from pecha_api.routines.routine_notifications.routine_notification_service import (
+    _compute_current_day_number,
+    _filter_by_local_time,
+    _local_time_matches,
+)
+
+
+def test_local_time_matches_prefers_routine_timezone():
+    utc_now = datetime(2026, 6, 23, 9, 30, tzinfo=timezone.utc)
+    created_at = datetime(2026, 1, 1, 8, 0, tzinfo=timezone.utc)
+
+    assert _local_time_matches("UTC", created_at, "09:30", utc_now) is True
+    assert _local_time_matches("UTC", created_at, "10:30", utc_now) is False
+
+
+def test_local_time_matches_using_created_at_offset_fallback():
+    created_at = datetime(2026, 1, 1, 8, 0, tzinfo=timezone(timedelta(hours=5, minutes=30)))
+    utc_now = datetime(2026, 6, 23, 4, 0, tzinfo=timezone.utc)
+
+    assert _local_time_matches(None, created_at, "09:30", utc_now) is True
+    assert _local_time_matches(None, created_at, "10:30", utc_now) is False
+
+
+def test_filter_by_local_time_deduplicates_rows():
+    user_id = uuid4()
+    time_block_id = uuid4()
+    created_at = datetime(2026, 1, 1, 8, 0, tzinfo=timezone(timedelta(hours=5, minutes=30)))
+    utc_now = datetime(2026, 6, 23, 4, 0, tzinfo=timezone.utc)
+    source_id = uuid4()
+
+    row = RoutineNotificationRow(
+        user_id=user_id,
+        routine_timezone=None,
+        time_block_id=time_block_id,
+        time_block_time="09:30",
+        time_block_created_at=created_at,
+        session_type="PLAN",
+        source_id=source_id,
+        device_token="token-1",
+        platform="android",
+    )
+    duplicate = RoutineNotificationRow(
+        user_id=user_id,
+        routine_timezone=None,
+        time_block_id=time_block_id,
+        time_block_time="09:30",
+        time_block_created_at=created_at,
+        session_type="PLAN",
+        source_id=source_id,
+        device_token="token-1",
+        platform="android",
+    )
+
+    filtered = _filter_by_local_time([row, duplicate], utc_now)
+    assert len(filtered) == 1
+
+
+def test_compute_current_day_number_defaults_to_one_without_progress():
+    utc_now = datetime(2026, 6, 23, 10, 0, tzinfo=timezone.utc)
+    assert _compute_current_day_number(None, utc_now) == 1


### PR DESCRIPTION
- Included `internal_routine_notifications_router` in the main API router.
- Added configuration options for notification dispatch, including secret token, default title, and body for routine notifications.