### PR TITLE
Add LA to LanguageCode enum and update OpenAPI spec

### DIFF
--- a/migrations/versions/b0c1d2e3f4a5_add_la_to_languagecode.py
+++ b/migrations/versions/b0c1d2e3f4a5_add_la_to_languagecode.py
@@ -1,0 +1,31 @@
+"""add LA to languagecode enum
+
+Revision ID: b0c1d2e3f4a5
+Revises: a9b0c1d2e3f4
+Create Date: 2026-07-22 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "b0c1d2e3f4a5"
+down_revision: Union[str, None] = "a9b0c1d2e3f4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Add Ladakhi to the languagecode enum so it matches languages.json.
+    # This type backs the `language` column on plans, series_metadata,
+    # mantra_metadata, event_metadata, tag_metadata and accumulator_metadata.
+    op.execute("ALTER TYPE languagecode ADD VALUE IF NOT EXISTS 'LA'")
+
+
+def downgrade() -> None:
+    # Note: PostgreSQL doesn't support removing enum values directly.
+    # This would require recreating the enum type and all dependent columns.
+    # For safety, we leave the enum values in place during downgrade.
+    pass

--- a/pecha_api/plans/plans_enums.py
+++ b/pecha_api/plans/plans_enums.py
@@ -34,6 +34,7 @@ class LanguageCode(enum.Enum):
     HI = "HI"
     NE = "NE"
     MN = "MN"
+    LA = "LA"
 
 class SortOrder(enum.Enum):
     ASC = "asc"

--- a/spec/series-openapi-spec.yaml
+++ b/spec/series-openapi-spec.yaml
@@ -396,7 +396,7 @@ paths:
           required: false
           schema:
             type: string
-          description: Filter plans by language (EN, BO, ZH, HI, NE, MN). Case-insensitive.
+          description: Filter plans by language (EN, BO, ZH, HI, NE, MN, LA). Case-insensitive.
       responses:
         '200':
           description: The requested Series.
@@ -518,7 +518,7 @@ components:
           type: string
           description: >-
             Language code of the metadata row. In practice the server emits a
-            LanguageCode enum value (`EN`, `BO`, `ZH`, `HI`, `NE`, `MN`), but the response model
+            LanguageCode enum value (`EN`, `BO`, `ZH`, `HI`, `NE`, `MN`, `LA`), but the response model
             is typed as a plain string and is not enum-validated.
 
     CreateSeriesRequest:
@@ -541,7 +541,7 @@ components:
           type: object
           nullable: true
           description: >-
-            Map of language code (EN/BO/ZH/HI/NE/MN) to an ordered list of plan UUIDs.
+            Map of language code (EN/BO/ZH/HI/NE/MN/LA) to an ordered list of plan UUIDs.
             Keys are validated against LanguageCode.
           additionalProperties:
             type: array
@@ -568,7 +568,7 @@ components:
           type: object
           nullable: true
           description: >-
-            Map of language code (EN/BO/ZH/HI/NE/MN) to an ordered list of plan UUIDs.
+            Map of language code (EN/BO/ZH/HI/NE/MN/LA) to an ordered list of plan UUIDs.
             Keys are validated against LanguageCode.
           additionalProperties:
             type: array
@@ -605,7 +605,7 @@ components:
           type: string
           description: >-
             Language code of the plan. In practice the server emits a
-            LanguageCode enum value (`EN`, `BO`, `ZH`, `HI`, `NE`, `MN`), but the response model
+            LanguageCode enum value (`EN`, `BO`, `ZH`, `HI`, `NE`, `MN`, `LA`), but the response model
             is typed as a plain string and is not enum-validated.
         difficulty_level:
           allOf:

--- a/tests/languages/test_language_views.py
+++ b/tests/languages/test_language_views.py
@@ -10,6 +10,7 @@ from pecha_api.app import api
 from pecha_api.languages import language_service
 from pecha_api.languages.language_response_models import LanguageDTO, LanguageListResponse
 from pecha_api.languages.language_service import list_languages_service, load_languages
+from pecha_api.plans.plans_enums import LanguageCode
 
 client = TestClient(api)
 
@@ -160,3 +161,19 @@ class TestListLanguagesEndpoint:
         assert "languages" in body
         assert len(body["languages"]) >= 1
         assert {"code", "name", "native_name", "enabled"} <= set(body["languages"][0])
+
+
+class TestLanguageCodeSync:
+    def test_language_code_enum_matches_languages_json(self):
+        payload = load_languages()
+        json_codes = {
+            entry["code"].upper()
+            for entry in payload.get("languages", [])
+        }
+        enum_codes = {code.value for code in LanguageCode}
+
+        assert enum_codes == json_codes, (
+            "LanguageCode enum must match pecha_api/languages/languages.json. "
+            f"Missing in enum: {sorted(json_codes - enum_codes)}. "
+            f"Extra in enum: {sorted(enum_codes - json_codes)}."
+        )


### PR DESCRIPTION
- Added 'LA' to the LanguageCode enum in plans_enums.py.
- Updated OpenAPI specification to include 'LA' in language filtering descriptions and response models.
- Introduced a new test to ensure the LanguageCode enum matches the languages defined in the JSON payload.