### PR TITLE
Implement nested comments functionality in GroupPostComment model

### DIFF
--- a/migrations/versions/f2a3b4c5d6e8_add_parent_comment_id_to_comments.py
+++ b/migrations/versions/f2a3b4c5d6e8_add_parent_comment_id_to_comments.py
@@ -1,0 +1,51 @@
+"""add parent comment id to group post comments
+
+Revision ID: f2a3b4c5d6e8
+Revises: e1f2a3b4c5d6
+Create Date: 2026-07-30 15:30:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "f2a3b4c5d6e8"
+down_revision: Union[str, None] = "e1f2a3b4c5d6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "group_post_comments",
+        sa.Column("parent_comment_id", sa.UUID(), nullable=True),
+    )
+    op.create_foreign_key(
+        "group_post_comments_parent_comment_id_fkey",
+        "group_post_comments",
+        "group_post_comments",
+        ["parent_comment_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.create_index(
+        "idx_group_post_comments_parent_comment_id",
+        "group_post_comments",
+        ["parent_comment_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "idx_group_post_comments_parent_comment_id",
+        table_name="group_post_comments",
+    )
+    op.drop_constraint(
+        "group_post_comments_parent_comment_id_fkey",
+        "group_post_comments",
+        type_="foreignkey",
+    )
+    op.drop_column("group_post_comments", "parent_comment_id")

--- a/pecha_api/group_posts/comment_models.py
+++ b/pecha_api/group_posts/comment_models.py
@@ -17,6 +17,7 @@ from pecha_api.db.database import Base
 
 FK_GROUP_POSTS_ID = "group_posts.id"
 FK_USERS_ID = "users.id"
+FK_GROUP_POST_COMMENTS_ID = "group_post_comments.id"
 
 
 class GroupPostComment(Base):
@@ -32,6 +33,11 @@ class GroupPostComment(Base):
         UUID(as_uuid=True),
         ForeignKey(FK_USERS_ID, ondelete="CASCADE"),
         nullable=False,
+    )
+    parent_comment_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey(FK_GROUP_POST_COMMENTS_ID, ondelete="CASCADE"),
+        nullable=True,
     )
     text = Column(Text, nullable=False)
 
@@ -49,10 +55,22 @@ class GroupPostComment(Base):
 
     post = relationship("GroupPost")
     user = relationship("Users")
+    parent_comment = relationship(
+        "GroupPostComment",
+        remote_side=[id],
+        foreign_keys=[parent_comment_id],
+        back_populates="replies",
+    )
+    replies = relationship(
+        "GroupPostComment",
+        foreign_keys=[parent_comment_id],
+        back_populates="parent_comment",
+    )
 
     __table_args__ = (
         Index("idx_group_post_comments_post_id", "post_id"),
         Index("idx_group_post_comments_user_id", "user_id"),
+        Index("idx_group_post_comments_parent_comment_id", "parent_comment_id"),
         Index(
             "idx_group_post_comments_feed",
             "post_id",

--- a/pecha_api/group_posts/comment_response_models.py
+++ b/pecha_api/group_posts/comment_response_models.py
@@ -10,6 +10,7 @@ class GroupPostCommentDTO(BaseModel):
     id: UUID
     post_id: UUID
     user_id: UUID
+    parent_comment_id: Optional[UUID] = None
     user_email: str
     text: str
     created_at: str
@@ -27,6 +28,7 @@ class GroupPostCommentsResponse(BaseModel):
 class CreateGroupPostCommentRequest(BaseModel):
     """Request to create a comment."""
     text: str
+    parent_comment_id: Optional[UUID] = None
 
     @field_validator("text")
     @classmethod

--- a/pecha_api/group_posts/comment_service.py
+++ b/pecha_api/group_posts/comment_service.py
@@ -40,6 +40,7 @@ def build_comment_dto(comment: GroupPostComment) -> GroupPostCommentDTO:
         id=comment.id,
         post_id=comment.post_id,
         user_id=comment.user_id,
+        parent_comment_id=comment.parent_comment_id,
         user_email=user_email,
         text=comment.text,
         created_at=_isoformat(comment.created_at),
@@ -98,11 +99,24 @@ def create_post_comment_service(
     post_id: UUID,
     author_email: str,
     text: str,
+    parent_comment_id: Optional[UUID] = None,
 ) -> GroupPostCommentDTO:
-    """Create a comment on a post. User must be authenticated."""
+    """Create a top-level comment or a reply to any comment on the post."""
     with SessionLocal() as db:
         _validate_group_is_public(db, group_id)
         _validate_post_published(db, post_id, group_id)
+
+        if parent_comment_id is not None:
+            parent_comment = get_comment_by_id(
+                db=db,
+                comment_id=parent_comment_id,
+                post_id=post_id,
+            )
+            if not parent_comment:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail="Parent comment not found",
+                )
 
         # Look up user by email in Users table
         user = db.query(Users).filter(Users.email == author_email).first()
@@ -115,6 +129,7 @@ def create_post_comment_service(
         comment = GroupPostComment(
             post_id=post_id,
             user_id=user.id,
+            parent_comment_id=parent_comment_id,
             text=text,
         )
 

--- a/pecha_api/group_posts/comment_views.py
+++ b/pecha_api/group_posts/comment_views.py
@@ -70,6 +70,7 @@ def create_post_comment(
         post_id=post_id,
         author_email=author.email,
         text=request.text,
+        parent_comment_id=request.parent_comment_id,
     )
 
 
@@ -173,18 +174,28 @@ async def websocket_post_comments(
 
                 # 5. Create comment via existing service
                 try:
+                    parent_comment_id = data.get("parent_comment_id")
+                    if parent_comment_id is not None:
+                        parent_comment_id = UUID(str(parent_comment_id))
+
                     comment_dto = create_post_comment_service(
                         group_id=group_id,
                         post_id=post_id,
                         author_email=author.email,
                         text=data.get("text", ""),
+                        parent_comment_id=parent_comment_id,
                     )
-                except HTTPException as e:
-                    logger.error(f"Comment creation failed: {e.detail}")
+                except (HTTPException, ValueError) as e:
+                    detail = (
+                        e.detail
+                        if isinstance(e, HTTPException)
+                        else "Invalid parent_comment_id"
+                    )
+                    logger.error(f"Comment creation failed: {detail}")
                     await websocket.send_json({
                         "type": "error",
-                        "code": e.detail if isinstance(e.detail, str) else "ERROR",
-                        "message": e.detail if isinstance(e.detail, str) else str(e.detail)
+                        "code": detail if isinstance(detail, str) else "ERROR",
+                        "message": detail if isinstance(detail, str) else str(detail)
                     })
                     continue
 

--- a/tests/group_posts/test_group_post_comments_service.py
+++ b/tests/group_posts/test_group_post_comments_service.py
@@ -24,10 +24,18 @@ class MockUser:
 
 
 class MockComment:
-    def __init__(self, user=None, user_id=None, post_id=None, text="Great post!"):
+    def __init__(
+        self,
+        user=None,
+        user_id=None,
+        post_id=None,
+        parent_comment_id=None,
+        text="Great post!",
+    ):
         self.id = uuid4()
         self.post_id = post_id or uuid4()
         self.user_id = user_id or uuid4()
+        self.parent_comment_id = parent_comment_id
         self.user = user or MockUser(user_id=self.user_id)
         self.text = text
         self.created_at = datetime.now(tz.utc)
@@ -150,6 +158,14 @@ class TestBuildCommentDTO:
         assert dto.updated_at is None
         assert dto.created_at == comment.created_at.isoformat()
 
+    def test_includes_parent_comment_id(self):
+        parent_comment_id = uuid4()
+        comment = MockComment(parent_comment_id=parent_comment_id)
+
+        dto = build_comment_dto(comment)
+
+        assert dto.parent_comment_id == parent_comment_id
+
 
 class TestCreatePostCommentService:
 
@@ -187,7 +203,88 @@ class TestCreatePostCommentService:
         persisted = mock_create.call_args.kwargs["comment"]
         assert persisted.post_id == post_id
         assert persisted.user_id == user.id
+        assert persisted.parent_comment_id is None
         assert persisted.text == "Hello"
+
+    @patch('pecha_api.group_posts.comment_service.create_comment')
+    @patch('pecha_api.group_posts.comment_service.get_comment_by_id')
+    @patch('pecha_api.group_posts.comment_service.get_post_by_id')
+    @patch('pecha_api.group_posts.comment_service.get_group_by_id')
+    @patch('pecha_api.group_posts.comment_service.SessionLocal')
+    def test_create_multilevel_reply_success(
+        self,
+        mock_session,
+        mock_get_group,
+        mock_get_post,
+        mock_get_comment,
+        mock_create,
+    ):
+        group_id = uuid4()
+        post_id = uuid4()
+        parent_comment_id = uuid4()
+        mock_db = MagicMock()
+        mock_session.return_value.__enter__.return_value = mock_db
+        mock_get_group.return_value = MockGroup(id=group_id)
+        mock_get_post.return_value = MockPost(id=post_id, group_id=group_id)
+        mock_get_comment.return_value = MockComment(post_id=post_id)
+
+        user = MockUser(email="commenter@example.com")
+        mock_db.query.return_value.filter.return_value.first.return_value = user
+        mock_create.return_value = MockComment(
+            user=user,
+            user_id=user.id,
+            post_id=post_id,
+            parent_comment_id=parent_comment_id,
+            text="Nested reply",
+        )
+
+        result = create_post_comment_service(
+            group_id=group_id,
+            post_id=post_id,
+            author_email=user.email,
+            text="Nested reply",
+            parent_comment_id=parent_comment_id,
+        )
+
+        assert result.parent_comment_id == parent_comment_id
+        persisted = mock_create.call_args.kwargs["comment"]
+        assert persisted.parent_comment_id == parent_comment_id
+        mock_get_comment.assert_called_once_with(
+            db=mock_db,
+            comment_id=parent_comment_id,
+            post_id=post_id,
+        )
+
+    @patch('pecha_api.group_posts.comment_service.get_comment_by_id')
+    @patch('pecha_api.group_posts.comment_service.get_post_by_id')
+    @patch('pecha_api.group_posts.comment_service.get_group_by_id')
+    @patch('pecha_api.group_posts.comment_service.SessionLocal')
+    def test_create_reply_rejects_parent_outside_post(
+        self,
+        mock_session,
+        mock_get_group,
+        mock_get_post,
+        mock_get_comment,
+    ):
+        group_id = uuid4()
+        post_id = uuid4()
+        parent_comment_id = uuid4()
+        mock_session.return_value.__enter__.return_value = MagicMock()
+        mock_get_group.return_value = MockGroup(id=group_id)
+        mock_get_post.return_value = MockPost(id=post_id, group_id=group_id)
+        mock_get_comment.return_value = None
+
+        with pytest.raises(HTTPException) as exc_info:
+            create_post_comment_service(
+                group_id=group_id,
+                post_id=post_id,
+                author_email="commenter@example.com",
+                text="Reply",
+                parent_comment_id=parent_comment_id,
+            )
+
+        assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
+        assert exc_info.value.detail == "Parent comment not found"
 
     @patch('pecha_api.group_posts.comment_service.get_post_by_id')
     @patch('pecha_api.group_posts.comment_service.get_group_by_id')

--- a/tests/group_posts/test_group_post_comments_views.py
+++ b/tests/group_posts/test_group_post_comments_views.py
@@ -18,12 +18,18 @@ def get_client():
 AUTH_HEADERS = {"Authorization": "Bearer test-token"}
 
 
-def _comment_dto(post_id=None, user_id=None, user_email="user@example.com") -> GroupPostCommentDTO:
+def _comment_dto(
+    post_id=None,
+    user_id=None,
+    user_email="user@example.com",
+    parent_comment_id=None,
+) -> GroupPostCommentDTO:
     now = datetime.now(tz.utc).isoformat()
     return GroupPostCommentDTO(
         id=uuid4(),
         post_id=post_id or uuid4(),
         user_id=user_id or uuid4(),
+        parent_comment_id=parent_comment_id,
         user_email=user_email,
         text="Great post!",
         created_at=now,
@@ -94,6 +100,39 @@ class TestCreatePostCommentView:
             post_id=post_id,
             author_email="author@example.com",
             text="Great post!",
+            parent_comment_id=None,
+        )
+
+    @patch('pecha_api.group_posts.comment_views.create_post_comment_service')
+    @patch('pecha_api.group_posts.comment_views.validate_and_extract_author_details')
+    def test_create_reply_to_comment(self, mock_validate, mock_service):
+        client = get_client()
+        group_id = uuid4()
+        post_id = uuid4()
+        parent_comment_id = uuid4()
+        mock_validate.return_value = MagicMock(email="author@example.com")
+        mock_service.return_value = _comment_dto(
+            post_id=post_id,
+            parent_comment_id=parent_comment_id,
+        )
+
+        response = client.post(
+            f"/author/groups/{group_id}/posts/{post_id}/comments",
+            headers=AUTH_HEADERS,
+            json={
+                "text": "Nested reply",
+                "parent_comment_id": str(parent_comment_id),
+            },
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.json()["parent_comment_id"] == str(parent_comment_id)
+        mock_service.assert_called_once_with(
+            group_id=group_id,
+            post_id=post_id,
+            author_email="author@example.com",
+            text="Nested reply",
+            parent_comment_id=parent_comment_id,
         )
 
     def test_create_comment_requires_auth(self):

--- a/tests/group_posts/test_group_post_comments_websocket_views.py
+++ b/tests/group_posts/test_group_post_comments_websocket_views.py
@@ -50,12 +50,13 @@ class FakePubSub:
             raise self.unsubscribe_error
 
 
-def _comment_dto(post_id) -> GroupPostCommentDTO:
+def _comment_dto(post_id, parent_comment_id=None) -> GroupPostCommentDTO:
     now = datetime.now(tz.utc).isoformat()
     return GroupPostCommentDTO(
         id=uuid4(),
         post_id=post_id,
         user_id=uuid4(),
+        parent_comment_id=parent_comment_id,
         user_email="user@example.com",
         text="Great post!",
         created_at=now,
@@ -221,6 +222,32 @@ class TestWebSocketPostCommentsMessages:
             post_id=post_id,
             author_email=author.email,
             text="Great post!",
+            parent_comment_id=None,
+        )
+        broadcaster.broadcast_comment.assert_awaited_once_with(post_id, dto)
+
+    def test_creates_and_broadcasts_reply(self):
+        group_id = uuid4()
+        post_id = uuid4()
+        parent_comment_id = uuid4()
+        author = MockAuthor()
+        dto = _comment_dto(post_id, parent_comment_id=parent_comment_id)
+
+        with _websocket_env(author=author) as (broadcaster, mock_create):
+            mock_create.return_value = dto
+            with client.websocket_connect(_ws_url(group_id, post_id)) as websocket:
+                websocket.send_json({
+                    "type": "comment",
+                    "text": "Nested reply",
+                    "parent_comment_id": str(parent_comment_id),
+                })
+
+        mock_create.assert_called_once_with(
+            group_id=group_id,
+            post_id=post_id,
+            author_email=author.email,
+            text="Nested reply",
+            parent_comment_id=parent_comment_id,
         )
         broadcaster.broadcast_comment.assert_awaited_once_with(post_id, dto)
 


### PR DESCRIPTION
- Added `parent_comment_id` field to the `GroupPostComment` model to support replies to existing comments.
- Updated related DTOs and request models to include `parent_comment_id`.
- Enhanced the comment creation service to handle nested comments, including validation for parent comment existence.
- Modified view functions and websocket handling to accommodate the new reply feature.
- Added tests to ensure proper functionality of nested comments and validation logic.