### PR TITLE
Refactor accumulator response models and services to utilize ImageUrl…

### DIFF
--- a/pecha_api/accumulator/accumulator_response_models.py
+++ b/pecha_api/accumulator/accumulator_response_models.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from uuid import UUID
 from .accumulator_enums import AccumulatorType
 from ..plans.plans_enums import LanguageCode
+from ..plans.media.media_response_models import ImageUrlModel
 
 
 class AccumulatorMetadataDTO(BaseModel):
@@ -121,7 +122,7 @@ class AccumulatorGroupDTO(BaseModel):
     group_accumulator_id: UUID
     group_id: UUID
     title: Optional[str] = None
-    image_key: Optional[str] = None
+    image: Optional[ImageUrlModel] = None
     target_count: Optional[int] = None
     user_total_count: int = Field(..., description="Authenticated user's total count for this group accumulator")
     is_joined: bool = Field(

--- a/pecha_api/accumulator/accumulator_service.py
+++ b/pecha_api/accumulator/accumulator_service.py
@@ -11,6 +11,7 @@ from ..uploads.S3_utils import generate_presigned_access_url
 from ..users.users_service import validate_and_extract_user_details
 from pecha_api.daily_log.daily_log_cache_service import invalidate_user_stats_cache
 from ..texts.texts_utils import TextUtils
+from ..plans.authors.plan_authors_service import get_image_url
 from .accumulator_repository import (
     get_all_accumulators,
     get_user_accumulators,
@@ -583,7 +584,7 @@ def get_accumulator_groups_service(
                     group_accumulator_id=item.group_accumulator.id,
                     group_id=item.group_accumulator.group_id,
                     title=item.group_accumulator.title,
-                    image_key=item.group_accumulator.image_key,
+                    image=get_image_url(item.group_accumulator.image_key),
                     target_count=item.group_accumulator.target_count,
                     user_total_count=item.user_total_count,
                     is_joined=item.is_joined,

--- a/pecha_api/plans/groups/groups_service.py
+++ b/pecha_api/plans/groups/groups_service.py
@@ -81,8 +81,12 @@ from pecha_api.group_accumulator.group_accumulator_repository import (
 from pecha_api.plans.series.series_repository import (
     get_active_plan_count_map_by_series_ids,
     get_enrolled_count_map_by_group_and_series_ids,
+    get_series_plan_schedule_by_series_ids,
 )
-from pecha_api.plans.series.series_service import _series_to_list_item_dto
+from pecha_api.plans.series.series_service import (
+    _series_schedule_from_plans,
+    _series_to_list_item_dto,
+)
 from pecha_api.plans.shared.metadata_utils import (
     format_metadata_response,
     filter_by_language_with_fallback,
@@ -422,23 +426,38 @@ def _series_to_dtos(
         enrollment_partner_map = get_user_series_enrollment_partner_map(
             db=db, user_id=user_id, series_ids=series_ids
         )
-    return [
-        GroupSeriesListItemDTO(
-            **_series_to_list_item_dto(
-                series,
-                plan_count=plan_count_map.get(series.id, 0),
-                enrolled_count=enrolled_count_map.get(series.id, 0),
-                language=language,
-                fallback=True,
-            ).model_dump(),
-            is_group_enrolled=_is_series_enrolled_for_group_context(
-                enrollment_partner_id=enrollment_partner_map.get(series.id),
-                expected_partner_id=partner_id_map.get(series.id),
-                is_enrolled_in_series=series.id in enrollment_partner_map,
-            ),
+    plans_by_series_id = get_series_plan_schedule_by_series_ids(
+        db=db,
+        series_ids=series_ids,
+    )
+    series_dtos: List[GroupSeriesListItemDTO] = []
+    for series in series_list:
+        start_date, end_date, total_days = _series_schedule_from_plans(
+            plans_by_series_id.get(series.id, []),
+            published_only=published_only,
+            language=language,
+            fallback=True,
         )
-        for series in series_list
-    ]
+        series_dtos.append(
+            GroupSeriesListItemDTO(
+                **_series_to_list_item_dto(
+                    series,
+                    plan_count=plan_count_map.get(series.id, 0),
+                    enrolled_count=enrolled_count_map.get(series.id, 0),
+                    language=language,
+                    start_date=start_date,
+                    end_date=end_date,
+                    total_days=total_days,
+                    fallback=True,
+                ).model_dump(),
+                is_group_enrolled=_is_series_enrolled_for_group_context(
+                    enrollment_partner_id=enrollment_partner_map.get(series.id),
+                    expected_partner_id=partner_id_map.get(series.id),
+                    is_enrolled_in_series=series.id in enrollment_partner_map,
+                ),
+            )
+        )
+    return series_dtos
 
 
 def _language_value(language) -> str:

--- a/pecha_api/plans/series/public_series_view.py
+++ b/pecha_api/plans/series/public_series_view.py
@@ -39,9 +39,14 @@ async def get_series_list(
 )
 async def get_featured_series(
     language: Annotated[
-        Optional[str],
-        Query(description=language_query_description("Filter metadata by language", lowercase_example=True)),
-    ] = None,
+        str,
+        Query(
+            description=(
+                f"{language_query_description('Filter metadata by language', lowercase_example=True)}. "
+                "Defaults to 'en'."
+            ),
+        ),
+    ] = "en",
     limit: Annotated[int, Query()] = 10,
 ):
     return get_random_featured_series(language=language, limit=limit)

--- a/pecha_api/plans/series/series_repository.py
+++ b/pecha_api/plans/series/series_repository.py
@@ -768,7 +768,6 @@ def get_series_paginated(
 def get_random_featured_published_series(
     db: Session,
     limit: int = 10,
-    language: Optional[str] = None,
 ) -> Tuple[List[Tuple[Series, int, int]], int]:
     plan_count = _series_active_plans_count_subquery(published_only=True).label("plan_count")
     filters = [
@@ -776,16 +775,6 @@ def get_random_featured_published_series(
         Series.featured.is_(True),
         Series.status == PlanStatus.PUBLISHED,
     ]
-    if language:
-        language_upper = language.upper()
-        filters.append(
-            exists(
-                select(1).where(
-                    SeriesMetadata.series_id == Series.id,
-                    SeriesMetadata.language == language_upper,
-                )
-            )
-        )
     query = (
         db.query(Series, plan_count)
         .options(selectinload(Series.metadata_entries))

--- a/pecha_api/plans/series/series_service.py
+++ b/pecha_api/plans/series/series_service.py
@@ -445,11 +445,12 @@ def get_random_featured_series(
 ) -> SeriesListResponse:
     from pecha_api.plans.response_message import NO_FEATURED_SERIES_FOUND
 
+    language = language or "en"
+
     with SessionLocal() as db_session:
         rows, total = get_random_featured_published_series(
             db=db_session,
             limit=limit,
-            language=language,
         )
         if total == 0:
             raise HTTPException(
@@ -473,6 +474,7 @@ def get_random_featured_series(
             plans_by_series_id.get(row.id, []),
             published_only=True,
             language=language,
+            fallback=True,
         )
         series_dtos.append(
             _series_to_list_item_dto(
@@ -484,20 +486,20 @@ def get_random_featured_series(
                 start_date=start_date,
                 end_date=end_date,
                 total_days=total_days,
+                fallback=True,
             )
         )
-    if language:
-        series_dtos = [dto for dto in series_dtos if dto.metadata is not None]
-        if not series_dtos:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=NO_FEATURED_SERIES_FOUND,
-            )
+    series_dtos = [dto for dto in series_dtos if dto.metadata is not None]
+    if not series_dtos:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=NO_FEATURED_SERIES_FOUND,
+        )
     return SeriesListResponse(
         series=series_dtos,
         skip=0,
         limit=limit,
-        total=total,
+        total=len(series_dtos),
     )
 
 

--- a/tests/accumulator/test_accumulator_service.py
+++ b/tests/accumulator/test_accumulator_service.py
@@ -1503,6 +1503,7 @@ class TestGetAccumulatorGroupsService:
         assert result.groups[0].target_count == 100000
         assert result.groups[0].user_total_count == 1234
         assert result.groups[0].is_joined is True
+        assert result.groups[0].image is None
 
         # Verify second group
         assert result.groups[1].group_id == group_id_2
@@ -1510,6 +1511,7 @@ class TestGetAccumulatorGroupsService:
         assert result.groups[1].target_count == 50000
         assert result.groups[1].user_total_count == 567
         assert result.groups[1].is_joined is False
+        assert result.groups[1].image is None
 
         mock_validate.assert_called_once_with(token=token)
         mock_get_accumulator.assert_called_once_with(mock_db, accumulator_id)
@@ -1521,6 +1523,63 @@ class TestGetAccumulatorGroupsService:
             limit=20,
             joined_only=False,
         )
+
+    @patch('pecha_api.accumulator.accumulator_service.get_image_url')
+    @patch('pecha_api.accumulator.accumulator_service.SessionLocal')
+    @patch('pecha_api.accumulator.accumulator_service.get_groups_by_accumulator_id')
+    @patch('pecha_api.accumulator.accumulator_service.get_accumulator_by_id')
+    @patch('pecha_api.accumulator.accumulator_service.validate_and_extract_user_details')
+    def test_get_accumulator_groups_service_returns_image_url(
+        self, mock_validate, mock_get_accumulator, mock_get_groups, mock_session, mock_get_image_url
+    ):
+        """Test group accumulator image is returned as presigned URL, not raw key."""
+        from pecha_api.accumulator.accumulator_repository import GroupAccumulatorWithUserCount
+        from pecha_api.plans.media.media_response_models import ImageUrlModel
+
+        user_id = uuid4()
+        accumulator_id = uuid4()
+        group_id = uuid4()
+        token = "valid_token"
+        image_key = "groups/abc123/cover.jpg"
+        image_model = ImageUrlModel(
+            thumbnail="https://example.com/thumb.jpg",
+            medium="https://example.com/medium.jpg",
+            original="https://example.com/original.jpg",
+        )
+
+        mock_validate.return_value = TestDataFactory.create_mock_user(user_id=user_id)
+        mock_db = MagicMock()
+        mock_session.return_value.__enter__.return_value = mock_db
+        mock_get_accumulator.return_value = TestDataFactory.create_mock_accumulator(
+            accumulator_id=accumulator_id
+        )
+        mock_get_image_url.return_value = image_model
+
+        group_acc = MagicMock()
+        group_acc.id = uuid4()
+        group_acc.group_id = group_id
+        group_acc.title = "Group Practice"
+        group_acc.target_count = 100000
+        group_acc.start_date = None
+        group_acc.end_date = None
+        group_acc.created_at = datetime.utcnow()
+        group_acc.image_key = image_key
+
+        mock_get_groups.return_value = (
+            [GroupAccumulatorWithUserCount(group_acc, 100, is_joined=True)],
+            1,
+        )
+
+        result = get_accumulator_groups_service(
+            token=token,
+            accumulator_id=accumulator_id,
+            skip=0,
+            limit=20,
+        )
+
+        mock_get_image_url.assert_called_once_with(image_key)
+        assert result.groups[0].image == image_model
+        assert "image_key" not in AccumulatorGroupDTO.model_fields
 
     @patch('pecha_api.accumulator.accumulator_service.SessionLocal')
     @patch('pecha_api.accumulator.accumulator_service.get_groups_by_accumulator_id')

--- a/tests/plans/groups/test_groups_service.py
+++ b/tests/plans/groups/test_groups_service.py
@@ -705,6 +705,9 @@ def test_series_to_dtos_sets_partner_enrollment_for_authenticated_user():
     ), patch(
         "pecha_api.plans.groups.groups_service.get_user_series_enrollment_partner_map",
         return_value={series.id: partner_id},
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_series_plan_schedule_by_series_ids",
+        return_value={},
     ):
         dtos = _series_to_dtos(
             db=mock_db,
@@ -733,7 +736,10 @@ def test_series_to_dtos_is_not_enrolled_without_user():
         return_value={series.id: partner_id},
     ), patch(
         "pecha_api.plans.groups.groups_service.get_user_series_enrollment_partner_map",
-    ) as mock_enrollment_map:
+    ) as mock_enrollment_map, patch(
+        "pecha_api.plans.groups.groups_service.get_series_plan_schedule_by_series_ids",
+        return_value={},
+    ):
         dtos = _series_to_dtos(
             db=mock_db,
             series_list=[series],
@@ -754,6 +760,9 @@ def test_series_to_dtos_filters_metadata_by_language():
     ), patch(
         "pecha_api.plans.groups.groups_service.get_series_partner_id_map_for_group",
         return_value={},
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_series_plan_schedule_by_series_ids",
+        return_value={},
     ):
         all_metadata = _series_to_dtos(db=mock_db, series_list=[series], group_id=group_id)
         bo_metadata = _series_to_dtos(db=mock_db, series_list=[series], group_id=group_id, language="bo")
@@ -766,6 +775,63 @@ def test_series_to_dtos_filters_metadata_by_language():
     # No metadata for the requested language falls back to English.
     assert missing_metadata[0].metadata.title == "English Series"
     assert missing_metadata[0].metadata.language == "EN"
+
+
+def test_series_to_dtos_includes_schedule_from_plans():
+    from pecha_api.plans.plans_enums import PlanStatus
+    from pecha_api.plans.series.series_repository import SeriesPlanScheduleRow
+
+    group_id = uuid4()
+    series = _make_series_with_metadata()
+    series_start = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    last_plan_start = datetime(2026, 6, 10, tzinfo=timezone.utc)
+    mock_db = MagicMock()
+    schedule_rows = {
+        series.id: [
+            SeriesPlanScheduleRow(
+                series_id=series.id,
+                status=PlanStatus.PUBLISHED,
+                language=LanguageCode.BO,
+                display_order=0,
+                start_date=series_start,
+                deleted_at=None,
+                total_days=3,
+            ),
+            SeriesPlanScheduleRow(
+                series_id=series.id,
+                status=PlanStatus.PUBLISHED,
+                language=LanguageCode.BO,
+                display_order=1,
+                start_date=last_plan_start,
+                deleted_at=None,
+                total_days=2,
+            ),
+        ]
+    }
+    with patch(
+        "pecha_api.plans.groups.groups_service.get_active_plan_count_map_by_series_ids",
+        return_value={series.id: 2},
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_enrolled_count_map_by_group_and_series_ids",
+        return_value={series.id: 0},
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_series_partner_id_map_for_group",
+        return_value={},
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_series_plan_schedule_by_series_ids",
+        return_value=schedule_rows,
+    ):
+        dtos = _series_to_dtos(
+            db=mock_db,
+            series_list=[series],
+            group_id=group_id,
+            language="bo",
+            published_only=True,
+        )
+
+    assert dtos[0].start_date == series_start
+    assert dtos[0].end_date == datetime(2026, 6, 11, tzinfo=timezone.utc)
+    assert dtos[0].total_days == 5
 
 
 def test_group_detail_series_metadata_filtered_by_language():
@@ -784,6 +850,9 @@ def test_group_detail_series_metadata_filtered_by_language():
         return_value={series.id: 0},
     ), patch(
         "pecha_api.plans.groups.groups_service.get_series_partner_id_map_for_group",
+        return_value={},
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_series_plan_schedule_by_series_ids",
         return_value={},
     ):
         detail_all = _group_to_detail(group, db=mock_db)
@@ -813,6 +882,9 @@ def test_get_author_group_detail_series_metadata_filtered_by_language():
     ), patch(
         "pecha_api.plans.groups.groups_service.get_active_plan_count_map_by_series_ids",
         return_value={series.id: 0},
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_series_plan_schedule_by_series_ids",
+        return_value={},
     ):
         _session_local_context(mock_session)
         result = get_author_group_detail(group_id=group.id, language="bo")
@@ -844,6 +916,9 @@ def test_get_cms_group_detail_series_metadata_filtered_by_language():
     ), patch(
         "pecha_api.plans.groups.groups_service.get_active_plan_count_map_by_series_ids",
         return_value={series.id: 0},
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_series_plan_schedule_by_series_ids",
+        return_value={},
     ):
         _session_local_context(mock_session)
         result = get_cms_group_detail(token="t", group_id=group.id, language="bo")

--- a/tests/plans/series/test_series_repository.py
+++ b/tests/plans/series/test_series_repository.py
@@ -605,19 +605,20 @@ def test_get_series_paginated_published_only_does_not_add_series_filter():
     assert total == 0
 
 
-def test_get_random_featured_published_series_with_language_applies_metadata_filter():
+def test_get_random_featured_published_series_ignores_language_parameter():
     db = _make_session_mock()
+    row = MagicMock(spec=Series)
 
-    db.query.return_value = _random_featured_query_chain([], 0)
+    db.query.return_value = _random_featured_query_chain([row], 1)
 
-    rows, total = get_random_featured_published_series(db=db, limit=10, language="bo")
+    rows, total = get_random_featured_published_series(db=db, limit=10)
 
-    assert rows == []
-    assert total == 0
+    assert total == 1
+    assert rows == [(row, 0, 0)]
     filtered = db.query.return_value.options.return_value.filter
     assert filtered.call_count == 1
     filter_args = filtered.call_args[0]
-    assert len(filter_args) == 4
+    assert len(filter_args) == 3
 
 
 def test_get_random_featured_published_series_without_language_uses_base_filters():

--- a/tests/plans/series/test_series_service.py
+++ b/tests/plans/series/test_series_service.py
@@ -1768,7 +1768,7 @@ def test_get_filtered_series_passes_language_to_repository():
     assert call_kwargs["status"] == PlanStatus.PUBLISHED
 
 
-def test_get_random_featured_series_returns_featured_series_without_language_filter():
+def test_get_random_featured_series_defaults_to_english_when_language_not_provided():
     row = MagicMock()
     row.id = uuid.uuid4()
     row.metadata_entries = [
@@ -1783,22 +1783,24 @@ def test_get_random_featured_series_returns_featured_series_without_language_fil
 
     with patch("pecha_api.plans.series.series_service.SessionLocal") as mock_session_local, \
          patch("pecha_api.plans.series.series_service.get_random_featured_published_series",
-               return_value=([(row, 4, 2)], 1)), \
+               return_value=([(row, 4, 2)], 1)) as mock_repo, \
          patch("pecha_api.plans.series.series_service._group_summaries_for_series_rows",
                return_value={}):
         _session_local_context(mock_session_local)
 
         result = get_random_featured_series(limit=10)
 
+    assert mock_repo.call_args.kwargs["limit"] == 10
     assert len(result.series) == 1
     assert result.total == 1
     assert result.series[0].featured is True
     assert result.series[0].plan_count == 4
     assert result.series[0].enrolled_count == 2
-    assert len(result.series[0].metadata) == 2
+    assert result.series[0].metadata.title == "Featured"
+    assert result.series[0].metadata.language == "EN"
 
 
-def test_get_random_featured_series_passes_language_to_repository():
+def test_get_random_featured_series_passes_limit_to_repository():
     with patch("pecha_api.plans.series.series_service.SessionLocal") as mock_session_local, \
          patch("pecha_api.plans.series.series_service.get_random_featured_published_series",
                return_value=([], 0)) as mock_repo:
@@ -1809,11 +1811,10 @@ def test_get_random_featured_series_passes_language_to_repository():
 
     assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
     call_kwargs = mock_repo.call_args.kwargs
-    assert call_kwargs["language"] == "bo"
     assert call_kwargs["limit"] == 10
 
 
-def test_get_random_featured_series_excludes_series_without_requested_language_metadata():
+def test_get_random_featured_series_falls_back_to_en_metadata_when_requested_language_missing():
     row_with_bo = MagicMock()
     row_with_bo.id = uuid.uuid4()
     row_with_bo.metadata_entries = [_metadata_entry(title="བོད་", language=LanguageCode.BO)]
@@ -1841,25 +1842,28 @@ def test_get_random_featured_series_excludes_series_without_requested_language_m
 
         result = get_random_featured_series(language="bo", limit=10)
 
-    assert len(result.series) == 1
+    assert len(result.series) == 2
     assert result.series[0].id == row_with_bo.id
     assert result.series[0].metadata.title == "བོད་"
     assert result.series[0].metadata.language == "BO"
+    assert result.series[1].id == row_en_only.id
+    assert result.series[1].metadata.title == "English only"
+    assert result.series[1].metadata.language == "EN"
 
 
-def test_get_random_featured_series_returns_404_when_no_metadata_for_language():
-    row_en_only = MagicMock()
-    row_en_only.id = uuid.uuid4()
-    row_en_only.metadata_entries = [_metadata_entry(title="English only", language=LanguageCode.EN)]
-    row_en_only.image = None
-    row_en_only.author_id = uuid.uuid4()
-    row_en_only.group_id = None
-    row_en_only.featured = True
-    row_en_only.status = PlanStatus.PUBLISHED
+def test_get_random_featured_series_returns_404_when_no_metadata_available():
+    row_no_metadata = MagicMock()
+    row_no_metadata.id = uuid.uuid4()
+    row_no_metadata.metadata_entries = []
+    row_no_metadata.image = None
+    row_no_metadata.author_id = uuid.uuid4()
+    row_no_metadata.group_id = None
+    row_no_metadata.featured = True
+    row_no_metadata.status = PlanStatus.PUBLISHED
 
     with patch("pecha_api.plans.series.series_service.SessionLocal") as mock_session_local, \
          patch("pecha_api.plans.series.series_service.get_random_featured_published_series",
-               return_value=([(row_en_only, 1, 0)], 1)), \
+               return_value=([(row_no_metadata, 1, 0)], 1)), \
          patch("pecha_api.plans.series.series_service._group_summaries_for_series_rows",
                return_value={}):
         _session_local_context(mock_session_local)

--- a/tests/plans/series/test_series_views.py
+++ b/tests/plans/series/test_series_views.py
@@ -127,7 +127,7 @@ def test_get_featured_series_success(sample_series_list_response):
         assert response.status_code == status.HTTP_200_OK
         data = response.json()
 
-        mock_service.assert_called_once_with(language=None, limit=10)
+        mock_service.assert_called_once_with(language="en", limit=10)
         assert len(data["series"]) == 1
         item = data["series"][0]
         assert item["id"] == str(featured_item.id)


### PR DESCRIPTION
…Model

- Updated `AccumulatorGroupDTO` to replace `image_key` with `image` of type `ImageUrlModel`, enhancing the structure of group accumulator responses.
- Modified the `get_accumulator_groups_service` to fetch the image URL using `get_image_url`, ensuring that the image is returned as a presigned URL instead of a raw key.
- Adjusted tests to validate the new image handling in accumulator group responses, confirming that the image URL is correctly retrieved and included in the service output.