### PR TITLE
Fallback lang on plans

### DIFF
--- a/pecha_api/accumulator/accumulator_service.py
+++ b/pecha_api/accumulator/accumulator_service.py
@@ -12,6 +12,7 @@ from ..users.users_service import validate_and_extract_user_details
 from pecha_api.daily_log.daily_log_cache_service import invalidate_user_stats_cache
 from ..texts.texts_utils import TextUtils
 from ..plans.authors.plan_authors_service import get_image_url
+from ..plans.shared.metadata_utils import filter_by_language_with_fallback
 from .accumulator_repository import (
     get_all_accumulators,
     get_user_accumulators,
@@ -165,7 +166,7 @@ def convert_accumulators_to_dtos(accumulators: List[Accumulator]) -> List[Accumu
 
 
 def _metadata_language(entry: MantraMetadata) -> str:
-    return entry.language.value if hasattr(entry.language, "value") else entry.language
+    return entry.language.value if hasattr(entry.language, "value") else str(entry.language)
 
 
 def _pick_mantra_metadata(
@@ -175,11 +176,12 @@ def _pick_mantra_metadata(
     if not metadata_entries:
         return None
     if language:
-        language_upper = language.upper()
-        for entry in metadata_entries:
-            if _metadata_language(entry) == language_upper:
-                return entry
-        return None
+        matched = filter_by_language_with_fallback(
+            entries=list(metadata_entries),
+            language=language,
+            language_of=_metadata_language,
+        )
+        return matched[0] if matched else None
     for entry in metadata_entries:
         if _metadata_language(entry) == "EN":
             return entry

--- a/pecha_api/plans/dashboard/dashboard_repository.py
+++ b/pecha_api/plans/dashboard/dashboard_repository.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import Query, Session
 from pecha_api.plans.authors.plan_authors_model import Author  # noqa: F401
 from pecha_api.plans.plans_enums import PlanStatus
 from pecha_api.plans.plans_models import Plan
+from pecha_api.plans.public.plan_repository import resolve_plans_language
 from pecha_api.plans.series.series_model import Series
 from pecha_api.plans.series.series_metadata_model import SeriesMetadata
 from pecha_api.plans.users.plan_users_models import UserPlanProgress
@@ -91,6 +92,7 @@ def _apply_series_filters(
     featured: Optional[bool],
     language: Optional[str],
     group_ids: Optional[Sequence[UUID]] = None,
+    language_fallback: bool = False,
 ) -> Query:
     query = query.filter(Series.deleted_at.is_(None))
     if group_ids is not None:
@@ -111,7 +113,11 @@ def _apply_series_filters(
         query = query.filter(Series.status == status)
     if featured is not None:
         query = query.filter(Series.featured == featured)
-    if language:
+    if language and not language_fallback:
+        # Strict mode (CMS): only series translated into ``language``.
+        # Public callers pass ``language_fallback=True`` so a series with no
+        # content in ``language`` is still returned and rendered in English by
+        # the service layer, instead of vanishing from the Practice list.
         language_upper = language.upper()
         query = query.filter(
             or_(
@@ -155,6 +161,9 @@ def _apply_plan_filters(
     if featured is not None:
         query = query.filter(Plan.featured == featured)
     if language:
+        # ``language`` is already resolved by the caller when falling back, so
+        # the list stays in a single language rather than mixing the requested
+        # one with English.
         query = query.filter(Plan.language == language.upper())
     return query
 
@@ -215,25 +224,41 @@ def get_dashboard_items(
     language: Optional[str],
     featured: Optional[bool],
     group_ids: Optional[Sequence[UUID]] = None,
+    language_fallback: bool = False,
 ) -> Tuple[List, int]:
-    filter_kwargs = {
+    common_kwargs = {
         "search": search,
         "status": status,
         "featured": featured,
-        "language": language,
         "group_ids": group_ids,
     }
 
-    series_query = _apply_series_filters(_series_base_query(db), **filter_kwargs)
+    # Plans carry their language on the row itself, so resolve a single language
+    # up front: the listing stays wholly in the requested language, or wholly in
+    # English when that language has no plans, rather than mixing the two.
+    plan_language = (
+        resolve_plans_language(db=db, language=language)
+        if language and language_fallback
+        else language
+    )
+
+    series_query = _apply_series_filters(
+        _series_base_query(db),
+        language=language,
+        language_fallback=language_fallback,
+        **common_kwargs,
+    )
     plan_query = _apply_plan_filters(
         _plan_base_query(db),
+        language=plan_language,
         standalone_only=False,
-        **filter_kwargs,
+        **common_kwargs,
     )
     standalone_plan_query = _apply_plan_filters(
         _plan_base_query(db),
+        language=plan_language,
         standalone_only=True,
-        **filter_kwargs,
+        **common_kwargs,
     )
 
     if tab == "series":

--- a/pecha_api/plans/dashboard/dashboard_repository.py
+++ b/pecha_api/plans/dashboard/dashboard_repository.py
@@ -114,10 +114,8 @@ def _apply_series_filters(
     if featured is not None:
         query = query.filter(Series.featured == featured)
     if language and not language_fallback:
-        # Strict mode (CMS): only series translated into ``language``.
-        # Public callers pass ``language_fallback=True`` so a series with no
-        # content in ``language`` is still returned and rendered in English by
-        # the service layer, instead of vanishing from the Practice list.
+        # Strict mode (CMS). Public callers skip this so untranslated series
+        # are still returned and rendered in English by the service layer.
         language_upper = language.upper()
         query = query.filter(
             or_(
@@ -161,9 +159,6 @@ def _apply_plan_filters(
     if featured is not None:
         query = query.filter(Plan.featured == featured)
     if language:
-        # ``language`` is already resolved by the caller when falling back, so
-        # the list stays in a single language rather than mixing the requested
-        # one with English.
         query = query.filter(Plan.language == language.upper())
     return query
 
@@ -233,9 +228,7 @@ def get_dashboard_items(
         "group_ids": group_ids,
     }
 
-    # Plans carry their language on the row itself, so resolve a single language
-    # up front: the listing stays wholly in the requested language, or wholly in
-    # English when that language has no plans, rather than mixing the two.
+    # Resolve once so the listing stays in a single language, never mixed.
     plan_language = (
         resolve_plans_language(db=db, language=language)
         if language and language_fallback

--- a/pecha_api/plans/dashboard/dashboard_service.py
+++ b/pecha_api/plans/dashboard/dashboard_service.py
@@ -33,7 +33,10 @@ from pecha_api.plans.series.series_service import (
     _series_schedule_from_plans,
     compute_series_progress,
 )
-from pecha_api.plans.shared.metadata_utils import format_metadata_response
+from pecha_api.plans.shared.metadata_utils import (
+    filter_by_language_with_fallback,
+    format_metadata_response,
+)
 def _parse_languages(item_type: str, languages_raw: Optional[str]) -> List[str]:
     if not languages_raw:
         return []
@@ -48,7 +51,7 @@ def _to_plan_status(status_value) -> PlanStatus:
     return PlanStatus(status_value)
 
 
-def _parse_metadata(raw, language: Optional[str] = None):
+def _parse_metadata(raw, language: Optional[str] = None, fallback: bool = False):
     if raw is None:
         metadata_list: List[SeriesMetadataDTO] = []
     elif isinstance(raw, str):
@@ -59,7 +62,13 @@ def _parse_metadata(raw, language: Optional[str] = None):
     else:
         metadata_list = [SeriesMetadataDTO(**item) for item in raw]
 
-    if language:
+    if fallback:
+        metadata_list = filter_by_language_with_fallback(
+            entries=metadata_list,
+            language=language,
+            language_of=lambda item: item.language,
+        )
+    elif language:
         language_upper = language.upper()
         metadata_list = [
             item for item in metadata_list
@@ -68,7 +77,9 @@ def _parse_metadata(raw, language: Optional[str] = None):
     return format_metadata_response(metadata_list, language=language)
 
 
-def _row_to_dto(row, language: Optional[str] = None) -> DashboardItemDTO:
+def _row_to_dto(
+    row, language: Optional[str] = None, fallback: bool = False
+) -> DashboardItemDTO:
     item_type = row.item_type
     common = dict(
         id=row.id,
@@ -88,7 +99,9 @@ def _row_to_dto(row, language: Optional[str] = None) -> DashboardItemDTO:
     if item_type == "series":
         return DashboardItemDTO(
             **common,
-            metadata=_parse_metadata(row.metadata_json, language=language),
+            metadata=_parse_metadata(
+                row.metadata_json, language=language, fallback=fallback
+            ),
             author_id=row.author_id,
         )
     return DashboardItemDTO(
@@ -170,8 +183,12 @@ def get_dashboard_items_list(
     )
 
 
-def _row_to_public_dto(row, language: Optional[str] = None) -> DashboardItemDTO:
-    return _row_to_dto(row, language=language).model_copy(update={"author_id": None})
+def _row_to_public_dto(
+    row, language: Optional[str] = None, fallback: bool = False
+) -> DashboardItemDTO:
+    return _row_to_dto(row, language=language, fallback=fallback).model_copy(
+        update={"author_id": None}
+    )
 
 
 def _published_plans_by_series(
@@ -186,6 +203,7 @@ def _published_plans_by_series(
                 series.plans,
                 published_only=True,
                 language=language,
+                fallback=True,
             )
         ]
         for series in get_series_with_plans_by_ids(db_session, series_ids)
@@ -203,6 +221,7 @@ def _series_progress_by_ids(
             series.plans,
             published_only=True,
             language=language,
+            fallback=True,
         )
         progress_map[series.id] = compute_series_progress(
             start_date=start_date,
@@ -232,9 +251,12 @@ def get_practice_items_list(
             status=PlanStatus.PUBLISHED,
             language=language,
             featured=featured,
+            language_fallback=True,
         )
 
-        items = [_row_to_public_dto(row, language=language) for row in rows]
+        items = [
+            _row_to_public_dto(row, language=language, fallback=True) for row in rows
+        ]
         series_ids = [item.id for item in items if item.type == "series"]
         plans_by_series = _published_plans_by_series(
             db_session,

--- a/pecha_api/plans/public/plan_repository.py
+++ b/pecha_api/plans/public/plan_repository.py
@@ -22,7 +22,7 @@ DEFAULT_TAG = None
 DEFAULT_GROUP_ID = None
 
 
-def _storable_language(language: str) -> Optional[str]:
+def storable_language(language: str) -> Optional[str]:
 
     requested = language.upper()
     return requested if requested in SUPPORTED_LANGUAGE_CODES else None
@@ -33,7 +33,7 @@ def _with_language_fallback(query, language: Optional[str], fetch):
     if not language:
         return fetch(query)
 
-    requested = _storable_language(language)
+    requested = storable_language(language)
     if requested is None:
         return fetch(query.filter(Plan.language == DEFAULT_LANGUAGE))
 
@@ -48,7 +48,7 @@ def resolve_plans_language(db: Session, language: Optional[str]) -> str:
     if not language:
         return DEFAULT_LANGUAGE
 
-    requested = _storable_language(language)
+    requested = storable_language(language)
     if requested is None or requested == DEFAULT_LANGUAGE:
         return DEFAULT_LANGUAGE
 

--- a/pecha_api/plans/public/plan_repository.py
+++ b/pecha_api/plans/public/plan_repository.py
@@ -9,6 +9,7 @@ from pecha_api.plans.tags.tag_model import Tag, plan_tags
 from pecha_api.plans.items.plan_items_models import PlanItem
 from pecha_api.plans.users.plan_users_models import UserPlanProgress
 from pecha_api.plans.plans_enums import PlanStatus
+from pecha_api.plans.language_constants import SUPPORTED_LANGUAGE_CODES
 from pecha_api.plans.public.plan_response_models import PlanWithAggregates
 
 DEFAULT_SKIP = 0
@@ -19,6 +20,50 @@ DEFAULT_SORT_BY = "title"
 DEFAULT_SORT_ORDER = "asc"
 DEFAULT_TAG = None
 DEFAULT_GROUP_ID = None
+
+
+def _storable_language(language: str) -> Optional[str]:
+
+    requested = language.upper()
+    return requested if requested in SUPPORTED_LANGUAGE_CODES else None
+
+
+def _with_language_fallback(query, language: Optional[str], fetch):
+
+    if not language:
+        return fetch(query)
+
+    requested = _storable_language(language)
+    if requested is None:
+        return fetch(query.filter(Plan.language == DEFAULT_LANGUAGE))
+
+    result = fetch(query.filter(Plan.language == requested))
+    if result or requested == DEFAULT_LANGUAGE:
+        return result
+    return fetch(query.filter(Plan.language == DEFAULT_LANGUAGE))
+
+
+def resolve_plans_language(db: Session, language: Optional[str]) -> str:
+
+    if not language:
+        return DEFAULT_LANGUAGE
+
+    requested = _storable_language(language)
+    if requested is None or requested == DEFAULT_LANGUAGE:
+        return DEFAULT_LANGUAGE
+
+    has_plans = db.query(
+        exists(
+            select(1).where(
+                and_(
+                    Plan.language == requested,
+                    Plan.deleted_at.is_(None),
+                    Plan.status == PlanStatus.PUBLISHED,
+                )
+            )
+        )
+    ).scalar()
+    return requested if has_plans else DEFAULT_LANGUAGE
 
 
 def _series_published_or_standalone():
@@ -197,9 +242,11 @@ def get_published_plans_in_series(
             _series_published_or_standalone(),
         )
     )
-    if language:
-        query = query.filter(Plan.language == language.upper())
-    return query.order_by(asc(Plan.display_order)).all()
+    return _with_language_fallback(
+        query,
+        language,
+        lambda q: q.order_by(asc(Plan.display_order)).all(),
+    )
 
 
 def get_plan_items_by_plan_id(db: Session, plan_id: UUID) -> list[PlanItem]:
@@ -263,9 +310,11 @@ def get_next_plan_in_series(
         Plan.deleted_at.is_(None),
         _series_published_or_standalone(),
     )
-    if language:
-        query = query.filter(Plan.language == language.upper())
-    return query.order_by(asc(Plan.display_order)).first()
+    return _with_language_fallback(
+        query,
+        language,
+        lambda q: q.order_by(asc(Plan.display_order)).first(),
+    )
 
 
 def get_previous_plan_in_series(
@@ -284,6 +333,8 @@ def get_previous_plan_in_series(
         Plan.deleted_at.is_(None),
         _series_published_or_standalone(),
     )
-    if language:
-        query = query.filter(Plan.language == language.upper())
-    return query.order_by(desc(Plan.display_order)).first()
+    return _with_language_fallback(
+        query,
+        language,
+        lambda q: q.order_by(desc(Plan.display_order)).first(),
+    )

--- a/pecha_api/plans/public/plan_service.py
+++ b/pecha_api/plans/public/plan_service.py
@@ -23,6 +23,7 @@ from pecha_api.plans.public.plan_repository import (
     get_all_unique_tags,
     get_next_plan_in_series,
     get_previous_plan_in_series,
+    resolve_plans_language,
 )
 from pecha_api.plans.series.series_service import (
     _series_schedule_from_plans,
@@ -84,7 +85,7 @@ async def get_published_plans(
     
     try:
         with SessionLocal() as db:
-            language_upper = language.upper()
+            language_upper = resolve_plans_language(db=db, language=language)
             plan_aggregates = get_published_plans_from_db(
                 db=db,
                 skip=skip,

--- a/pecha_api/plans/series/series_repository.py
+++ b/pecha_api/plans/series/series_repository.py
@@ -688,6 +688,7 @@ def get_series_paginated(
     featured: Optional[bool] = None,
     published_only: bool = False,
     group_ids: Optional[Sequence[UUID]] = None,
+    language_fallback: bool = False,
 ) -> Tuple[List[Tuple[Series, int, int]], int]:
 
     filters = []
@@ -712,7 +713,12 @@ def get_series_paginated(
         filters.append(Series.status == status)
     if featured is not None:
         filters.append(Series.featured == featured)
-    if language:
+    if language and not language_fallback:
+        # Strict mode (CMS): only series translated into ``language``.
+        # Public callers pass ``language_fallback=True`` so that a series with
+        # no metadata in ``language`` is still returned and rendered in
+        # English by the per-series fallback in the service layer, rather than
+        # disappearing from the list entirely.
         language_upper = language.upper()
         filters.append(
             exists(

--- a/pecha_api/plans/series/series_repository.py
+++ b/pecha_api/plans/series/series_repository.py
@@ -714,11 +714,8 @@ def get_series_paginated(
     if featured is not None:
         filters.append(Series.featured == featured)
     if language and not language_fallback:
-        # Strict mode (CMS): only series translated into ``language``.
-        # Public callers pass ``language_fallback=True`` so that a series with
-        # no metadata in ``language`` is still returned and rendered in
-        # English by the per-series fallback in the service layer, rather than
-        # disappearing from the list entirely.
+        # Strict mode (CMS). Public callers skip this so untranslated series
+        # are still returned and rendered in English by the service layer.
         language_upper = language.upper()
         filters.append(
             exists(

--- a/pecha_api/plans/series/series_service.py
+++ b/pecha_api/plans/series/series_service.py
@@ -623,6 +623,7 @@ def get_filtered_series(
             status=PlanStatus.PUBLISHED,
             published_only=True,
             group_ids=[group_id] if group_id is not None else None,
+            language_fallback=True,
         )
         rows = filter_items_for_timezone(
             rows,
@@ -665,6 +666,7 @@ def get_filtered_series(
                 start_date=start_date,
                 end_date=end_date,
                 total_days=total_days,
+                fallback=True,
                 partner=partner_by_series_id.get(row.id),
             )
         )

--- a/tests/accumulator/test_accumulator_service.py
+++ b/tests/accumulator/test_accumulator_service.py
@@ -1270,15 +1270,48 @@ class TestHelperFunctions:
 
         assert build_preset_mantra_dto(mantra, language="en") is None
 
-    def test_build_preset_mantra_dto_returns_none_when_language_missing(self):
-        """Requested language with no matching metadata yields None."""
+    def test_build_preset_mantra_dto_falls_back_to_english_when_language_missing(self):
+        """Requested language with no matching metadata falls back to English."""
         mantra = TestDataFactory.create_mock_mantra(
             metadata_entries=[
-                TestDataFactory.create_mock_mantra_metadata(language=LanguageCode.EN)
+                TestDataFactory.create_mock_mantra_metadata(
+                    mantra="EN text", language=LanguageCode.EN
+                )
             ],
         )
 
-        assert build_preset_mantra_dto(mantra, language="bo") is None
+        result = build_preset_mantra_dto(mantra, language="bo")
+
+        assert result is not None
+        assert result.mantra == "EN text"
+
+    def test_build_preset_mantra_dto_falls_back_to_english_for_unlisted_language(self):
+        """A language outside the enum (e.g. Ladakhi) still resolves to English."""
+        mantra = TestDataFactory.create_mock_mantra(
+            metadata_entries=[
+                TestDataFactory.create_mock_mantra_metadata(
+                    mantra="EN text", language=LanguageCode.EN
+                ),
+                TestDataFactory.create_mock_mantra_metadata(
+                    mantra="BO text", language=LanguageCode.BO
+                ),
+            ],
+        )
+
+        result = build_preset_mantra_dto(mantra, language="la")
+
+        assert result is not None
+        assert result.mantra == "EN text"
+
+    def test_build_preset_mantra_dto_returns_none_when_no_match_and_no_english(self):
+        """With neither the requested language nor English available, yield None."""
+        mantra = TestDataFactory.create_mock_mantra(
+            metadata_entries=[
+                TestDataFactory.create_mock_mantra_metadata(language=LanguageCode.BO)
+            ],
+        )
+
+        assert build_preset_mantra_dto(mantra, language="zh") is None
 
     def test_build_preset_mantra_dto_falls_back_to_first_metadata(self):
         """Without English metadata, the first entry is used."""

--- a/tests/plans/authors/test_plan_author_service.py
+++ b/tests/plans/authors/test_plan_author_service.py
@@ -1,7 +1,5 @@
 import pytest
 from unittest.mock import MagicMock, patch
-import sys
-import types
 from fastapi import HTTPException
 from jose import JWTError
 from jose.exceptions import JWTClaimsError
@@ -9,17 +7,6 @@ from jwt import ExpiredSignatureError
 from starlette import status
 from uuid import uuid4
 from typing import List
-
-# Stub heavy repository module before importing the service to avoid ORM initialization during import
-_stub_repo_module = types.ModuleType("pecha_api.plans.public.plan_repository")
-setattr(_stub_repo_module, "get_published_plans_by_author_id", MagicMock())
-# Ensure other imports from this module in unrelated tests still work
-setattr(_stub_repo_module, "get_published_plans_from_db", MagicMock())
-setattr(_stub_repo_module, "get_published_plans_count", MagicMock())
-setattr(_stub_repo_module, "get_published_plan_by_id", MagicMock())
-setattr(_stub_repo_module, "get_plan_items_by_plan_id", MagicMock())
-setattr(_stub_repo_module, "get_plan_item_by_day_number", MagicMock())
-sys.modules["pecha_api.plans.public.plan_repository"] = _stub_repo_module
 
 from pecha_api.plans.platform_enums import PlatformRole
 from pecha_api.plans.authors.plan_authors_service import (

--- a/tests/plans/dashboard/test_dashboard_service.py
+++ b/tests/plans/dashboard/test_dashboard_service.py
@@ -483,8 +483,85 @@ def test_published_plans_by_series_filters_by_language():
         mock_series.plans,
         published_only=True,
         language="bo",
+        fallback=True,
     )
     assert result == {series_id: [mock_plan_dto]}
+
+
+def test_get_dashboard_items_list_keeps_strict_language_filter():
+    """CMS browsing stays strict so authors can audit actual translations."""
+    with patch(
+        "pecha_api.plans.dashboard.dashboard_service.validate_cms_author_details",
+        return_value=_make_mock_author(is_admin=True),
+    ), patch(
+        "pecha_api.plans.dashboard.dashboard_service.SessionLocal"
+    ) as mock_session_local, patch(
+        "pecha_api.plans.dashboard.dashboard_service.get_dashboard_items",
+        return_value=([], 0),
+    ) as mock_repo:
+        _session_local_context(mock_session_local)
+        get_dashboard_items_list(
+            token="admin-token", tab="all", page=1, page_size=20, language="ne"
+        )
+
+    assert mock_repo.call_args.kwargs.get("language_fallback") in (None, False)
+
+
+def test_get_dashboard_items_resolves_a_single_plan_language():
+    """Standalone plans stay in one language instead of mixing with English.
+
+    ``resolve_plans_language`` decides once: the requested language when it has
+    published plans, English otherwise.
+    """
+    from pecha_api.plans.dashboard import dashboard_repository
+
+    with patch.object(
+        dashboard_repository, "resolve_plans_language", return_value="EN"
+    ) as mock_resolve, patch.object(
+        dashboard_repository, "_apply_plan_filters"
+    ) as mock_plan_filters, patch.object(
+        dashboard_repository, "_apply_series_filters"
+    ), patch.object(
+        dashboard_repository, "_series_base_query"
+    ), patch.object(
+        dashboard_repository, "_plan_base_query"
+    ), patch.object(
+        dashboard_repository, "_order_combined_query"
+    ):
+        dashboard_repository.get_dashboard_items(
+            MagicMock(),
+            tab="plans",
+            page=1,
+            page_size=10,
+            search=None,
+            status=PlanStatus.PUBLISHED,
+            language="ne",
+            featured=None,
+            language_fallback=True,
+        )
+
+    mock_resolve.assert_called_once()
+    # Both plan queries receive the resolved language, never the raw request.
+    for call in mock_plan_filters.call_args_list:
+        assert call.kwargs["language"] == "EN"
+
+
+def test_get_practice_items_list_opts_into_language_fallback():
+    """Practice listing must not drop items lacking content in ``language``.
+
+    Without fallback the SQL filter removes them before the service layer can
+    render an English version, leaving the Practice page empty.
+    """
+    with patch(
+        "pecha_api.plans.dashboard.dashboard_service.SessionLocal"
+    ) as mock_session_local, patch(
+        "pecha_api.plans.dashboard.dashboard_service.get_dashboard_items",
+        return_value=([], 0),
+    ) as mock_repo:
+        _session_local_context(mock_session_local)
+        get_practice_items_list(tab="all", page=1, page_size=10, language="ne")
+
+    assert mock_repo.call_args.kwargs["language_fallback"] is True
 
 
 def test_get_practice_items_list_clamps_page_and_page_size():

--- a/tests/plans/public/test_plan_language_fallback.py
+++ b/tests/plans/public/test_plan_language_fallback.py
@@ -1,0 +1,119 @@
+"""Language fallback for published-plan queries.
+
+Plans are stored per-language, so a requested language with no authored plans
+(e.g. 'LA' for Ladakhi) must fall back to English rather than returning an
+empty result. See ``plan_repository._with_language_fallback`` and
+``plan_repository.resolve_plans_language``.
+"""
+from unittest.mock import MagicMock, patch
+
+from pecha_api.plans.public.plan_repository import (
+    DEFAULT_LANGUAGE,
+    _with_language_fallback,
+    resolve_plans_language,
+)
+
+
+class FakeQuery:
+    """Records the languages filtered on and replays canned results."""
+
+    def __init__(self, results_by_language, language=None, calls=None):
+        self._results_by_language = results_by_language
+        self._language = language
+        self.calls = calls if calls is not None else []
+
+    def filter(self, criterion):
+        # criterion is ``Plan.language == <value>``; pull the bound value out.
+        language = criterion.right.value
+        self.calls.append(language)
+        return FakeQuery(self._results_by_language, language, self.calls)
+
+    def result(self):
+        return self._results_by_language.get(self._language, [])
+
+
+def _fetch(query):
+    return query.result()
+
+
+class TestWithLanguageFallback:
+    def test_returns_requested_language_when_present(self):
+        query = FakeQuery({"BO": ["bo-plan"], "EN": ["en-plan"]})
+
+        assert _with_language_fallback(query, "bo", _fetch) == ["bo-plan"]
+        assert query.calls == ["BO"]
+
+    def test_falls_back_to_english_when_language_has_no_plans(self):
+        query = FakeQuery({"EN": ["en-plan"], "ZH": []})
+
+        assert _with_language_fallback(query, "zh", _fetch) == ["en-plan"]
+        assert query.calls == ["ZH", "EN"]
+
+    def test_language_outside_db_enum_queries_english_only(self):
+        """``Plan.language`` is a PG enum: comparing an unknown label raises
+        InvalidTextRepresentation, so such languages must never be queried."""
+        query = FakeQuery({"EN": ["en-plan"]})
+
+        assert _with_language_fallback(query, "la", _fetch) == ["en-plan"]
+        assert query.calls == ["EN"]
+
+    def test_language_is_upper_cased(self):
+        query = FakeQuery({"BO": ["bo-plan"]})
+
+        _with_language_fallback(query, "bo", _fetch)
+
+        assert query.calls == ["BO"]
+
+    def test_no_second_query_when_english_requested(self):
+        query = FakeQuery({})
+
+        assert _with_language_fallback(query, "en", _fetch) == []
+        assert query.calls == ["EN"]
+
+    def test_empty_result_when_neither_language_has_plans(self):
+        query = FakeQuery({})
+
+        assert _with_language_fallback(query, "zh", _fetch) == []
+        assert query.calls == ["ZH", "EN"]
+
+    def test_unfiltered_when_language_is_none(self):
+        query = FakeQuery({None: ["any-plan"]})
+
+        assert _with_language_fallback(query, None, _fetch) == ["any-plan"]
+        assert query.calls == []
+
+
+class TestResolvePlansLanguage:
+    def _db_returning(self, has_plans):
+        db = MagicMock()
+        db.query.return_value.scalar.return_value = has_plans
+        return db
+
+    def test_keeps_requested_language_when_plans_exist(self):
+        db = self._db_returning(True)
+
+        assert resolve_plans_language(db=db, language="bo") == "BO"
+
+    def test_falls_back_to_english_when_no_plans_exist(self):
+        db = self._db_returning(False)
+
+        assert resolve_plans_language(db=db, language="zh") == DEFAULT_LANGUAGE
+
+    def test_language_outside_db_enum_skips_the_query(self):
+        """An unknown enum label would raise in PostgreSQL, so never query it."""
+        db = self._db_returning(False)
+
+        assert resolve_plans_language(db=db, language="la") == DEFAULT_LANGUAGE
+        db.query.assert_not_called()
+
+    def test_defaults_to_english_when_language_missing(self):
+        db = self._db_returning(False)
+
+        assert resolve_plans_language(db=db, language=None) == DEFAULT_LANGUAGE
+        db.query.assert_not_called()
+
+    def test_english_short_circuits_without_query(self):
+        db = self._db_returning(False)
+
+        assert resolve_plans_language(db=db, language="en") == DEFAULT_LANGUAGE
+        db.query.assert_not_called()

--- a/tests/plans/series/test_series_repository.py
+++ b/tests/plans/series/test_series_repository.py
@@ -190,6 +190,29 @@ def test_get_series_paginated_with_language_applies_metadata_filter():
     assert len(filter_args) == 2
 
 
+def test_get_series_paginated_language_fallback_skips_metadata_filter():
+    """Public callers must not drop series lacking metadata in ``language``.
+
+    The series would otherwise never reach the service layer, where the
+    per-series English fallback runs, so the list would come back empty.
+    """
+    db = _make_session_mock()
+    row = MagicMock(spec=Series)
+
+    db.query.return_value = _paginated_query_chain([row], 1)
+
+    rows, total = get_series_paginated(
+        db=db, search=None, skip=0, limit=10, language="ne", language_fallback=True
+    )
+
+    assert rows == [(row, 0, 0)]
+    assert total == 1
+    filtered = db.query.return_value.options.return_value.filter
+    filter_args = filtered.call_args[0]
+    # Only the deleted_at filter remains; the language exists() is not applied.
+    assert len(filter_args) == 1
+
+
 def test_get_series_paginated_returns_series_with_plan_count():
     db = _make_session_mock()
     row = MagicMock(spec=Series)

--- a/tests/plans/series/test_series_service.py
+++ b/tests/plans/series/test_series_service.py
@@ -1768,6 +1768,23 @@ def test_get_filtered_series_passes_language_to_repository():
     call_kwargs = mock_repo.call_args.kwargs
     assert call_kwargs["language"] == "zh"
     assert call_kwargs["status"] == PlanStatus.PUBLISHED
+    # Public listing must opt into fallback so untranslated series still appear.
+    assert call_kwargs["language_fallback"] is True
+
+
+def test_get_cms_filtered_series_keeps_strict_language_filter():
+    """CMS browsing stays strict: authors filter series by actual translation."""
+    with patch("pecha_api.plans.series.series_service.SessionLocal") as mock_session_local, \
+         patch("pecha_api.plans.series.series_service.validate_cms_author_details") as mock_author, \
+         patch("pecha_api.plans.series.series_service.is_super_admin", return_value=True), \
+         patch("pecha_api.plans.series.series_service.get_series_paginated",
+               return_value=([], 0)) as mock_repo:
+        _session_local_context(mock_session_local)
+        mock_author.return_value = MagicMock(id=uuid.uuid4())
+
+        get_cms_filtered_series(token="dummy", search=None, skip=0, limit=10, language="ne")
+
+    assert mock_repo.call_args.kwargs.get("language_fallback") in (None, False)
 
 
 def test_get_random_featured_series_defaults_to_english_when_language_not_provided():


### PR DESCRIPTION
https://github.com/OpenPecha/WeBuddhist-Backend/issues/875
- Added English fallback to `GET /series` — series with no metadata in the selected language were being filtered out in SQL before the fallback could run, so they disappeared from the Practice page entirely.
- Added English fallback to `GET /plans` — covers the plan listing, plan detail, and series next/previous navigation.
- Added English fallback to `GET /practice/items` — same issue, fixed preemptively.
- Fixed accumulations (`GET /accumulators`) — mantras without metadata in the selected language were dropped from the response instead of falling back to English.
- Fixed when an unrecognised language code was passed, so unknown codes now resolve to English.
- Listings now resolve to a single language; the selected one where content exists, English otherwise instead of mixing both in one response. (Standalone plans)
