### PR TITLE
Add event participation tracking and response updates

### DIFF
--- a/pecha_api/events/event_participant_repository.py
+++ b/pecha_api/events/event_participant_repository.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 from uuid import UUID
 
 from sqlalchemy import func, select
@@ -19,6 +19,21 @@ def is_user_joined_event(db: Session, event_id: UUID, user_id: UUID) -> bool:
         )
     ).first()
     return row is not None
+
+
+def get_joined_event_ids_by_user(
+    db: Session,
+    user_id: UUID,
+    event_ids: Optional[List[UUID]] = None,
+) -> List[UUID]:
+    if event_ids is not None and not event_ids:
+        return []
+    query = db.query(GroupEventParticipant.event_id).filter(
+        GroupEventParticipant.user_id == user_id,
+    )
+    if event_ids is not None:
+        query = query.filter(GroupEventParticipant.event_id.in_(event_ids))
+    return [row.event_id for row in query.all()]
 
 
 def upsert_event_participant(db: Session, event_id: UUID, user_id: UUID) -> None:

--- a/pecha_api/events/event_response_models.py
+++ b/pecha_api/events/event_response_models.py
@@ -93,6 +93,10 @@ class EventDTO(BaseModel):
     image: Optional[ImageUrlModel] = None
     image_url: Optional[str] = None
     participant_count: int = 0
+    is_joined: Optional[bool] = Field(
+        None,
+        description="Whether the authenticated user has joined (null when unauthenticated)",
+    )
     created_at: datetime
     created_by: str
     updated_at: Optional[datetime] = None

--- a/pecha_api/events/event_service.py
+++ b/pecha_api/events/event_service.py
@@ -27,6 +27,7 @@ from pecha_api.plans.shared.permissions import (
     is_reviewer,
     is_super_admin,
 )
+from pecha_api.users.users_service import validate_and_extract_user_details
 
 from .event_model import Event
 from .event_response_models import (
@@ -49,6 +50,8 @@ from .event_repository import (
 from .event_participant_repository import (
     get_event_participant_count,
     get_event_participant_counts,
+    get_joined_event_ids_by_user,
+    is_user_joined_event,
 )
 
 _CONTENT_EDIT_ROLES = {
@@ -122,6 +125,7 @@ def _event_to_dto(
     language: Optional[str] = None,
     fallback: bool = False,
     participant_count: int = 0,
+    is_joined: Optional[bool] = None,
 ) -> EventDTO:
     return EventDTO(
         id=event.id,
@@ -144,6 +148,7 @@ def _event_to_dto(
         ),
         image_url=event.image_url,
         participant_count=participant_count,
+        is_joined=is_joined,
         created_at=event.created_at,
         created_by=event.created_by,
         updated_at=event.updated_at,
@@ -194,6 +199,7 @@ def get_events_service(
     fallback: bool = False,
     skip: int = 0,
     limit: int = 20,
+    token: Optional[str] = None,
 ) -> EventsResponse:
     with SessionLocal() as db:
         events, total = get_events(
@@ -210,9 +216,20 @@ def get_events_service(
             skip=skip,
             limit=limit,
         )
-        counts_by_event = get_event_participant_counts(
-            db=db, event_ids=[event.id for event in events]
-        )
+        event_ids = [event.id for event in events]
+        counts_by_event = get_event_participant_counts(db=db, event_ids=event_ids)
+
+        joined_ids: set[UUID] = set()
+        if token:
+            current_user = validate_and_extract_user_details(token=token)
+            joined_ids = set(
+                get_joined_event_ids_by_user(
+                    db=db,
+                    user_id=current_user.id,
+                    event_ids=event_ids,
+                )
+            )
+
         return EventsResponse(
             events=[
                 _event_to_dto(
@@ -220,6 +237,7 @@ def get_events_service(
                     language=language,
                     fallback=fallback,
                     participant_count=counts_by_event.get(event.id, 0),
+                    is_joined=(event.id in joined_ids) if token else None,
                 )
                 for event in events
             ],
@@ -293,6 +311,7 @@ def get_events_today_service(
     language: Optional[str] = None,
     skip: int = 0,
     limit: int = 20,
+    token: Optional[str] = None,
 ) -> EventsResponse:
     from_date, to_date = get_day_bounds_in_timezone(timezone)
     return get_events_service(
@@ -303,10 +322,15 @@ def get_events_today_service(
         fallback=True,
         skip=skip,
         limit=limit,
+        token=token,
     )
 
 
-def get_event_by_id_service(event_id: UUID, language: Optional[str] = None) -> EventDTO:
+def get_event_by_id_service(
+    event_id: UUID,
+    language: Optional[str] = None,
+    token: Optional[str] = None,
+) -> EventDTO:
     with SessionLocal() as db:
         event = get_event_by_id(db, event_id)
         if not event:
@@ -315,8 +339,18 @@ def get_event_by_id_service(event_id: UUID, language: Optional[str] = None) -> E
                 detail=f"Event with id '{event_id}' not found",
             )
         participant_count = get_event_participant_count(db=db, event_id=event_id)
+        is_joined = None
+        if token:
+            current_user = validate_and_extract_user_details(token=token)
+            is_joined = is_user_joined_event(
+                db=db, event_id=event_id, user_id=current_user.id
+            )
         return _event_to_dto(
-            event, language=language, fallback=True, participant_count=participant_count
+            event,
+            language=language,
+            fallback=True,
+            participant_count=participant_count,
+            is_joined=is_joined,
         )
 
 
@@ -416,11 +450,32 @@ def delete_event_service(token: str, event_id: UUID) -> None:
 def get_featured_events_service(
     language: Optional[str] = None,
     limit: int = 10,
+    token: Optional[str] = None,
 ) -> List[EventDTO]:
     with SessionLocal() as db:
         events = get_featured_events(db, limit=limit)
+        event_ids = [event.id for event in events]
+        counts_by_event = get_event_participant_counts(db=db, event_ids=event_ids)
+
+        joined_ids: set[UUID] = set()
+        if token:
+            current_user = validate_and_extract_user_details(token=token)
+            joined_ids = set(
+                get_joined_event_ids_by_user(
+                    db=db,
+                    user_id=current_user.id,
+                    event_ids=event_ids,
+                )
+            )
+
         return [
-            _event_to_dto(event, language=language, fallback=True)
+            _event_to_dto(
+                event,
+                language=language,
+                fallback=True,
+                participant_count=counts_by_event.get(event.id, 0),
+                is_joined=(event.id in joined_ids) if token else None,
+            )
             for event in events
         ]
 

--- a/pecha_api/events/event_views.py
+++ b/pecha_api/events/event_views.py
@@ -20,6 +20,7 @@ from .event_participant_service import (
 )
 
 oauth2_scheme = HTTPBearer()
+optional_oauth2_scheme = HTTPBearer(auto_error=False)
 
 events_router = APIRouter(
     prefix="/events",
@@ -40,6 +41,10 @@ def get_events_endpoint(
     language: Annotated[Optional[str], Query(description="Filter metadata by language code")] = None,
     skip: Annotated[int, Query(ge=0)] = 0,
     limit: Annotated[int, Query(ge=1, le=100)] = 20,
+    credentials: Annotated[
+        Optional[HTTPAuthorizationCredentials],
+        Depends(optional_oauth2_scheme),
+    ] = None,
 ) -> EventsResponse:
     return get_events_service(
         group_id=group_id,
@@ -54,6 +59,7 @@ def get_events_endpoint(
         fallback=True,
         skip=skip,
         limit=limit,
+        token=credentials.credentials if credentials else None,
     )
 
 
@@ -67,6 +73,10 @@ def get_events_today_endpoint(
         Optional[str],
         Header(alias="X-Timezone", description="IANA timezone for determining today's date."),
     ] = None,
+    credentials: Annotated[
+        Optional[HTTPAuthorizationCredentials],
+        Depends(optional_oauth2_scheme),
+    ] = None,
 ) -> EventsResponse:
     return get_events_today_service(
         timezone=x_timezone,
@@ -74,6 +84,7 @@ def get_events_today_endpoint(
         language=language,
         skip=skip,
         limit=limit,
+        token=credentials.credentials if credentials else None,
     )
 
 
@@ -81,8 +92,16 @@ def get_events_today_endpoint(
 def get_featured_events_endpoint(
     language: Annotated[Optional[str], Query(description="Filter metadata by language code")] = "en",
     limit: Annotated[int, Query(ge=1, le=100)] = 10,
+    credentials: Annotated[
+        Optional[HTTPAuthorizationCredentials],
+        Depends(optional_oauth2_scheme),
+    ] = None,
 ) -> list[EventDTO]:
-    return get_featured_events_service(language=language, limit=limit)
+    return get_featured_events_service(
+        language=language,
+        limit=limit,
+        token=credentials.credentials if credentials else None,
+    )
 
 
 @events_router.post(
@@ -126,5 +145,13 @@ def get_event_participants_endpoint(
 def get_event_by_id_endpoint(
     event_id: UUID,
     language: Annotated[Optional[str], Query(description="Filter metadata by language code")] = None,
+    credentials: Annotated[
+        Optional[HTTPAuthorizationCredentials],
+        Depends(optional_oauth2_scheme),
+    ] = None,
 ) -> EventDTO:
-    return get_event_by_id_service(event_id=event_id, language=language)
+    return get_event_by_id_service(
+        event_id=event_id,
+        language=language,
+        token=credentials.credentials if credentials else None,
+    )

--- a/tests/events/test_event_is_joined.py
+++ b/tests/events/test_event_is_joined.py
@@ -1,0 +1,182 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+from pecha_api.events.event_service import (
+    get_event_by_id_service,
+    get_events_service,
+    get_featured_events_service,
+)
+
+MODULE = "pecha_api.events.event_service"
+
+
+def _event(event_id=None):
+    now = datetime.now(timezone.utc)
+    return SimpleNamespace(
+        id=event_id or uuid4(),
+        plan_id=None,
+        accumulator_id=None,
+        mantra_id=None,
+        timer_id=None,
+        group_recitation_collection_id=None,
+        group_id=uuid4(),
+        start_date=now,
+        end_date=now,
+        image_url=None,
+        featured=False,
+        metadata_entries=[],
+        links=[],
+        created_at=now,
+        created_by="author@example.com",
+        updated_at=None,
+    )
+
+
+def _user(user_id=None):
+    return SimpleNamespace(id=user_id or uuid4())
+
+
+@patch(f"{MODULE}.SessionLocal")
+@patch(f"{MODULE}.get_event_participant_counts", return_value={})
+@patch(f"{MODULE}.get_events")
+def test_list_without_token_leaves_is_joined_null(
+    mock_get_events, _mock_counts, mock_session
+):
+    mock_session.return_value.__enter__.return_value = MagicMock()
+    event = _event()
+    mock_get_events.return_value = ([event], 1)
+
+    result = get_events_service()
+
+    assert result.events[0].is_joined is None
+
+
+@patch(f"{MODULE}.SessionLocal")
+@patch(f"{MODULE}.validate_and_extract_user_details")
+@patch(f"{MODULE}.get_joined_event_ids_by_user")
+@patch(f"{MODULE}.get_event_participant_counts")
+@patch(f"{MODULE}.get_events")
+def test_list_with_token_sets_is_joined(
+    mock_get_events,
+    mock_counts,
+    mock_joined_ids,
+    mock_validate,
+    mock_session,
+):
+    mock_session.return_value.__enter__.return_value = MagicMock()
+    joined = _event()
+    not_joined = _event()
+    mock_get_events.return_value = ([joined, not_joined], 2)
+    mock_counts.return_value = {joined.id: 3, not_joined.id: 1}
+    user = _user()
+    mock_validate.return_value = user
+    mock_joined_ids.return_value = [joined.id]
+
+    result = get_events_service(token="user-token")
+
+    by_id = {event.id: event for event in result.events}
+    assert by_id[joined.id].is_joined is True
+    assert by_id[not_joined.id].is_joined is False
+    mock_validate.assert_called_once_with(token="user-token")
+    mock_joined_ids.assert_called_once()
+    assert mock_joined_ids.call_args.kwargs["user_id"] == user.id
+    assert set(mock_joined_ids.call_args.kwargs["event_ids"]) == {
+        joined.id,
+        not_joined.id,
+    }
+
+
+@patch(f"{MODULE}.SessionLocal")
+@patch(f"{MODULE}.get_event_participant_count", return_value=2)
+@patch(f"{MODULE}.get_event_by_id")
+def test_detail_without_token_leaves_is_joined_null(
+    mock_get_by_id, _mock_count, mock_session
+):
+    mock_session.return_value.__enter__.return_value = MagicMock()
+    event = _event()
+    mock_get_by_id.return_value = event
+
+    result = get_event_by_id_service(event_id=event.id)
+
+    assert result.is_joined is None
+
+
+@patch(f"{MODULE}.SessionLocal")
+@patch(f"{MODULE}.validate_and_extract_user_details")
+@patch(f"{MODULE}.is_user_joined_event", return_value=True)
+@patch(f"{MODULE}.get_event_participant_count", return_value=2)
+@patch(f"{MODULE}.get_event_by_id")
+def test_detail_with_token_sets_is_joined_true(
+    mock_get_by_id,
+    _mock_count,
+    mock_is_joined,
+    mock_validate,
+    mock_session,
+):
+    mock_session.return_value.__enter__.return_value = MagicMock()
+    event = _event()
+    mock_get_by_id.return_value = event
+    user = _user()
+    mock_validate.return_value = user
+
+    result = get_event_by_id_service(event_id=event.id, token="user-token")
+
+    assert result.is_joined is True
+    mock_is_joined.assert_called_once_with(
+        db=mock_session.return_value.__enter__.return_value,
+        event_id=event.id,
+        user_id=user.id,
+    )
+
+
+@patch(f"{MODULE}.SessionLocal")
+@patch(f"{MODULE}.validate_and_extract_user_details")
+@patch(f"{MODULE}.is_user_joined_event", return_value=False)
+@patch(f"{MODULE}.get_event_participant_count", return_value=0)
+@patch(f"{MODULE}.get_event_by_id")
+def test_detail_with_token_sets_is_joined_false(
+    mock_get_by_id,
+    _mock_count,
+    mock_is_joined,
+    mock_validate,
+    mock_session,
+):
+    mock_session.return_value.__enter__.return_value = MagicMock()
+    event = _event()
+    mock_get_by_id.return_value = event
+    mock_validate.return_value = _user()
+
+    result = get_event_by_id_service(event_id=event.id, token="user-token")
+
+    assert result.is_joined is False
+    mock_is_joined.assert_called_once()
+
+
+@patch(f"{MODULE}.SessionLocal")
+@patch(f"{MODULE}.validate_and_extract_user_details")
+@patch(f"{MODULE}.get_joined_event_ids_by_user")
+@patch(f"{MODULE}.get_event_participant_counts", return_value={})
+@patch(f"{MODULE}.get_featured_events")
+def test_featured_with_token_sets_is_joined(
+    mock_get_featured,
+    _mock_counts,
+    mock_joined_ids,
+    mock_validate,
+    mock_session,
+):
+    mock_session.return_value.__enter__.return_value = MagicMock()
+    joined = _event()
+    not_joined = _event()
+    joined.featured = True
+    not_joined.featured = True
+    mock_get_featured.return_value = [joined, not_joined]
+    mock_validate.return_value = _user()
+    mock_joined_ids.return_value = [joined.id]
+
+    result = get_featured_events_service(token="user-token")
+
+    by_id = {event.id: event for event in result}
+    assert by_id[joined.id].is_joined is True
+    assert by_id[not_joined.id].is_joined is False

--- a/tests/events/test_event_language_fallback.py
+++ b/tests/events/test_event_language_fallback.py
@@ -98,8 +98,9 @@ def test_no_fallback_returns_null_when_selected_language_missing():
 
 
 @patch(f"{MODULE}.SessionLocal")
+@patch(f"{MODULE}.get_event_participant_counts", return_value={})
 @patch(f"{MODULE}.get_events")
-def test_get_events_service_public_uses_fallback(mock_get_events, mock_session):
+def test_get_events_service_public_uses_fallback(mock_get_events, _mock_counts, mock_session):
     mock_session.return_value.__enter__.return_value = MagicMock()
     event = _event([_metadata("en", "English")])
     mock_get_events.return_value = ([event], 1)
@@ -111,8 +112,9 @@ def test_get_events_service_public_uses_fallback(mock_get_events, mock_session):
 
 
 @patch(f"{MODULE}.SessionLocal")
+@patch(f"{MODULE}.get_event_participant_counts", return_value={})
 @patch(f"{MODULE}.get_events")
-def test_get_events_service_cms_default_no_fallback(mock_get_events, mock_session):
+def test_get_events_service_cms_default_no_fallback(mock_get_events, _mock_counts, mock_session):
     mock_session.return_value.__enter__.return_value = MagicMock()
     event = _event([_metadata("en", "English")])
     mock_get_events.return_value = ([event], 1)
@@ -125,8 +127,9 @@ def test_get_events_service_cms_default_no_fallback(mock_get_events, mock_sessio
 
 
 @patch(f"{MODULE}.SessionLocal")
+@patch(f"{MODULE}.get_event_participant_count", return_value=0)
 @patch(f"{MODULE}.get_event_by_id")
-def test_get_event_by_id_service_uses_fallback(mock_get_by_id, mock_session):
+def test_get_event_by_id_service_uses_fallback(mock_get_by_id, _mock_count, mock_session):
     mock_session.return_value.__enter__.return_value = MagicMock()
     event = _event([_metadata("en", "English")])
     mock_get_by_id.return_value = event
@@ -135,3 +138,4 @@ def test_get_event_by_id_service_uses_fallback(mock_get_by_id, mock_session):
 
     assert dto.metadata is not None
     assert dto.metadata.language == "en"
+    assert dto.is_joined is None

--- a/tests/events/test_event_response_serialization.py
+++ b/tests/events/test_event_response_serialization.py
@@ -39,3 +39,4 @@ def test_event_response_omits_null_fields():
     assert "image" not in event_body
     assert "image_url" not in event_body
     assert "updated_at" not in event_body
+    assert "is_joined" not in event_body

--- a/tests/events/test_event_service.py
+++ b/tests/events/test_event_service.py
@@ -41,5 +41,6 @@ def test_get_events_today_service_uses_day_bounds():
         fallback=True,
         skip=0,
         limit=20,
+        token=None,
     )
     assert result == expected

--- a/tests/events/test_event_views.py
+++ b/tests/events/test_event_views.py
@@ -46,6 +46,7 @@ def test_get_events_today_success():
         language=None,
         skip=0,
         limit=20,
+        token=None,
     )
 
 
@@ -68,6 +69,51 @@ def test_get_events_today_with_timezone_header():
         language=None,
         skip=0,
         limit=20,
+        token=None,
+    )
+
+
+def test_get_events_today_forwards_optional_token():
+    response_payload = EventsResponse(events=[], total=0, skip=0, limit=20)
+
+    with patch(
+        "pecha_api.events.event_views.get_events_today_service",
+        return_value=response_payload,
+    ) as mock_service:
+        response = client.get(
+            "/events/today",
+            headers={"Authorization": "Bearer user-token"},
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    mock_service.assert_called_once_with(
+        timezone=None,
+        group_id=None,
+        language=None,
+        skip=0,
+        limit=20,
+        token="user-token",
+    )
+
+
+def test_get_event_by_id_forwards_optional_token():
+    event = _sample_event_dto()
+    event_id = event.id
+
+    with patch(
+        "pecha_api.events.event_views.get_event_by_id_service",
+        return_value=event,
+    ) as mock_service:
+        response = client.get(
+            f"/events/{event_id}",
+            headers={"Authorization": "Bearer user-token"},
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    mock_service.assert_called_once_with(
+        event_id=event_id,
+        language=None,
+        token="user-token",
     )
 
 

--- a/tests/events/test_featured_events_service.py
+++ b/tests/events/test_featured_events_service.py
@@ -44,8 +44,9 @@ def _event(event_id=None, group_id=None, featured=False):
 
 
 @patch(f"{MODULE}.SessionLocal")
+@patch(f"{MODULE}.get_event_participant_counts", return_value={})
 @patch(f"{MODULE}.get_featured_events")
-def test_get_featured_events_returns_list(mock_get_featured, mock_session):
+def test_get_featured_events_returns_list(mock_get_featured, _mock_counts, mock_session):
     mock_db = MagicMock()
     mock_session.return_value.__enter__.return_value = mock_db
     
@@ -57,12 +58,14 @@ def test_get_featured_events_returns_list(mock_get_featured, mock_session):
 
     assert len(result) == 2
     assert all(isinstance(e, EventDTO) for e in result)
+    assert all(e.is_joined is None for e in result)
     mock_get_featured.assert_called_once_with(mock_db, limit=10)
 
 
 @patch(f"{MODULE}.SessionLocal")
+@patch(f"{MODULE}.get_event_participant_counts", return_value={})
 @patch(f"{MODULE}.get_featured_events")
-def test_get_featured_events_empty_list(mock_get_featured, mock_session):
+def test_get_featured_events_empty_list(mock_get_featured, _mock_counts, mock_session):
     mock_db = MagicMock()
     mock_session.return_value.__enter__.return_value = mock_db
     mock_get_featured.return_value = []
@@ -74,8 +77,9 @@ def test_get_featured_events_empty_list(mock_get_featured, mock_session):
 
 
 @patch(f"{MODULE}.SessionLocal")
+@patch(f"{MODULE}.get_event_participant_counts", return_value={})
 @patch(f"{MODULE}.get_featured_events")
-def test_get_featured_events_with_language(mock_get_featured, mock_session):
+def test_get_featured_events_with_language(mock_get_featured, _mock_counts, mock_session):
     mock_db = MagicMock()
     mock_session.return_value.__enter__.return_value = mock_db
     
@@ -89,8 +93,9 @@ def test_get_featured_events_with_language(mock_get_featured, mock_session):
 
 
 @patch(f"{MODULE}.SessionLocal")
+@patch(f"{MODULE}.get_event_participant_counts", return_value={})
 @patch(f"{MODULE}.get_featured_events")
-def test_get_featured_events_respects_limit(mock_get_featured, mock_session):
+def test_get_featured_events_respects_limit(mock_get_featured, _mock_counts, mock_session):
     mock_db = MagicMock()
     mock_session.return_value.__enter__.return_value = mock_db
     

--- a/tests/events/test_featured_events_views.py
+++ b/tests/events/test_featured_events_views.py
@@ -45,7 +45,7 @@ def test_get_featured_events_success():
     body = response.json()
     assert len(body) == 2
     assert all(event["featured"] is True for event in body)
-    mock_service.assert_called_once_with(language="en", limit=10)
+    mock_service.assert_called_once_with(language="en", limit=10, token=None)
 
 
 def test_get_featured_events_default_params():
@@ -56,7 +56,7 @@ def test_get_featured_events_default_params():
         response = client.get("/events/featured")
 
     assert response.status_code == status.HTTP_200_OK
-    mock_service.assert_called_once_with(language="en", limit=10)
+    mock_service.assert_called_once_with(language="en", limit=10, token=None)
 
 
 def test_get_featured_events_custom_params():
@@ -71,7 +71,7 @@ def test_get_featured_events_custom_params():
     assert response.status_code == status.HTTP_200_OK
     body = response.json()
     assert len(body) == 1
-    mock_service.assert_called_once_with(language="bo", limit=5)
+    mock_service.assert_called_once_with(language="bo", limit=5, token=None)
 
 
 def test_get_featured_events_empty():
@@ -84,7 +84,7 @@ def test_get_featured_events_empty():
     assert response.status_code == status.HTTP_200_OK
     body = response.json()
     assert body == []
-    mock_service.assert_called_once_with(language="en", limit=10)
+    mock_service.assert_called_once_with(language="en", limit=10, token=None)
 
 
 def test_get_featured_events_max_limit():
@@ -99,7 +99,21 @@ def test_get_featured_events_max_limit():
     assert response.status_code == status.HTTP_200_OK
     body = response.json()
     assert len(body) == 20
-    mock_service.assert_called_once_with(language="en", limit=100)
+    mock_service.assert_called_once_with(language="en", limit=100, token=None)
+
+
+def test_get_featured_events_forwards_optional_token():
+    with patch(
+        "pecha_api.events.event_views.get_featured_events_service",
+        return_value=[],
+    ) as mock_service:
+        response = client.get(
+            "/events/featured",
+            headers={"Authorization": "Bearer user-token"},
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    mock_service.assert_called_once_with(language="en", limit=10, token="user-token")
 
 
 def test_get_featured_events_invalid_limit():


### PR DESCRIPTION
- Introduced `get_joined_event_ids_by_user` function to retrieve event IDs a user has joined, with optional filtering by specific event IDs.
- Updated `EventDTO` to include `is_joined` field, indicating if the authenticated user has joined the event.
- Enhanced event service functions to populate `is_joined` based on user authentication status.
- Modified event view endpoints to accept an optional token for user identification, allowing for personalized event participation data.
- Added comprehensive tests to validate the new functionality and ensure correct behavior for both authenticated and unauthenticated users.