### PR TITLE
Refactor push device token management

### DIFF
--- a/pecha_api/assets/chinese_timezone.json
+++ b/pecha_api/assets/chinese_timezone.json
@@ -1,0 +1,66 @@
+[
+    {
+      "id": "Asia/Shanghai",
+      "type": "Canonical",
+      "region": "Mainland China",
+      "standardName": "China Standard Time",
+      "abbreviation": "CST",
+      "utcOffset": "+08:00"
+    },
+    {
+      "id": "Asia/Urumqi",
+      "type": "Canonical",
+      "region": "Xinjiang (Local unofficial time)",
+      "standardName": "Xinjiang Time",
+      "abbreviation": "XJT",
+      "utcOffset": "+06:00"
+    },
+    {
+      "id": "Asia/Hong_Kong",
+      "type": "Canonical",
+      "region": "Hong Kong SAR",
+      "standardName": "Hong Kong Time",
+      "abbreviation": "HKT",
+      "utcOffset": "+08:00"
+    },
+    {
+      "id": "Asia/Macau",
+      "type": "Canonical",
+      "region": "Macau SAR",
+      "standardName": "Macau Standard Time",
+      "abbreviation": "MST",
+      "utcOffset": "+08:00"
+    },
+    {
+      "id": "Asia/Chongqing",
+      "type": "Link (Alias to Asia/Shanghai)",
+      "region": "Mainland China (Legacy)",
+      "standardName": "China Standard Time",
+      "abbreviation": "CST",
+      "utcOffset": "+08:00"
+    },
+    {
+      "id": "Asia/Harbin",
+      "type": "Link (Alias to Asia/Shanghai)",
+      "region": "Mainland China (Legacy)",
+      "standardName": "China Standard Time",
+      "abbreviation": "CST",
+      "utcOffset": "+08:00"
+    },
+    {
+      "id": "Asia/Kashgar",
+      "type": "Link (Alias to Asia/Urumqi)",
+      "region": "Xinjiang (Legacy)",
+      "standardName": "Xinjiang Time",
+      "abbreviation": "XJT",
+      "utcOffset": "+06:00"
+    },
+    {
+      "id": "PRC",
+      "type": "Link (Alias to Asia/Shanghai)",
+      "region": "Mainland China (System Alias)",
+      "standardName": "China Standard Time",
+      "abbreviation": "CST",
+      "utcOffset": "+08:00"
+    }
+  ]

--- a/pecha_api/bookmarks/bookmark_utils.py
+++ b/pecha_api/bookmarks/bookmark_utils.py
@@ -44,6 +44,11 @@ from pecha_api.accumulator.accumulator_service import (
     generate_mala_image_presigned_url,
     resolve_accumulator_bookmark_mala_image_url,
 )
+from pecha_api.texts.first_segment_preview_service import (
+    build_first_segment_preview_for_text,
+    build_first_segment_previews_for_texts,
+    resolve_segment_by_ref,
+)
 from pecha_api.mantra.mantra_repository import get_mantra_by_id
 from pecha_api.timers.timer_repository import get_timer_by_id
 
@@ -89,23 +94,12 @@ def _text_language_code(text) -> str:
     return text.language if isinstance(text.language, str) else str(text.language)
 
 
-async def _resolve_segment_by_ref(segment_ref: str) -> Optional[Segment]:
-    try:
-        UUID(segment_ref)
-        segment = await get_segment_by_id(segment_id=segment_ref)
-        if segment:
-            return segment
-    except ValueError:
-        pass
-    return await Segment.get_segment_by_pecha_segment_id(pecha_segment_id=segment_ref)
-
-
 async def _resolve_text_segment(
     text_id: str,
     verse_id: Optional[str],
 ) -> tuple[Optional[str], Optional[Segment]]:
     if verse_id:
-        segment = await _resolve_segment_by_ref(verse_id)
+        segment = await resolve_segment_by_ref(verse_id)
         if segment and segment.text_id == text_id:
             return str(segment.id), segment
 
@@ -127,10 +121,13 @@ async def enrich_text_bookmark(
 ) -> dict:
     verse_id: Optional[str] = None
     text_id: Optional[str] = None
+    segment: Optional[Segment] = None
+    segment_id: Optional[str] = None
+    use_first_segment_preview = False
 
     if bookmark.type == BookmarkType.VERSE:
         verse_id = bookmark.source_id
-        segment = await _resolve_segment_by_ref(verse_id)
+        segment = await resolve_segment_by_ref(verse_id)
         if not segment:
             return {}
         text_id = segment.text_id
@@ -138,12 +135,18 @@ async def enrich_text_bookmark(
     elif bookmark.type == BookmarkType.TEXT:
         text_id = bookmark.source_id
         if bookmark.name:
-            candidate = await _resolve_segment_by_ref(bookmark.name)
+            candidate = await resolve_segment_by_ref(bookmark.name)
             if candidate and candidate.text_id == text_id:
                 verse_id = bookmark.name
-        segment_id, segment = await _resolve_text_segment(text_id=text_id, verse_id=verse_id)
-        if not segment_id:
-            return {}
+        if verse_id:
+            segment_id, segment = await _resolve_text_segment(
+                text_id=text_id,
+                verse_id=verse_id,
+            )
+            if not segment_id:
+                return {}
+        else:
+            use_first_segment_preview = True
     else:
         return {}
 
@@ -156,7 +159,7 @@ async def enrich_text_bookmark(
     else:
         text = await get_texts_by_id(text_id=text_id)
 
-    if language and segment and text_id != segment.text_id:
+    if not use_first_segment_preview and language and segment and text_id != segment.text_id:
         localized_segment = await _resolve_localized_segment(
             segment=segment,
             target_text_id=text_id,
@@ -166,7 +169,16 @@ async def enrich_text_bookmark(
             segment_id = str(segment.id)
 
     segment_dto = None
-    if segment_id and segment:
+    if use_first_segment_preview:
+        preview = await build_first_segment_preview_for_text(text_id)
+        if not preview:
+            return {}
+        segment_id, preview_content = preview
+        segment_dto = BookmarkSegmentDTO(
+            id=segment_id,
+            content=preview_content,
+        )
+    elif segment_id and segment:
         segment_dto = BookmarkSegmentDTO(
             id=segment_id,
             content=segment.content,

--- a/pecha_api/push_devices/push_device_repository.py
+++ b/pecha_api/push_devices/push_device_repository.py
@@ -1,4 +1,3 @@
-from datetime import datetime, timezone
 from typing import List, Optional
 from uuid import UUID
 
@@ -83,48 +82,34 @@ def get_active_push_device_tokens_by_user_id(db: Session, user_id: UUID) -> List
     )
 
 
-def upsert_push_device_token(
+def delete_push_device_token_by_token(
     db: Session,
-    user_id: UUID,
     token: str,
-    platform: PushPlatform,
-    device_id: Optional[str] = None,
+    exclude_id: Optional[UUID] = None,
+) -> None:
+    query = db.query(PushDeviceToken).filter(PushDeviceToken.token == token)
+    if exclude_id is not None:
+        query = query.filter(PushDeviceToken.id != exclude_id)
+
+    conflicting_records = query.all()
+    if not conflicting_records:
+        return
+
+    for conflicting in conflicting_records:
+        db.delete(conflicting)
+    db.flush()
+
+
+def save_push_device_token(
+    db: Session,
+    push_device_token: PushDeviceToken,
+    is_new: bool = False,
 ) -> PushDeviceToken:
-    now = datetime.now(timezone.utc)
-
-    existing_by_token = get_push_device_token_by_token(db=db, token=token)
-    if existing_by_token:
-        existing_by_token.user_id = user_id
-        existing_by_token.platform = platform
-        if device_id is not None:
-            existing_by_token.device_id = device_id
-        existing_by_token.is_active = True
-        existing_by_token.updated_at = now
-        return _commit_push_device_token(db=db, push_device_token=existing_by_token)
-
-    if device_id is not None:
-        existing_by_device = get_push_device_token_by_user_and_device_id(
-            db=db,
-            user_id=user_id,
-            device_id=device_id,
-        )
-        if existing_by_device:
-            existing_by_device.token = token
-            existing_by_device.platform = platform
-            existing_by_device.is_active = True
-            existing_by_device.updated_at = now
-            return _commit_push_device_token(db=db, push_device_token=existing_by_device)
-
-    push_device_token = PushDeviceToken(
-        user_id=user_id,
-        token=token,
-        platform=platform,
-        device_id=device_id,
-        is_active=True,
-        created_at=now,
-        updated_at=now,
+    return _commit_push_device_token(
+        db=db,
+        push_device_token=push_device_token,
+        is_new=is_new,
     )
-    return _commit_push_device_token(db=db, push_device_token=push_device_token, is_new=True)
 
 
 def delete_push_device_token(db: Session, user_id: UUID, push_device_token_id: UUID) -> None:

--- a/pecha_api/push_devices/push_device_service.py
+++ b/pecha_api/push_devices/push_device_service.py
@@ -1,7 +1,9 @@
+from datetime import datetime, timezone
 from typing import Optional
 from uuid import UUID
 
 from fastapi import HTTPException
+from sqlalchemy.orm import Session
 from starlette import status
 
 from pecha_api.db.database import SessionLocal
@@ -11,9 +13,12 @@ from pecha_api.push_devices.push_device_models import PushDeviceToken
 from pecha_api.push_devices.push_device_repository import (
     count_push_device_tokens,
     delete_push_device_token,
+    delete_push_device_token_by_token,
     get_active_push_device_tokens_by_user_id,
     get_all_push_device_tokens,
-    upsert_push_device_token,
+    get_push_device_token_by_token,
+    get_push_device_token_by_user_and_device_id,
+    save_push_device_token,
 )
 from pecha_api.push_devices.push_device_response_models import (
     AdminPushDeviceTokenDTO,
@@ -36,6 +41,61 @@ def _to_dto(push_device_token: PushDeviceToken) -> PushDeviceTokenDTO:
     )
 
 
+def _upsert_push_device_token(
+    db: Session,
+    user_id: UUID,
+    token: str,
+    platform: PushPlatform,
+    device_id: Optional[str] = None,
+) -> PushDeviceToken:
+    now = datetime.now(timezone.utc)
+
+    if device_id is not None:
+        existing_installation = get_push_device_token_by_user_and_device_id(
+            db=db,
+            user_id=user_id,
+            device_id=device_id,
+        )
+        if existing_installation is not None:
+            if existing_installation.token == token:
+                existing_installation.is_active = True
+                existing_installation.updated_at = now
+                return save_push_device_token(db=db, push_device_token=existing_installation)
+
+            delete_push_device_token_by_token(
+                db=db,
+                token=token,
+                exclude_id=existing_installation.id,
+            )
+            existing_installation.token = token
+            existing_installation.platform = platform
+            existing_installation.is_active = True
+            existing_installation.updated_at = now
+            return save_push_device_token(db=db, push_device_token=existing_installation)
+
+    existing_by_token = get_push_device_token_by_token(db=db, token=token)
+    if existing_by_token is not None and existing_by_token.user_id == user_id:
+        existing_by_token.platform = platform
+        if device_id is not None:
+            existing_by_token.device_id = device_id
+        existing_by_token.is_active = True
+        existing_by_token.updated_at = now
+        return save_push_device_token(db=db, push_device_token=existing_by_token)
+
+    delete_push_device_token_by_token(db=db, token=token)
+
+    push_device_token = PushDeviceToken(
+        user_id=user_id,
+        token=token,
+        platform=platform,
+        device_id=device_id,
+        is_active=True,
+        created_at=now,
+        updated_at=now,
+    )
+    return save_push_device_token(db=db, push_device_token=push_device_token, is_new=True)
+
+
 async def register_push_device_service(
     token: str,
     register_request: RegisterPushDeviceRequest,
@@ -43,7 +103,7 @@ async def register_push_device_service(
     current_user = validate_and_extract_user_details(token=token)
 
     with SessionLocal() as db:
-        push_device_token = upsert_push_device_token(
+        push_device_token = _upsert_push_device_token(
             db=db,
             user_id=current_user.id,
             token=register_request.token,

--- a/pecha_api/recitations/recitations_services.py
+++ b/pecha_api/recitations/recitations_services.py
@@ -5,18 +5,11 @@ from pecha_api.collections.collections_repository import get_all_collections_by_
 from pecha_api.collections.collections_service import get_collection
 from pecha_api.recitations.recitations_repository import get_text_images_by_text_ids
 from pecha_api.recitations.recitations_response_models import RecitationDTO, RecitationsResponse, Segment
-from pecha_api.texts.texts_repository import get_all_texts_by_collection, get_contents_by_text_ids
-from pecha_api.texts.segments.segments_repository import get_segment_contents_by_ids
-from pecha_api.texts.texts_toc_utils import get_first_segment_ids_by_text_ids
+from pecha_api.texts.first_segment_preview_service import (
+    build_first_segment_previews_for_texts,
+)
+from pecha_api.texts.texts_repository import get_all_texts_by_group_id, get_contents_by_id
 from pecha_api.texts.texts_service import get_root_text_by_collection_id
-from fastapi import HTTPException
-from starlette import status
-from uuid import UUID
-
-from pecha_api.error_contants import ErrorConstants
-from pecha_api.texts.texts_utils import TextUtils
-from pecha_api.texts.texts_response_models import TextDTO, TableOfContent
-from pecha_api.texts.texts_repository import get_contents_by_id, get_all_texts_by_group_id
 from pecha_api.texts.segments.segments_service import get_segment_by_id, get_related_mapped_segments, get_segment_details_by_id, get_related_mapped_segments_batch, get_segments_details_by_ids
 from pecha_api.texts.segments.segments_utils import SegmentUtils
 from pecha_api.texts.segments.segments_response_models import SegmentTranslation, SegmentTransliteration, SegmentAdaptation, SegmentRecitation
@@ -34,6 +27,13 @@ from pecha_api.recitations.recication_cache_services import set_recitation_by_te
 from pecha_api.db.database import SessionLocal
 from pecha_api.uploads.S3_utils import generate_presigned_access_url
 from pecha_api.config import get
+from fastapi import HTTPException
+from starlette import status
+from uuid import UUID
+
+from pecha_api.error_contants import ErrorConstants
+from pecha_api.texts.texts_utils import TextUtils
+from pecha_api.texts.texts_response_models import TextDTO, TableOfContent
 
 def get_recitations_with_image_urls(recitations: List[RecitationDTO]) -> List[RecitationDTO]:
     text_ids = [str(recitation.text_id) for recitation in recitations]
@@ -65,34 +65,27 @@ async def get_recitations_with_first_segments(recitations: List[RecitationDTO]) 
     if not text_ids:
         return recitations
 
-    table_of_contents_by_text_id = await get_contents_by_text_ids(text_ids=text_ids)
-    first_segment_ids = get_first_segment_ids_by_text_ids(table_of_contents_by_text_id)
+    previews_by_text_id = await build_first_segment_previews_for_texts(text_ids)
 
-    if not first_segment_ids:
-        return recitations
-
-    segment_contents = await get_segment_contents_by_ids(
-        segment_ids=list(first_segment_ids.values())
-    )
-
-    first_segments_by_text_id: Dict[str, Segment] = {}
-    for text_id, segment_id in first_segment_ids.items():
-        content_data = segment_contents.get(segment_id)
-        if content_data:
-            first_segments_by_text_id[text_id] = Segment(
-                id=UUID(segment_id),
-                content=content_data[1],
+    result: List[RecitationDTO] = []
+    for recitation in recitations:
+        preview = previews_by_text_id.get(str(recitation.text_id))
+        first_segment = None
+        if preview is not None:
+            first_segment_id, preview_content = preview
+            first_segment = Segment(
+                id=UUID(first_segment_id),
+                content=preview_content,
             )
-
-    return [
-        RecitationDTO(
-            title=recitation.title,
-            text_id=recitation.text_id,
-            image_url=recitation.image_url,
-            first_segment=first_segments_by_text_id.get(str(recitation.text_id)),
+        result.append(
+            RecitationDTO(
+                title=recitation.title,
+                text_id=recitation.text_id,
+                image_url=recitation.image_url,
+                first_segment=first_segment,
+            )
         )
-        for recitation in recitations
-    ]
+    return result
 
 async def get_list_of_recitations_service(search: Optional[str] = None, language: str = "en", skip: int = 0, limit: int = 10) -> RecitationsResponse:
     collection_id = await get_collection_id_by_slug(slug="Liturgy")

--- a/pecha_api/routines/routines_response_models.py
+++ b/pecha_api/routines/routines_response_models.py
@@ -41,6 +41,11 @@ class UpdateTimeBlockRequest(BaseModel):
     sessions: List[SessionRequest]
 
 
+class RoutineFirstSegmentDTO(BaseModel):
+    id: str
+    content: str
+
+
 class SessionDTO(BaseModel):
     id: UUID
     session_type: SessionType
@@ -59,6 +64,7 @@ class SessionDTO(BaseModel):
     item_count: Optional[int] = None  # Recitation collection's item count
     current_plan_id: Optional[UUID] = None  # SERIES: plan active for today's date
     current_plan_title: Optional[str] = None  # SERIES: title of the active plan
+    first_segment: Optional[RoutineFirstSegmentDTO] = None
 
     @model_serializer(mode="wrap")
     def _omit_inapplicable_fields(self, serializer):
@@ -75,6 +81,7 @@ class SessionDTO(BaseModel):
                 "item_count",
                 "current_plan_id",
                 "current_plan_title",
+                "first_segment",
             ):
                 data.pop(field, None)
         elif self.session_type == SessionType.RECITATION_COLLECTION:
@@ -86,6 +93,7 @@ class SessionDTO(BaseModel):
                 "current_plan_id",
                 "current_plan_title",
                 "accumulator_id",
+                "first_segment",
             ):
                 data.pop(field, None)
         elif self.session_type == SessionType.RECITATION:
@@ -111,6 +119,7 @@ class SessionDTO(BaseModel):
                 "item_count",
                 "current_plan_id",
                 "current_plan_title",
+                "first_segment",
             ):
                 data.pop(field, None)
         elif self.session_type == SessionType.PLAN:
@@ -120,10 +129,11 @@ class SessionDTO(BaseModel):
                 "current_plan_id",
                 "current_plan_title",
                 "accumulator_id",
+                "first_segment",
             ):
                 data.pop(field, None)
         else:  # SERIES exposes start_date / started_at and current plan fields
-            for field in ("duration_ms", "item_count", "accumulator_id"):
+            for field in ("duration_ms", "item_count", "accumulator_id", "first_segment"):
                 data.pop(field, None)
         return data
 

--- a/pecha_api/routines/routines_service.py
+++ b/pecha_api/routines/routines_service.py
@@ -33,6 +33,10 @@ from pecha_api.accumulator.accumulator_enums import AccumulatorType
 from pecha_api.accumulator.accumulator_service import (
     resolve_accumulator_bookmark_mala_image_url,
 )
+from pecha_api.mantra.mantra_repository import get_mantras_by_ids
+from pecha_api.texts.segments.segments_models import Segment
+from pecha_api.texts.texts_repository import get_contents_by_text_ids
+from pecha_api.texts.texts_toc_utils import get_first_segment_ids_by_text_ids
 
 from .routines_models import Routine, RoutineTimeBlock, RoutineSession
 from .routines_enums import SessionType
@@ -578,6 +582,30 @@ def _resolve_plan_sessions(db, plan_sessions: List[RoutineSession], user_id: UUI
     return resolved
 
 
+async def _resolve_first_segment_ids_for_texts(
+    text_ids: List[str],
+) -> Dict[str, UUID]:
+    if not text_ids:
+        return {}
+
+    table_of_contents_by_text_id = await get_contents_by_text_ids(text_ids=text_ids)
+    first_segment_ids = get_first_segment_ids_by_text_ids(table_of_contents_by_text_id)
+
+    result: Dict[str, UUID] = {
+        text_id: UUID(segment_id)
+        for text_id, segment_id in first_segment_ids.items()
+    }
+
+    for text_id in text_ids:
+        if text_id in result:
+            continue
+        segment = await Segment.get_first_segment_by_text_id(text_id=text_id)
+        if segment is not None:
+            result[text_id] = segment.id
+
+    return result
+
+
 async def _resolve_recitation_sessions(
     recitation_sessions: List[RoutineSession],
 ) -> List[SessionDTO]:
@@ -587,17 +615,24 @@ async def _resolve_recitation_sessions(
     text_ids = [str(session.source_id) for session in recitation_sessions]
     texts = await Text.get_texts_by_ids(text_ids)
     text_map = {str(text.id): text for text in texts}
+    first_segment_by_text_id = await _resolve_first_segment_ids_for_texts(text_ids)
 
     resolved = []
     for session in recitation_sessions:
-        text = text_map.get(str(session.source_id))
+        text_id = str(session.source_id)
+        text = text_map.get(text_id)
         if text is None:
             continue
+
+        first_segment_id = first_segment_by_text_id.get(text_id)
+        if first_segment_id is None:
+            continue
+
         resolved.append(
             SessionDTO(
                 id=session.id,
                 session_type=session.session_type,
-                source_id=session.source_id,
+                source_id=first_segment_id,
                 title=text.title,
                 language=text.language or "en",
                 image=None,
@@ -679,27 +714,6 @@ def _resolve_recitation_collection_sessions(
     return resolved
 
 
-def _accumulator_metadata_language(metadata) -> Optional[str]:
-    if metadata is None:
-        return None
-    return (
-        metadata.language.value
-        if hasattr(metadata.language, "value")
-        else str(metadata.language)
-    )
-
-
-def _select_accumulator_metadata(metadata_entries, language: Optional[str]):
-    if not metadata_entries:
-        return None
-    matched = filter_by_language_with_fallback(
-        entries=list(metadata_entries),
-        language=language,
-        language_of=_accumulator_metadata_language,
-    )
-    return matched[0] if matched else metadata_entries[0]
-
-
 def _accumulator_mala_image(
     db, accumulator: Accumulator
 ) -> Optional[ImageUrlModel]:
@@ -711,6 +725,42 @@ def _accumulator_mala_image(
         medium=mala_image_url,
         original=mala_image_url,
     )
+
+
+def _mantra_metadata_language(metadata) -> Optional[str]:
+    if metadata is None:
+        return None
+    return (
+        metadata.language.value
+        if hasattr(metadata.language, "value")
+        else str(metadata.language)
+    )
+
+
+def _select_mantra_metadata(metadata_entries, language: Optional[str]):
+    if not metadata_entries:
+        return None
+    matched = filter_by_language_with_fallback(
+        entries=list(metadata_entries),
+        language=language,
+        language_of=_mantra_metadata_language,
+    )
+    return matched[0] if matched else metadata_entries[0]
+
+
+def _preset_session_title_and_language(
+    mantra,
+    language: Optional[str] = None,
+) -> tuple[str, Optional[str]]:
+    if mantra is not None and mantra.metadata_entries:
+        mantra_metadata = _select_mantra_metadata(mantra.metadata_entries, language)
+        if mantra_metadata and mantra_metadata.title:
+            return (
+                mantra_metadata.title,
+                _mantra_metadata_language(mantra_metadata),
+            )
+
+    return "Untitled", None
 
 
 def _resolve_accumulator_sessions(
@@ -734,14 +784,26 @@ def _resolve_accumulator_sessions(
     )
     preset_map = {preset.id: preset for preset in presets}
 
+    mantra_ids = [
+        preset.mantra_id
+        for preset in presets
+        if preset.mantra_id is not None
+    ]
+    mantras_by_id = get_mantras_by_ids(db, mantra_ids)
+
     resolved = []
     for session in accumulator_sessions:
         preset = preset_map.get(session.source_id)
         if preset is None:
             continue
 
-        metadata = _select_accumulator_metadata(
-            preset.metadata_entries, language
+        mantra = (
+            mantras_by_id.get(preset.mantra_id)
+            if preset.mantra_id is not None
+            else None
+        )
+        title, session_language = _preset_session_title_and_language(
+            mantra, language
         )
         resolved.append(
             SessionDTO(
@@ -749,8 +811,8 @@ def _resolve_accumulator_sessions(
                 session_type=session.session_type,
                 source_id=session.source_id,
                 accumulator_id=session.source_id,
-                title=metadata.name if metadata else "Untitled",
-                language=_accumulator_metadata_language(metadata),
+                title=title,
+                language=session_language,
                 image=_accumulator_mala_image(db, preset),
                 display_order=session.display_order,
             )

--- a/pecha_api/routines/routines_service.py
+++ b/pecha_api/routines/routines_service.py
@@ -34,9 +34,9 @@ from pecha_api.accumulator.accumulator_service import (
     resolve_accumulator_bookmark_mala_image_url,
 )
 from pecha_api.mantra.mantra_repository import get_mantras_by_ids
-from pecha_api.texts.segments.segments_models import Segment
-from pecha_api.texts.texts_repository import get_contents_by_text_ids
-from pecha_api.texts.texts_toc_utils import get_first_segment_ids_by_text_ids
+from pecha_api.texts.first_segment_preview_service import (
+    build_first_segment_previews_for_texts,
+)
 
 from .routines_models import Routine, RoutineTimeBlock, RoutineSession
 from .routines_enums import SessionType
@@ -86,6 +86,7 @@ from .routines_response_models import (
     CreateTimeBlockRequest,
     UpdateTimeBlockRequest,
     SessionDTO,
+    RoutineFirstSegmentDTO,
     TimeBlockDTO,
     RoutineWithTimeBlocksResponse,
     RoutineResponse,
@@ -582,28 +583,11 @@ def _resolve_plan_sessions(db, plan_sessions: List[RoutineSession], user_id: UUI
     return resolved
 
 
-async def _resolve_first_segment_ids_for_texts(
-    text_ids: List[str],
-) -> Dict[str, UUID]:
-    if not text_ids:
-        return {}
-
-    table_of_contents_by_text_id = await get_contents_by_text_ids(text_ids=text_ids)
-    first_segment_ids = get_first_segment_ids_by_text_ids(table_of_contents_by_text_id)
-
-    result: Dict[str, UUID] = {
-        text_id: UUID(segment_id)
-        for text_id, segment_id in first_segment_ids.items()
-    }
-
-    for text_id in text_ids:
-        if text_id in result:
-            continue
-        segment = await Segment.get_first_segment_by_text_id(text_id=text_id)
-        if segment is not None:
-            result[text_id] = segment.id
-
-    return result
+def _normalize_text_id(text_id) -> str:
+    try:
+        return str(UUID(str(text_id)))
+    except (ValueError, TypeError):
+        return str(text_id)
 
 
 async def _resolve_recitation_sessions(
@@ -612,31 +596,36 @@ async def _resolve_recitation_sessions(
     if not recitation_sessions:
         return []
 
-    text_ids = [str(session.source_id) for session in recitation_sessions]
+    text_ids = [_normalize_text_id(session.source_id) for session in recitation_sessions]
     texts = await Text.get_texts_by_ids(text_ids)
-    text_map = {str(text.id): text for text in texts}
-    first_segment_by_text_id = await _resolve_first_segment_ids_for_texts(text_ids)
+    text_map = {_normalize_text_id(text.id): text for text in texts}
+    previews_by_text_id = await build_first_segment_previews_for_texts(text_ids)
 
     resolved = []
     for session in recitation_sessions:
-        text_id = str(session.source_id)
+        text_id = _normalize_text_id(session.source_id)
         text = text_map.get(text_id)
         if text is None:
             continue
 
-        first_segment_id = first_segment_by_text_id.get(text_id)
-        if first_segment_id is None:
+        preview = previews_by_text_id.get(text_id)
+        if preview is None:
             continue
 
+        first_segment_id, preview_content = preview
         resolved.append(
             SessionDTO(
                 id=session.id,
                 session_type=session.session_type,
-                source_id=first_segment_id,
+                source_id=UUID(first_segment_id),
                 title=text.title,
                 language=text.language or "en",
                 image=None,
                 display_order=session.display_order,
+                first_segment=RoutineFirstSegmentDTO(
+                    id=first_segment_id,
+                    content=preview_content,
+                ),
             )
         )
     return resolved

--- a/pecha_api/texts/first_segment_preview_service.py
+++ b/pecha_api/texts/first_segment_preview_service.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Tuple
+from uuid import UUID
+
+from pecha_api.texts.segments.segments_models import Segment
+from pecha_api.texts.texts_repository import get_contents_by_id, get_contents_by_text_ids
+from pecha_api.texts.texts_toc_utils import (
+    FIRST_SEGMENT_PREVIEW_COUNT,
+    combine_segment_preview_contents,
+    get_first_n_segment_refs_from_table_of_contents,
+)
+
+FirstSegmentPreview = Tuple[str, str]
+
+
+async def resolve_segment_by_ref(segment_ref: str) -> Optional[Segment]:
+    try:
+        UUID(segment_ref)
+        segment = await Segment.get_segment_by_id(segment_id=segment_ref)
+        if segment is not None:
+            return segment
+    except ValueError:
+        pass
+    return await Segment.get_segment_by_pecha_segment_id(pecha_segment_id=segment_ref)
+
+
+async def _resolve_preview_segments_for_refs(refs: List[str]) -> List[Segment]:
+    resolved_segments: List[Segment] = []
+    for ref in refs:
+        segment = await resolve_segment_by_ref(ref)
+        if segment is not None:
+            resolved_segments.append(segment)
+    return resolved_segments
+
+
+async def _preview_from_text_segments(
+    text_id: str,
+    preview_count: int,
+) -> Optional[FirstSegmentPreview]:
+    segments = await Segment.get_segments_by_text_id(text_id=text_id)
+    if not segments:
+        return None
+
+    preview_segments = segments[:preview_count]
+    return (
+        str(preview_segments[0].id),
+        combine_segment_preview_contents([segment.content for segment in preview_segments]),
+    )
+
+
+async def build_first_segment_preview_for_text(
+    text_id: str,
+    *,
+    preview_count: int = FIRST_SEGMENT_PREVIEW_COUNT,
+) -> Optional[FirstSegmentPreview]:
+    table_of_contents = await get_contents_by_id(text_id=text_id)
+    refs = get_first_n_segment_refs_from_table_of_contents(
+        table_of_contents,
+        preview_count,
+    )
+
+    if not refs:
+        return await _preview_from_text_segments(text_id, preview_count)
+
+    preview_segments = await _resolve_preview_segments_for_refs(refs)
+    if not preview_segments:
+        return await _preview_from_text_segments(text_id, preview_count)
+
+    return (
+        str(preview_segments[0].id),
+        combine_segment_preview_contents([segment.content for segment in preview_segments]),
+    )
+
+
+async def build_first_segment_previews_for_texts(
+    text_ids: List[str],
+    *,
+    preview_count: int = FIRST_SEGMENT_PREVIEW_COUNT,
+) -> Dict[str, FirstSegmentPreview]:
+    if not text_ids:
+        return {}
+
+    normalized_ids = list(dict.fromkeys(text_ids))
+    table_of_contents_by_text_id = await get_contents_by_text_ids(text_ids=normalized_ids)
+    previews: Dict[str, FirstSegmentPreview] = {}
+
+    for text_id in normalized_ids:
+        refs = get_first_n_segment_refs_from_table_of_contents(
+            table_of_contents_by_text_id.get(text_id, []),
+            preview_count,
+        )
+        if not refs:
+            preview = await _preview_from_text_segments(text_id, preview_count)
+            if preview is not None:
+                previews[text_id] = preview
+            continue
+
+        preview_segments = await _resolve_preview_segments_for_refs(refs)
+        if not preview_segments:
+            preview = await _preview_from_text_segments(text_id, preview_count)
+            if preview is not None:
+                previews[text_id] = preview
+            continue
+
+        previews[text_id] = (
+            str(preview_segments[0].id),
+            combine_segment_preview_contents(
+                [segment.content for segment in preview_segments]
+            ),
+        )
+
+    return previews

--- a/pecha_api/texts/texts_toc_utils.py
+++ b/pecha_api/texts/texts_toc_utils.py
@@ -3,6 +3,8 @@ from typing import Dict, Iterator, List, Optional, Tuple
 from pecha_api.texts.texts_enums import PaginationDirection
 from pecha_api.texts.texts_response_models import Section, TableOfContent
 
+FIRST_SEGMENT_PREVIEW_COUNT = 3
+
 
 def section_contains_segment(sections: List[Section], segment_id: str) -> bool:
     for section in sections:
@@ -15,14 +17,52 @@ def section_contains_segment(sections: List[Section], segment_id: str) -> bool:
 
 
 def find_first_segment_in_sections(sections: List[Section]) -> Optional[str]:
+    refs = get_first_n_segment_refs_from_sections(sections, count=1)
+    return refs[0] if refs else None
+
+
+def iter_segment_refs_in_sections(sections: List[Section]):
     for section in sections:
-        if section.segments:
-            return section.segments[0].segment_id
+        for segment in section.segments:
+            segment_ref = segment.segment_id or segment.pecha_segment_id
+            if segment_ref:
+                yield segment_ref
         if section.sections:
-            segment_id = find_first_segment_in_sections(section.sections)
-            if segment_id:
-                return segment_id
-    return None
+            yield from iter_segment_refs_in_sections(section.sections)
+
+
+def get_first_n_segment_refs_from_sections(
+    sections: List[Section],
+    *,
+    count: int = FIRST_SEGMENT_PREVIEW_COUNT,
+) -> List[str]:
+    refs: List[str] = []
+    for segment_ref in iter_segment_refs_in_sections(sections):
+        refs.append(segment_ref)
+        if len(refs) >= count:
+            break
+    return refs
+
+
+def get_first_n_segment_refs_from_table_of_contents(
+    table_of_contents: List[TableOfContent],
+    count: int = FIRST_SEGMENT_PREVIEW_COUNT,
+) -> List[str]:
+    refs: List[str] = []
+    for table_of_content in table_of_contents:
+        for segment_ref in iter_segment_refs_in_sections(table_of_content.sections):
+            refs.append(segment_ref)
+            if len(refs) >= count:
+                return refs
+    return refs
+
+
+def combine_segment_preview_contents(contents: List[str]) -> str:
+    return "\n".join(
+        content.strip()
+        for content in contents
+        if content and content.strip()
+    )
 
 
 def get_first_segment_ids_by_text_ids(

--- a/tests/bookmarks/test_bookmark_utils.py
+++ b/tests/bookmarks/test_bookmark_utils.py
@@ -3,8 +3,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 from pecha_api.bookmarks.bookmark_enums import BookmarkType
+from pecha_api.texts.first_segment_preview_service import resolve_segment_by_ref
 from pecha_api.bookmarks.bookmark_utils import (
-    _resolve_segment_by_ref,
     _resolve_text_segment,
     enrich_text_bookmark,
 )
@@ -16,11 +16,11 @@ async def test_resolve_segment_by_ref_with_uuid():
     mock_segment = MagicMock()
 
     with patch(
-        "pecha_api.bookmarks.bookmark_utils.get_segment_by_id",
+        "pecha_api.texts.first_segment_preview_service.Segment.get_segment_by_id",
         new_callable=AsyncMock,
         return_value=mock_segment,
     ):
-        result = await _resolve_segment_by_ref(segment_id)
+        result = await resolve_segment_by_ref(segment_id)
 
     assert result is mock_segment
 
@@ -30,15 +30,15 @@ async def test_resolve_segment_by_ref_with_pecha_id_when_uuid_lookup_fails():
     mock_segment = MagicMock()
 
     with patch(
-        "pecha_api.bookmarks.bookmark_utils.get_segment_by_id",
+        "pecha_api.texts.first_segment_preview_service.Segment.get_segment_by_id",
         new_callable=AsyncMock,
         return_value=None,
     ), patch(
-        "pecha_api.bookmarks.bookmark_utils.Segment.get_segment_by_pecha_segment_id",
+        "pecha_api.texts.first_segment_preview_service.Segment.get_segment_by_pecha_segment_id",
         new_callable=AsyncMock,
         return_value=mock_segment,
     ) as mock_pecha_lookup:
-        result = await _resolve_segment_by_ref(str(uuid4()))
+        result = await resolve_segment_by_ref(str(uuid4()))
 
     mock_pecha_lookup.assert_awaited_once()
     assert result is mock_segment
@@ -50,11 +50,11 @@ async def test_resolve_segment_by_ref_with_non_uuid_uses_pecha_lookup():
     mock_segment = MagicMock()
 
     with patch(
-        "pecha_api.bookmarks.bookmark_utils.Segment.get_segment_by_pecha_segment_id",
+        "pecha_api.texts.first_segment_preview_service.Segment.get_segment_by_pecha_segment_id",
         new_callable=AsyncMock,
         return_value=mock_segment,
     ) as mock_pecha_lookup:
-        result = await _resolve_segment_by_ref(verse_locator)
+        result = await resolve_segment_by_ref(verse_locator)
 
     mock_pecha_lookup.assert_awaited_once_with(pecha_segment_id=verse_locator)
     assert result is mock_segment
@@ -69,7 +69,7 @@ async def test_resolve_text_segment_with_matching_verse_id():
     mock_segment.text_id = text_id
 
     with patch(
-        "pecha_api.bookmarks.bookmark_utils._resolve_segment_by_ref",
+        "pecha_api.bookmarks.bookmark_utils.resolve_segment_by_ref",
         new_callable=AsyncMock,
         return_value=mock_segment,
     ):
@@ -94,7 +94,7 @@ async def test_resolve_text_segment_ignores_verse_from_other_text():
     fallback_segment.id = str(uuid4())
 
     with patch(
-        "pecha_api.bookmarks.bookmark_utils._resolve_segment_by_ref",
+        "pecha_api.bookmarks.bookmark_utils.resolve_segment_by_ref",
         new_callable=AsyncMock,
         return_value=mock_segment,
     ), patch(
@@ -180,13 +180,9 @@ async def test_enrich_text_bookmark_without_verse_uses_first_segment():
     mock_segment.content = "Segment content"
 
     with patch(
-        "pecha_api.bookmarks.bookmark_utils.get_first_segment_table_of_content",
+        "pecha_api.bookmarks.bookmark_utils.build_first_segment_preview_for_text",
         new_callable=AsyncMock,
-        return_value=(segment_id, None),
-    ), patch(
-        "pecha_api.bookmarks.bookmark_utils.get_segment_by_id",
-        new_callable=AsyncMock,
-        return_value=mock_segment,
+        return_value=(segment_id, "Segment content"),
     ), patch(
         "pecha_api.bookmarks.bookmark_utils.get_texts_by_id",
         new_callable=AsyncMock,
@@ -220,7 +216,7 @@ async def test_enrich_text_bookmark_with_name_as_segment_ref():
     mock_segment.content = "Named segment content"
 
     with patch(
-        "pecha_api.bookmarks.bookmark_utils._resolve_segment_by_ref",
+        "pecha_api.bookmarks.bookmark_utils.resolve_segment_by_ref",
         new_callable=AsyncMock,
         return_value=mock_segment,
     ), patch(
@@ -272,7 +268,7 @@ async def test_enrich_verse_bookmark_includes_segment_content():
     mock_segment.content = "Verse segment content"
 
     with patch(
-        "pecha_api.bookmarks.bookmark_utils._resolve_segment_by_ref",
+        "pecha_api.bookmarks.bookmark_utils.resolve_segment_by_ref",
         new_callable=AsyncMock,
         return_value=mock_segment,
     ), patch(
@@ -296,7 +292,7 @@ async def test_enrich_verse_bookmark_returns_empty_when_segment_not_found():
     bookmark.name = None
 
     with patch(
-        "pecha_api.bookmarks.bookmark_utils._resolve_segment_by_ref",
+        "pecha_api.bookmarks.bookmark_utils.resolve_segment_by_ref",
         new_callable=AsyncMock,
         return_value=None,
     ):

--- a/tests/push_devices/test_push_device_repository.py
+++ b/tests/push_devices/test_push_device_repository.py
@@ -9,7 +9,8 @@ from pecha_api.push_devices.push_device_enums import PushPlatform
 from pecha_api.push_devices.push_device_models import PushDeviceToken
 from pecha_api.push_devices.push_device_repository import (
     delete_push_device_token,
-    upsert_push_device_token,
+    delete_push_device_token_by_token,
+    save_push_device_token,
 )
 
 
@@ -22,55 +23,58 @@ def _make_query_chain(result):
     return chain
 
 
-def test_upsert_push_device_token_creates_new_record():
-    user_id = uuid4()
+def test_save_push_device_token_creates_new_record():
     db = MagicMock()
-    db.query.return_value = _make_query_chain(None)
-
-    result = upsert_push_device_token(
-        db=db,
-        user_id=user_id,
+    push_device_token = PushDeviceToken(
+        id=uuid4(),
+        user_id=uuid4(),
         token="new-token",
         platform=PushPlatform.ANDROID,
         device_id="device-1",
+        is_active=True,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
     )
 
-    db.add.assert_called_once()
+    result = save_push_device_token(db=db, push_device_token=push_device_token, is_new=True)
+
+    db.add.assert_called_once_with(push_device_token)
     db.commit.assert_called_once()
     db.refresh.assert_called_once()
-    assert isinstance(result, PushDeviceToken)
+    assert result is push_device_token
 
 
-def test_upsert_push_device_token_updates_existing_by_token():
-    user_id = uuid4()
-    existing = PushDeviceToken(
+def test_delete_push_device_token_by_token_removes_all_conflicting_records():
+    conflicting_one = PushDeviceToken(
         id=uuid4(),
         user_id=uuid4(),
-        token="existing-token",
+        token="conflicting-token",
+        platform=PushPlatform.ANDROID,
+        device_id="device-1",
+        is_active=True,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+    conflicting_two = PushDeviceToken(
+        id=uuid4(),
+        user_id=uuid4(),
+        token="conflicting-token",
         platform=PushPlatform.IOS,
-        device_id="old-device",
-        is_active=False,
+        device_id="device-2",
+        is_active=True,
         created_at=datetime.now(timezone.utc),
         updated_at=datetime.now(timezone.utc),
     )
 
     db = MagicMock()
-    db.query.return_value = _make_query_chain(existing)
+    db.query.return_value = _make_query_chain([conflicting_one, conflicting_two])
 
-    result = upsert_push_device_token(
-        db=db,
-        user_id=user_id,
-        token="existing-token",
-        platform=PushPlatform.ANDROID,
-        device_id="new-device",
-    )
+    delete_push_device_token_by_token(db=db, token="conflicting-token")
 
-    assert result.user_id == user_id
-    assert result.platform == PushPlatform.ANDROID
-    assert result.device_id == "new-device"
-    assert result.is_active is True
-    db.add.assert_not_called()
-    db.commit.assert_called_once()
+    assert db.delete.call_count == 2
+    db.delete.assert_any_call(conflicting_one)
+    db.delete.assert_any_call(conflicting_two)
+    db.flush.assert_called_once()
 
 
 def test_delete_push_device_token_not_found_raises_404():

--- a/tests/push_devices/test_push_device_services.py
+++ b/tests/push_devices/test_push_device_services.py
@@ -6,8 +6,10 @@ import pytest
 from fastapi import HTTPException
 
 from pecha_api.push_devices.push_device_enums import PushPlatform
+from pecha_api.push_devices.push_device_models import PushDeviceToken
 from pecha_api.push_devices.push_device_response_models import RegisterPushDeviceRequest
 from pecha_api.push_devices.push_device_service import (
+    _upsert_push_device_token,
     delete_push_device_service,
     get_push_devices_service,
     list_all_push_devices_service,
@@ -47,7 +49,7 @@ async def test_register_push_device_service_success():
     ) as mock_validate, patch(
         "pecha_api.push_devices.push_device_service.SessionLocal"
     ) as mock_session, patch(
-        "pecha_api.push_devices.push_device_service.upsert_push_device_token"
+        "pecha_api.push_devices.push_device_service._upsert_push_device_token"
     ) as mock_upsert:
         mock_validate.return_value = mock_user
         mock_session.return_value = mock_db
@@ -189,3 +191,116 @@ async def test_list_all_push_devices_service_forbidden():
             await list_all_push_devices_service(token="user_token")
 
         assert exc_info.value.status_code == 403
+
+
+def test_upsert_push_device_token_creates_new_installation():
+    user_id = uuid4()
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = None
+
+    with patch(
+        "pecha_api.push_devices.push_device_service.get_push_device_token_by_user_and_device_id",
+        return_value=None,
+    ), patch(
+        "pecha_api.push_devices.push_device_service.get_push_device_token_by_token",
+        return_value=None,
+    ), patch(
+        "pecha_api.push_devices.push_device_service.delete_push_device_token_by_token",
+    ) as mock_delete_by_token, patch(
+        "pecha_api.push_devices.push_device_service.save_push_device_token",
+    ) as mock_save:
+        mock_save.return_value = MagicMock()
+
+        _upsert_push_device_token(
+            db=db,
+            user_id=user_id,
+            token="new-token",
+            platform=PushPlatform.ANDROID,
+            device_id="device-1",
+        )
+
+        mock_delete_by_token.assert_called_once_with(db=db, token="new-token")
+        saved_token = mock_save.call_args.kwargs["push_device_token"]
+        assert saved_token.user_id == user_id
+        assert saved_token.token == "new-token"
+        assert saved_token.device_id == "device-1"
+        assert mock_save.call_args.kwargs["is_new"] is True
+
+
+def test_upsert_push_device_token_same_installation_same_token_updates_last_seen():
+    user_id = uuid4()
+    now = datetime.now(timezone.utc)
+    existing = PushDeviceToken(
+        id=uuid4(),
+        user_id=user_id,
+        token="same-token",
+        platform=PushPlatform.ANDROID,
+        device_id="device-1",
+        is_active=True,
+        created_at=now,
+        updated_at=now,
+    )
+
+    with patch(
+        "pecha_api.push_devices.push_device_service.get_push_device_token_by_user_and_device_id",
+        return_value=existing,
+    ), patch(
+        "pecha_api.push_devices.push_device_service.save_push_device_token",
+    ) as mock_save:
+        mock_save.return_value = existing
+
+        result = _upsert_push_device_token(
+            db=MagicMock(),
+            user_id=user_id,
+            token="same-token",
+            platform=PushPlatform.ANDROID,
+            device_id="device-1",
+        )
+
+        assert result is existing
+        assert result.is_active is True
+        assert result.updated_at >= now
+        mock_save.assert_called_once_with(db=mock_save.call_args.kwargs["db"], push_device_token=existing)
+
+
+def test_upsert_push_device_token_same_installation_different_token_replaces_token():
+    user_id = uuid4()
+    now = datetime.now(timezone.utc)
+    existing = PushDeviceToken(
+        id=uuid4(),
+        user_id=user_id,
+        token="old-token",
+        platform=PushPlatform.IOS,
+        device_id="device-1",
+        is_active=True,
+        created_at=now,
+        updated_at=now,
+    )
+    db = MagicMock()
+
+    with patch(
+        "pecha_api.push_devices.push_device_service.get_push_device_token_by_user_and_device_id",
+        return_value=existing,
+    ), patch(
+        "pecha_api.push_devices.push_device_service.delete_push_device_token_by_token",
+    ) as mock_delete_by_token, patch(
+        "pecha_api.push_devices.push_device_service.save_push_device_token",
+    ) as mock_save:
+        mock_save.return_value = existing
+
+        result = _upsert_push_device_token(
+            db=db,
+            user_id=user_id,
+            token="new-token",
+            platform=PushPlatform.ANDROID,
+            device_id="device-1",
+        )
+
+        mock_delete_by_token.assert_called_once_with(
+            db=db,
+            token="new-token",
+            exclude_id=existing.id,
+        )
+        assert result.token == "new-token"
+        assert result.platform == PushPlatform.ANDROID
+        assert result.is_active is True

--- a/tests/recitations/test_recitations_services.py
+++ b/tests/recitations/test_recitations_services.py
@@ -224,37 +224,18 @@ class TestGetListOfRecitationsService:
 class TestGetRecitationsWithFirstSegments:
     """Test cases for get_recitations_with_first_segments function."""
 
-    @patch('pecha_api.recitations.recitations_services.get_segment_contents_by_ids')
-    @patch('pecha_api.recitations.recitations_services.get_contents_by_text_ids')
+    @patch('pecha_api.recitations.recitations_services.build_first_segment_previews_for_texts')
     @pytest.mark.asyncio
     async def test_get_recitations_with_first_segments_success(
         self,
-        mock_get_contents_by_text_ids,
-        mock_get_segment_contents_by_ids,
+        mock_build_first_segment_previews_for_texts,
     ):
         text_id = str(uuid4())
         segment_id = str(uuid4())
         recitation_dto = RecitationDTO(text_id=UUID(text_id), title="Test Recitation")
 
-        mock_get_contents_by_text_ids.return_value = {
-            text_id: [
-                TableOfContent(
-                    text_id=text_id,
-                    type=TableOfContentType.TEXT,
-                    sections=[
-                        Section(
-                            id=str(uuid4()),
-                            section_number=1,
-                            segments=[
-                                TextSegment(segment_id=segment_id, segment_number=1),
-                            ],
-                        )
-                    ],
-                )
-            ]
-        }
-        mock_get_segment_contents_by_ids.return_value = {
-            segment_id: (text_id, "First segment content"),
+        mock_build_first_segment_previews_for_texts.return_value = {
+            text_id: (segment_id, "Verse 1\nVerse 2\nVerse 3"),
         }
 
         result = await get_recitations_with_first_segments(recitations=[recitation_dto])
@@ -262,22 +243,22 @@ class TestGetRecitationsWithFirstSegments:
         assert len(result) == 1
         assert result[0].first_segment is not None
         assert str(result[0].first_segment.id) == segment_id
-        assert result[0].first_segment.content == "First segment content"
+        assert result[0].first_segment.content == "Verse 1\nVerse 2\nVerse 3"
 
     @pytest.mark.asyncio
     async def test_get_recitations_with_first_segments_empty_list(self):
         result = await get_recitations_with_first_segments(recitations=[])
         assert result == []
 
-    @patch('pecha_api.recitations.recitations_services.get_contents_by_text_ids')
+    @patch('pecha_api.recitations.recitations_services.build_first_segment_previews_for_texts')
     @pytest.mark.asyncio
     async def test_get_recitations_with_first_segments_no_toc(
         self,
-        mock_get_contents_by_text_ids,
+        mock_build_first_segment_previews_for_texts,
     ):
         text_id = str(uuid4())
         recitation_dto = RecitationDTO(text_id=UUID(text_id), title="Test Recitation")
-        mock_get_contents_by_text_ids.return_value = {text_id: []}
+        mock_build_first_segment_previews_for_texts.return_value = {}
 
         result = await get_recitations_with_first_segments(recitations=[recitation_dto])
 

--- a/tests/routines/test_routines_service.py
+++ b/tests/routines/test_routines_service.py
@@ -750,15 +750,24 @@ async def test_resolve_recitation_sessions_success():
         title="Heart Sutra",
         language="bo",
     )
+    mock_segment = SimpleNamespace(
+        id=segment_id,
+        content="Om gate gate paragate parasamgate bodhi svaha",
+    )
 
     with patch(
         "pecha_api.routines.routines_service.Text.get_texts_by_ids",
         new_callable=AsyncMock,
         return_value=[mock_text],
     ), patch(
-        "pecha_api.routines.routines_service._resolve_first_segment_ids_for_texts",
+        "pecha_api.routines.routines_service.build_first_segment_previews_for_texts",
         new_callable=AsyncMock,
-        return_value={str(text_id): segment_id},
+        return_value={
+            str(text_id): (
+                str(segment_id),
+                "Verse one\nVerse two\nVerse three",
+            )
+        },
     ):
         result = await _resolve_recitation_sessions(recitation_sessions=[session])
 
@@ -767,6 +776,11 @@ async def test_resolve_recitation_sessions_success():
         assert result[0].title == "Heart Sutra"
         assert result[0].language == "bo"
         assert result[0].image is None
+        assert result[0].first_segment.id == str(segment_id)
+        assert result[0].first_segment.content == "Verse one\nVerse two\nVerse three"
+        serialized = result[0].model_dump()
+        assert serialized["first_segment"]["id"] == str(segment_id)
+        assert serialized["first_segment"]["content"] == "Verse one\nVerse two\nVerse three"
 
 
 @pytest.mark.asyncio
@@ -791,9 +805,9 @@ async def test_resolve_recitation_sessions_null_language():
         new_callable=AsyncMock,
         return_value=[mock_text],
     ), patch(
-        "pecha_api.routines.routines_service._resolve_first_segment_ids_for_texts",
+        "pecha_api.routines.routines_service.build_first_segment_previews_for_texts",
         new_callable=AsyncMock,
-        return_value={str(text_id): segment_id},
+        return_value={str(text_id): (str(segment_id), "Test content")},
     ):
         result = await _resolve_recitation_sessions(recitation_sessions=[session])
 
@@ -815,7 +829,7 @@ async def test_resolve_recitation_sessions_missing_text():
         new_callable=AsyncMock,
         return_value=[],
     ), patch(
-        "pecha_api.routines.routines_service._resolve_first_segment_ids_for_texts",
+        "pecha_api.routines.routines_service.build_first_segment_previews_for_texts",
         new_callable=AsyncMock,
         return_value={},
     ):
@@ -844,7 +858,7 @@ async def test_resolve_recitation_sessions_skips_when_first_segment_missing():
         new_callable=AsyncMock,
         return_value=[mock_text],
     ), patch(
-        "pecha_api.routines.routines_service._resolve_first_segment_ids_for_texts",
+        "pecha_api.routines.routines_service.build_first_segment_previews_for_texts",
         new_callable=AsyncMock,
         return_value={},
     ):
@@ -2435,9 +2449,11 @@ async def test_get_user_routine_with_multiple_time_blocks():
         new_callable=AsyncMock,
         return_value=[mock_text],
     ), patch(
-        "pecha_api.routines.routines_service._resolve_first_segment_ids_for_texts",
+        "pecha_api.routines.routines_service.build_first_segment_previews_for_texts",
         new_callable=AsyncMock,
-        return_value={str(source_id_2): uuid.uuid4()},
+        return_value={
+            str(source_id_2): (str(uuid.uuid4()), "Evening opening verse"),
+        },
     ):
         result = await get_user_routine(token="token123", skip=0, limit=20)
 
@@ -2607,9 +2623,14 @@ async def test_resolve_sessions_mixed_types():
         new_callable=AsyncMock,
         return_value=[mock_text],
     ), patch(
-        "pecha_api.routines.routines_service._resolve_first_segment_ids_for_texts",
+        "pecha_api.routines.routines_service.build_first_segment_previews_for_texts",
         new_callable=AsyncMock,
-        return_value={str(recitation_source_id): recitation_segment_id},
+        return_value={
+            str(recitation_source_id): (
+                str(recitation_segment_id),
+                "Recitation opening verse",
+            )
+        },
     ), patch(
         "pecha_api.routines.routines_service.get_plan_progress_by_user_id_and_plan_ids",
         return_value={},
@@ -2623,6 +2644,7 @@ async def test_resolve_sessions_mixed_types():
         assert result[2].display_order == 2  # Timer last
         assert result[0].source_id == recitation_segment_id
         assert result[0].title == "Recitation Title"
+        assert result[0].first_segment.content == "Recitation opening verse"
         assert result[1].title == "Plan Title"
         assert result[2].session_type == SessionType.TIMER
         assert result[2].duration_ms == 600000

--- a/tests/routines/test_routines_service.py
+++ b/tests/routines/test_routines_service.py
@@ -735,17 +735,18 @@ def test_resolve_plan_sessions_with_user_progress():
 @pytest.mark.asyncio
 async def test_resolve_recitation_sessions_success():
     session_id = uuid.uuid4()
-    source_id = uuid.uuid4()
+    text_id = uuid.uuid4()
+    segment_id = uuid.uuid4()
 
     session = SimpleNamespace(
         id=session_id,
         session_type=SessionType.RECITATION,
-        source_id=source_id,
+        source_id=text_id,
         display_order=0,
     )
 
     mock_text = SimpleNamespace(
-        id=source_id,
+        id=text_id,
         title="Heart Sutra",
         language="bo",
     )
@@ -754,10 +755,15 @@ async def test_resolve_recitation_sessions_success():
         "pecha_api.routines.routines_service.Text.get_texts_by_ids",
         new_callable=AsyncMock,
         return_value=[mock_text],
+    ), patch(
+        "pecha_api.routines.routines_service._resolve_first_segment_ids_for_texts",
+        new_callable=AsyncMock,
+        return_value={str(text_id): segment_id},
     ):
         result = await _resolve_recitation_sessions(recitation_sessions=[session])
 
         assert len(result) == 1
+        assert result[0].source_id == segment_id
         assert result[0].title == "Heart Sutra"
         assert result[0].language == "bo"
         assert result[0].image is None
@@ -765,15 +771,17 @@ async def test_resolve_recitation_sessions_success():
 
 @pytest.mark.asyncio
 async def test_resolve_recitation_sessions_null_language():
+    text_id = uuid.uuid4()
+    segment_id = uuid.uuid4()
     session = SimpleNamespace(
         id=uuid.uuid4(),
         session_type=SessionType.RECITATION,
-        source_id=uuid.uuid4(),
+        source_id=text_id,
         display_order=0,
     )
 
     mock_text = SimpleNamespace(
-        id=session.source_id,
+        id=text_id,
         title="Test Text",
         language=None,
     )
@@ -782,6 +790,10 @@ async def test_resolve_recitation_sessions_null_language():
         "pecha_api.routines.routines_service.Text.get_texts_by_ids",
         new_callable=AsyncMock,
         return_value=[mock_text],
+    ), patch(
+        "pecha_api.routines.routines_service._resolve_first_segment_ids_for_texts",
+        new_callable=AsyncMock,
+        return_value={str(text_id): segment_id},
     ):
         result = await _resolve_recitation_sessions(recitation_sessions=[session])
 
@@ -802,10 +814,43 @@ async def test_resolve_recitation_sessions_missing_text():
         "pecha_api.routines.routines_service.Text.get_texts_by_ids",
         new_callable=AsyncMock,
         return_value=[],
+    ), patch(
+        "pecha_api.routines.routines_service._resolve_first_segment_ids_for_texts",
+        new_callable=AsyncMock,
+        return_value={},
     ):
         result = await _resolve_recitation_sessions(recitation_sessions=[session])
 
         assert len(result) == 0
+
+
+@pytest.mark.asyncio
+async def test_resolve_recitation_sessions_skips_when_first_segment_missing():
+    text_id = uuid.uuid4()
+    session = SimpleNamespace(
+        id=uuid.uuid4(),
+        session_type=SessionType.RECITATION,
+        source_id=text_id,
+        display_order=0,
+    )
+    mock_text = SimpleNamespace(
+        id=text_id,
+        title="Heart Sutra",
+        language="bo",
+    )
+
+    with patch(
+        "pecha_api.routines.routines_service.Text.get_texts_by_ids",
+        new_callable=AsyncMock,
+        return_value=[mock_text],
+    ), patch(
+        "pecha_api.routines.routines_service._resolve_first_segment_ids_for_texts",
+        new_callable=AsyncMock,
+        return_value={},
+    ):
+        result = await _resolve_recitation_sessions(recitation_sessions=[session])
+
+        assert result == []
 
 
 def test_resolve_timer_sessions_success():
@@ -2389,6 +2434,10 @@ async def test_get_user_routine_with_multiple_time_blocks():
         "pecha_api.routines.routines_service.Text.get_texts_by_ids",
         new_callable=AsyncMock,
         return_value=[mock_text],
+    ), patch(
+        "pecha_api.routines.routines_service._resolve_first_segment_ids_for_texts",
+        new_callable=AsyncMock,
+        return_value={str(source_id_2): uuid.uuid4()},
     ):
         result = await get_user_routine(token="token123", skip=0, limit=20)
 
@@ -2513,6 +2562,7 @@ async def test_resolve_sessions_mixed_types():
     timer_session_id = uuid.uuid4()
     plan_source_id = uuid.uuid4()
     recitation_source_id = uuid.uuid4()
+    recitation_segment_id = uuid.uuid4()
 
     sessions = [
         SimpleNamespace(
@@ -2557,6 +2607,10 @@ async def test_resolve_sessions_mixed_types():
         new_callable=AsyncMock,
         return_value=[mock_text],
     ), patch(
+        "pecha_api.routines.routines_service._resolve_first_segment_ids_for_texts",
+        new_callable=AsyncMock,
+        return_value={str(recitation_source_id): recitation_segment_id},
+    ), patch(
         "pecha_api.routines.routines_service.get_plan_progress_by_user_id_and_plan_ids",
         return_value={},
     ):
@@ -2567,6 +2621,7 @@ async def test_resolve_sessions_mixed_types():
         assert result[0].display_order == 0  # Recitation first
         assert result[1].display_order == 1  # Plan second
         assert result[2].display_order == 2  # Timer last
+        assert result[0].source_id == recitation_segment_id
         assert result[0].title == "Recitation Title"
         assert result[1].title == "Plan Title"
         assert result[2].session_type == SessionType.TIMER
@@ -2797,6 +2852,7 @@ def test_validate_accumulators_not_found():
 def test_resolve_accumulator_sessions_success():
     user_id = uuid.uuid4()
     preset_id = uuid.uuid4()
+    mantra_id = uuid.uuid4()
     session_id = uuid.uuid4()
     session = SimpleNamespace(
         id=session_id,
@@ -2804,10 +2860,13 @@ def test_resolve_accumulator_sessions_success():
         source_id=preset_id,
         display_order=2,
     )
-    metadata = SimpleNamespace(name="Mani Preset", language="en")
+    accumulator_metadata = SimpleNamespace(name="Mani Preset", language="en")
+    mantra_metadata = SimpleNamespace(title="Om Mani Padme Hum", language="en")
+    mantra = SimpleNamespace(id=mantra_id, metadata_entries=[mantra_metadata])
     preset = SimpleNamespace(
         id=preset_id,
-        metadata_entries=[metadata],
+        mantra_id=mantra_id,
+        metadata_entries=[accumulator_metadata],
     )
     db = MagicMock()
     query_chain = MagicMock()
@@ -2816,6 +2875,9 @@ def test_resolve_accumulator_sessions_success():
     db.query.return_value = query_chain
 
     with patch(
+        "pecha_api.routines.routines_service.get_mantras_by_ids",
+        return_value={mantra_id: mantra},
+    ), patch(
         "pecha_api.routines.routines_service.resolve_accumulator_bookmark_mala_image_url",
         return_value="https://example.com/mala.jpg",
     ):
@@ -2830,12 +2892,51 @@ def test_resolve_accumulator_sessions_success():
     assert dto.id == session_id
     assert dto.session_type == SessionType.ACCUMULATOR
     assert dto.accumulator_id == preset_id
-    assert dto.title == "Mani Preset"
+    assert dto.title == "Om Mani Padme Hum"
     assert dto.language == "en"
     assert dto.display_order == 2
     serialized = dto.model_dump()
     assert serialized["accumulator_id"] == preset_id
     assert "source_id" not in serialized
+
+
+def test_resolve_accumulator_sessions_without_mantra_returns_untitled():
+    user_id = uuid.uuid4()
+    preset_id = uuid.uuid4()
+    session_id = uuid.uuid4()
+    session = SimpleNamespace(
+        id=session_id,
+        session_type=SessionType.ACCUMULATOR,
+        source_id=preset_id,
+        display_order=0,
+    )
+    accumulator_metadata = SimpleNamespace(name="Mani Preset", language="en")
+    preset = SimpleNamespace(
+        id=preset_id,
+        mantra_id=None,
+        metadata_entries=[accumulator_metadata],
+    )
+    db = MagicMock()
+    query_chain = MagicMock()
+    query_chain.filter.return_value = query_chain
+    query_chain.all.return_value = [preset]
+    db.query.return_value = query_chain
+
+    with patch(
+        "pecha_api.routines.routines_service.get_mantras_by_ids",
+        return_value={},
+    ), patch(
+        "pecha_api.routines.routines_service.resolve_accumulator_bookmark_mala_image_url",
+        return_value=None,
+    ):
+        result = _resolve_accumulator_sessions(
+            db=db,
+            accumulator_sessions=[session],
+            user_id=user_id,
+        )
+
+    assert len(result) == 1
+    assert result[0].title == "Untitled"
 
 
 def test_resolve_accumulator_sessions_missing_preset_skipped():

--- a/tests/texts/test_first_segment_preview_service.py
+++ b/tests/texts/test_first_segment_preview_service.py
@@ -1,0 +1,44 @@
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from pecha_api.texts.first_segment_preview_service import (
+    build_first_segment_preview_for_text,
+)
+from pecha_api.texts.texts_toc_utils import combine_segment_preview_contents
+
+
+def test_combine_segment_preview_contents_joins_non_empty_segments():
+    assert combine_segment_preview_contents(["Verse 1", "Verse 2", "Verse 3"]) == (
+        "Verse 1\nVerse 2\nVerse 3"
+    )
+
+
+@pytest.mark.asyncio
+async def test_build_first_segment_preview_for_text_combines_first_three_segments():
+    text_id = str(uuid.uuid4())
+    first_segment_id = uuid.uuid4()
+    second_segment_id = uuid.uuid4()
+    third_segment_id = uuid.uuid4()
+
+    mock_segments = [
+        SimpleNamespace(id=first_segment_id, content="Verse 1"),
+        SimpleNamespace(id=second_segment_id, content="Verse 2"),
+        SimpleNamespace(id=third_segment_id, content="Verse 3"),
+    ]
+
+    with patch(
+        "pecha_api.texts.first_segment_preview_service.get_contents_by_id",
+        new_callable=AsyncMock,
+        return_value=[],
+    ), patch(
+        "pecha_api.texts.first_segment_preview_service.Segment.get_segments_by_text_id",
+        new_callable=AsyncMock,
+        return_value=mock_segments,
+    ):
+        segment_id, preview_content = await build_first_segment_preview_for_text(text_id)
+
+    assert segment_id == str(first_segment_id)
+    assert preview_content == "Verse 1\nVerse 2\nVerse 3"


### PR DESCRIPTION
- Renamed `upsert_push_device_token` to `delete_push_device_token_by_token` and updated its logic to remove conflicting tokens based on the provided token, with an option to exclude a specific ID.
- Introduced `_upsert_push_device_token` in the service layer to handle the creation and updating of push device tokens, ensuring proper management of existing tokens and their states.
- Updated tests to reflect changes in the repository and service methods, ensuring comprehensive coverage for the new functionality.