### PR TITLE
Add idempotency checks for event_links table and index creation

### DIFF
--- a/documentation/accumulator-api.md
+++ b/documentation/accumulator-api.md
@@ -154,6 +154,8 @@ Accumulators support **multi-language metadata** with `name` and `description` f
 | `updated_at` | datetime | Last update timestamp |
 | `deleted_at` | datetime? | Soft delete timestamp |
 
+> **`text_id` note**: `GroupAccumulator` does not store `text_id` directly. When `accumulator_id` is set, it points at a preset `Accumulator` row, and presets now carry their own `text_id` (UUID, added alongside `mantra_id` — see [Accumulator](#accumulator) below) linking the practice to a recitation text. To resolve which text a group accumulator practices, read `accumulator_id` off the group accumulator response, then fetch `GET /accumulators/{accumulator_id}` (or `GET /accumulators/presets`) and read `text_id` off that preset. See [Resolving `text_id` for a group accumulator](#resolving-text_id-for-a-group-accumulator) for the full flow.
+
 ### GroupAccumulatorJoin
 
 | Field | Type | Description |
@@ -604,6 +606,8 @@ List all active group accumulators for a specific group.
 ```
 
 **App usage**: Call this when opening a group page to populate the list of group accumulations/practices available in that group.
+
+**Note**: `accumulator_id` (renamed `preset_accumulator_id` in some responses — see [GroupAccumulatorDTO](#groupaccumulatordto)) is the only pointer back to the preset. It does not itself carry `text_id`; fetch the preset (`GET /accumulators/{accumulator_id}`) to read `text_id` if the client needs to deep-link into the practiced text.
 
 ---
 

--- a/migrations/versions/c1d2e3f4a5b7_add_event_links_table.py
+++ b/migrations/versions/c1d2e3f4a5b7_add_event_links_table.py
@@ -10,6 +10,8 @@ from typing import Sequence, Union
 from alembic import op
 import sqlalchemy as sa
 
+from migrations.idempotency import index_exists, table_exists
+
 revision: str = 'c1d2e3f4a5b7'
 down_revision: Union[str, None] = 'b0c1d2e3f4a5'
 branch_labels: Union[str, Sequence[str], None] = None
@@ -17,20 +19,23 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    op.create_table(
-        'event_links',
-        sa.Column('id', sa.UUID(), nullable=False),
-        sa.Column('event_id', sa.UUID(), nullable=False),
-        sa.Column('type', sa.String(length=50), nullable=False),
-        sa.Column('url', sa.String(length=2000), nullable=False),
-        sa.Column('label', sa.String(length=255), nullable=True),
-        sa.Column('display_order', sa.Integer(), nullable=False, server_default='1'),
-        sa.Column('created_at', sa.DateTime(timezone=True), nullable=False),
-        sa.Column('updated_at', sa.DateTime(timezone=True), nullable=True),
-        sa.ForeignKeyConstraint(['event_id'], ['events.id'], ondelete='CASCADE'),
-        sa.PrimaryKeyConstraint('id'),
-    )
-    op.create_index('idx_event_links_event_id', 'event_links', ['event_id'], unique=False)
+    if not table_exists('event_links'):
+        op.create_table(
+            'event_links',
+            sa.Column('id', sa.UUID(), nullable=False),
+            sa.Column('event_id', sa.UUID(), nullable=False),
+            sa.Column('type', sa.String(length=50), nullable=False),
+            sa.Column('url', sa.String(length=2000), nullable=False),
+            sa.Column('label', sa.String(length=255), nullable=True),
+            sa.Column('display_order', sa.Integer(), nullable=False, server_default='1'),
+            sa.Column('created_at', sa.DateTime(timezone=True), nullable=False),
+            sa.Column('updated_at', sa.DateTime(timezone=True), nullable=True),
+            sa.ForeignKeyConstraint(['event_id'], ['events.id'], ondelete='CASCADE'),
+            sa.PrimaryKeyConstraint('id'),
+        )
+
+    if not index_exists('event_links', 'idx_event_links_event_id'):
+        op.create_index('idx_event_links_event_id', 'event_links', ['event_id'], unique=False)
 
 
 def downgrade() -> None:

--- a/migrations/versions/e1f2a3b4c5d6_ensure_event_links_table.py
+++ b/migrations/versions/e1f2a3b4c5d6_ensure_event_links_table.py
@@ -1,0 +1,46 @@
+"""ensure event_links table exists
+
+Revision ID: e1f2a3b4c5d6
+Revises: 4b87b7a7d6c1
+Create Date: 2026-07-30 12:45:00.000000
+
+Repair migration for databases stamped past c1d2e3f4a5b7 without running it.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+from migrations.idempotency import index_exists, table_exists
+
+revision: str = "e1f2a3b4c5d6"
+down_revision: Union[str, None] = "4b87b7a7d6c1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    if not table_exists("event_links"):
+        op.create_table(
+            "event_links",
+            sa.Column("id", sa.UUID(), nullable=False),
+            sa.Column("event_id", sa.UUID(), nullable=False),
+            sa.Column("type", sa.String(length=50), nullable=False),
+            sa.Column("url", sa.String(length=2000), nullable=False),
+            sa.Column("label", sa.String(length=255), nullable=True),
+            sa.Column("display_order", sa.Integer(), nullable=False, server_default="1"),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+            sa.ForeignKeyConstraint(["event_id"], ["events.id"], ondelete="CASCADE"),
+            sa.PrimaryKeyConstraint("id"),
+        )
+
+    if not index_exists("event_links", "idx_event_links_event_id"):
+        op.create_index(
+            "idx_event_links_event_id", "event_links", ["event_id"], unique=False
+        )
+
+
+def downgrade() -> None:
+    # No-op: c1d2e3f4a5b7 owns dropping this table.
+    pass


### PR DESCRIPTION
- Implemented checks to ensure the 'event_links' table and its index 'idx_event_links_event_id' are only created if they do not already exist.
- This change enhances the migration's robustness by preventing errors during upgrades when the table or index is already present.