### PR TITLE
Add group practices feed functionality

### DIFF
--- a/pecha_api/group_accumulator/group_accumulator_repository.py
+++ b/pecha_api/group_accumulator/group_accumulator_repository.py
@@ -65,6 +65,27 @@ def get_group_accumulators(
     return accumulators, total
 
 
+def get_group_accumulators_for_group_ids(
+    db: Session,
+    group_ids: List[UUID],
+    limit: int,
+) -> Tuple[List[GroupAccumulator], int]:
+    """Active group accumulators across the given groups, newest first."""
+    if not group_ids:
+        return [], 0
+    query = (
+        db.query(GroupAccumulator)
+        .options(joinedload(GroupAccumulator.accumulator))
+        .filter(
+            GroupAccumulator.group_id.in_(group_ids),
+            GroupAccumulator.deleted_at.is_(None),
+        )
+    )
+    total = query.count()
+    accumulators = query.order_by(GroupAccumulator.created_at.desc()).limit(limit).all()
+    return accumulators, total
+
+
 def get_group_accumulator_by_id(
     db: Session,
     group_accumulator_id: UUID,

--- a/pecha_api/group_accumulator/group_accumulator_repository.py
+++ b/pecha_api/group_accumulator/group_accumulator_repository.py
@@ -69,6 +69,7 @@ def get_group_accumulators_for_group_ids(
     db: Session,
     group_ids: List[UUID],
     limit: int,
+    exclude_ids: Optional[List[UUID]] = None,
 ) -> Tuple[List[GroupAccumulator], int]:
     """Active group accumulators across the given groups, newest first."""
     if not group_ids:
@@ -81,6 +82,8 @@ def get_group_accumulators_for_group_ids(
             GroupAccumulator.deleted_at.is_(None),
         )
     )
+    if exclude_ids:
+        query = query.filter(GroupAccumulator.id.not_in(exclude_ids))
     total = query.count()
     accumulators = query.order_by(GroupAccumulator.created_at.desc(), GroupAccumulator.id.desc()).limit(limit).all()
     return accumulators, total

--- a/pecha_api/group_accumulator/group_accumulator_repository.py
+++ b/pecha_api/group_accumulator/group_accumulator_repository.py
@@ -82,7 +82,7 @@ def get_group_accumulators_for_group_ids(
         )
     )
     total = query.count()
-    accumulators = query.order_by(GroupAccumulator.created_at.desc()).limit(limit).all()
+    accumulators = query.order_by(GroupAccumulator.created_at.desc(), GroupAccumulator.id.desc()).limit(limit).all()
     return accumulators, total
 
 

--- a/pecha_api/group_posts/comment_like_service.py
+++ b/pecha_api/group_posts/comment_like_service.py
@@ -28,7 +28,6 @@ from pecha_api.group_posts.repository import get_post_by_id_only
 from pecha_api.group_posts.service_utils import (
     isoformat,
     validate_group_is_public,
-    resolve_user_id,
 )
 
 logger = logging.getLogger(__name__)
@@ -55,14 +54,12 @@ def _get_and_validate_comment(db: Session, comment_id: UUID) -> tuple:
 
 def like_comment_service(
     comment_id: UUID,
-    author_email: str,
+    user_id: UUID,
 ) -> LikeCommentResponse:
     """Like a comment. Idempotent - returns 200 if already liked."""
     with SessionLocal() as db:
         comment, post, group_id = _get_and_validate_comment(db, comment_id)
         validate_group_is_public(db, group_id)
-
-        user_id = resolve_user_id(db, author_email)
 
         like = GroupPostCommentLike(
             comment_id=comment_id,
@@ -84,14 +81,12 @@ def like_comment_service(
 
 def unlike_comment_service(
     comment_id: UUID,
-    author_email: str,
+    user_id: UUID,
 ) -> None:
     """Unlike a comment. Idempotent - succeeds even if not liked."""
     with SessionLocal() as db:
         comment, post, group_id = _get_and_validate_comment(db, comment_id)
         validate_group_is_public(db, group_id)
-
-        user_id = resolve_user_id(db, author_email)
 
         delete_like(db=db, comment_id=comment_id, user_id=user_id)
 

--- a/pecha_api/group_posts/comment_like_views.py
+++ b/pecha_api/group_posts/comment_like_views.py
@@ -14,7 +14,7 @@ from pecha_api.group_posts.comment_like_service import (
     unlike_comment_service,
     list_comment_likers_service,
 )
-from pecha_api.plans.authors.plan_authors_service import validate_and_extract_author_details
+from pecha_api.users.users_service import validate_and_extract_user_details
 
 oauth2_scheme = HTTPBearer()
 
@@ -34,10 +34,10 @@ def like_comment(
     response: Response,
 ) -> LikeCommentResponse:
     """Like a comment (requires authentication). Returns 201 if newly created, 200 if already liked."""
-    author = validate_and_extract_author_details(token=authentication_credential.credentials)
+    user = validate_and_extract_user_details(token=authentication_credential.credentials)
     result = like_comment_service(
         comment_id=comment_id,
-        author_email=author.email,
+        user_id=user.id,
     )
     response.status_code = status.HTTP_201_CREATED if result.is_new else status.HTTP_200_OK
     return result
@@ -52,10 +52,10 @@ def unlike_comment(
     authentication_credential: Annotated[HTTPAuthorizationCredentials, Depends(oauth2_scheme)],
 ) -> Response:
     """Unlike a comment (requires authentication). Idempotent - succeeds even if not liked."""
-    author = validate_and_extract_author_details(token=authentication_credential.credentials)
+    user = validate_and_extract_user_details(token=authentication_credential.credentials)
     unlike_comment_service(
         comment_id=comment_id,
-        author_email=author.email,
+        user_id=user.id,
     )
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 

--- a/pecha_api/group_posts/comment_service.py
+++ b/pecha_api/group_posts/comment_service.py
@@ -154,7 +154,7 @@ def list_post_comments_service(
 
 def create_post_comment_service(
     post_id: UUID,
-    author_email: str,
+    user_id: UUID,
     text: str,
     parent_comment_id: Optional[UUID] = None,
 ) -> GroupPostCommentDTO:
@@ -175,17 +175,9 @@ def create_post_comment_service(
                     detail="Parent comment not found",
                 )
 
-        # Look up user by email in Users table
-        user = db.query(Users).filter(Users.email == author_email).first()
-        if not user:
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail=f"User account not found: {author_email}",
-            )
-
         comment = GroupPostComment(
             post_id=post_id,
-            user_id=user.id,
+            user_id=user_id,
             parent_comment_id=parent_comment_id,
             text=text,
         )

--- a/pecha_api/group_posts/comment_views.py
+++ b/pecha_api/group_posts/comment_views.py
@@ -20,10 +20,7 @@ from pecha_api.group_posts.comment_service import (
     list_post_comments_service,
 )
 from pecha_api.group_posts.comment_websocket import get_broadcaster
-from pecha_api.group_posts.service_utils import resolve_user_id
-from pecha_api.plans.authors.plan_authors_service import validate_and_extract_author_details
-from pecha_api.users.users_models import Users
-from pecha_api.db.database import SessionLocal
+from pecha_api.users.users_service import validate_and_extract_user_details
 
 logger = logging.getLogger(__name__)
 
@@ -58,11 +55,8 @@ def list_post_comments(
     user_id = None
     if authentication_credential:
         try:
-            author = validate_and_extract_author_details(token=authentication_credential.credentials)
-            with SessionLocal() as db:
-                user = db.query(Users).filter(Users.email == author.email).first()
-                if user:
-                    user_id = user.id
+            user = validate_and_extract_user_details(token=authentication_credential.credentials)
+            user_id = user.id
         except Exception:
             pass
     return list_post_comments_service(
@@ -84,10 +78,10 @@ def create_post_comment(
     authentication_credential: Annotated[HTTPAuthorizationCredentials, Depends(oauth2_scheme)],
 ) -> GroupPostCommentDTO:
     """Create a comment on a post (requires authentication)."""
-    author = validate_and_extract_author_details(token=authentication_credential.credentials)
+    user = validate_and_extract_user_details(token=authentication_credential.credentials)
     return create_post_comment_service(
         post_id=post_id,
-        author_email=author.email,
+        user_id=user.id,
         text=request.text,
         parent_comment_id=request.parent_comment_id,
     )
@@ -102,12 +96,10 @@ def delete_post_comment(
     authentication_credential: Annotated[HTTPAuthorizationCredentials, Depends(oauth2_scheme)],
 ) -> Response:
     """Delete a comment (only the author can delete)."""
-    author = validate_and_extract_author_details(token=authentication_credential.credentials)
-    with SessionLocal() as db:
-        user_id = resolve_user_id(db, author.email)
+    user = validate_and_extract_user_details(token=authentication_credential.credentials)
     delete_post_comment_service(
         comment_id=comment_id,
-        user_id=user_id,
+        user_id=user.id,
     )
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
@@ -121,7 +113,7 @@ async def websocket_post_comments(
     token: str = Query(...),
 ):
     """Live comment stream for a post (WebSocket)."""
-    author = None
+    user = None
 
     try:
         broadcaster = get_broadcaster()
@@ -133,7 +125,7 @@ async def websocket_post_comments(
     try:
         # 1. Authenticate
         try:
-            author = validate_and_extract_author_details(token=token)
+            user = validate_and_extract_user_details(token=token)
         except HTTPException as auth_error:
             logger.error(f"WebSocket auth failed: {auth_error.detail}")
             await websocket.accept()
@@ -158,7 +150,7 @@ async def websocket_post_comments(
 
         # 3. Accept, track connection, and subscribe to Redis channel
         await websocket.accept()
-        await broadcaster.add_connection(post_id, author.id, websocket)
+        await broadcaster.add_connection(post_id, user.id, websocket)
         pubsub = await broadcaster.subscribe_to_post(post_id)
 
         # 4a. Background task: listen for Redis pub/sub messages
@@ -196,7 +188,7 @@ async def websocket_post_comments(
 
                     comment_dto = create_post_comment_service(
                         post_id=post_id,
-                        author_email=author.email,
+                        user_id=user.id,
                         text=data.get("text", ""),
                         parent_comment_id=parent_comment_id,
                     )
@@ -240,5 +232,5 @@ async def websocket_post_comments(
             pass
 
     finally:
-        if author:
-            await broadcaster.remove_connection(post_id, author.id)
+        if user:
+            await broadcaster.remove_connection(post_id, user.id)

--- a/pecha_api/group_posts/like_service.py
+++ b/pecha_api/group_posts/like_service.py
@@ -28,7 +28,6 @@ from pecha_api.group_posts.repository import get_post_by_id_only
 from pecha_api.group_posts.service_utils import (
     isoformat,
     validate_group_is_public,
-    resolve_user_id,
 )
 
 logger = logging.getLogger(__name__)
@@ -47,14 +46,12 @@ def _get_and_validate_post(db: Session, post_id: UUID) -> tuple:
 
 def like_post_service(
     post_id: UUID,
-    author_email: str,
+    user_id: UUID,
 ) -> LikePostResponse:
     """Like a post. Idempotent - returns 200 if already liked."""
     with SessionLocal() as db:
         post, group_id = _get_and_validate_post(db, post_id)
         validate_group_is_public(db, group_id)
-
-        user_id = resolve_user_id(db, author_email)
 
         like = GroupPostLike(
             post_id=post_id,
@@ -76,14 +73,12 @@ def like_post_service(
 
 def unlike_post_service(
     post_id: UUID,
-    author_email: str,
+    user_id: UUID,
 ) -> None:
     """Unlike a post. Idempotent - succeeds even if not liked."""
     with SessionLocal() as db:
         post, group_id = _get_and_validate_post(db, post_id)
         validate_group_is_public(db, group_id)
-
-        user_id = resolve_user_id(db, author_email)
 
         delete_like(db=db, post_id=post_id, user_id=user_id)
 

--- a/pecha_api/group_posts/like_views.py
+++ b/pecha_api/group_posts/like_views.py
@@ -14,7 +14,7 @@ from pecha_api.group_posts.like_service import (
     unlike_post_service,
     list_post_likers_service,
 )
-from pecha_api.plans.authors.plan_authors_service import validate_and_extract_author_details
+from pecha_api.users.users_service import validate_and_extract_user_details
 
 oauth2_scheme = HTTPBearer()
 
@@ -34,10 +34,10 @@ def like_post(
     response: Response,
 ) -> LikePostResponse:
     """Like a post (requires authentication). Returns 201 if newly created, 200 if already liked."""
-    author = validate_and_extract_author_details(token=authentication_credential.credentials)
+    user = validate_and_extract_user_details(token=authentication_credential.credentials)
     result = like_post_service(
         post_id=post_id,
-        author_email=author.email,
+        user_id=user.id,
     )
     response.status_code = status.HTTP_201_CREATED if result.is_new else status.HTTP_200_OK
     return result
@@ -52,10 +52,10 @@ def unlike_post(
     authentication_credential: Annotated[HTTPAuthorizationCredentials, Depends(oauth2_scheme)],
 ) -> Response:
     """Unlike a post (requires authentication). Idempotent - succeeds even if not liked."""
-    author = validate_and_extract_author_details(token=authentication_credential.credentials)
+    user = validate_and_extract_user_details(token=authentication_credential.credentials)
     unlike_post_service(
         post_id=post_id,
-        author_email=author.email,
+        user_id=user.id,
     )
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 

--- a/pecha_api/group_posts/service_utils.py
+++ b/pecha_api/group_posts/service_utils.py
@@ -9,7 +9,6 @@ from starlette import status
 
 from pecha_api.plans.groups.groups_repository import get_group_by_id
 from pecha_api.plans.response_message import NOT_FOUND
-from pecha_api.users.users_models import Users
 
 logger = logging.getLogger(__name__)
 
@@ -29,14 +28,3 @@ def validate_group_is_public(db: Session, group_id: UUID) -> None:
             status_code=status.HTTP_404_NOT_FOUND,
             detail=NOT_FOUND,
         )
-
-
-def resolve_user_id(db: Session, author_email: str) -> UUID:
-    """Resolve user ID from author email."""
-    user = db.query(Users).filter(Users.email == author_email).first()
-    if not user:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail=f"User account not found: {author_email}",
-        )
-    return user.id

--- a/pecha_api/group_recitation_collection/repository.py
+++ b/pecha_api/group_recitation_collection/repository.py
@@ -55,6 +55,7 @@ def get_collections_for_group_ids_with_total(
     db: Session,
     group_ids: List[UUID],
     limit: int,
+    exclude_ids: Optional[List[UUID]] = None,
 ) -> Tuple[List[GroupRecitationCollection], int]:
     """Get non-deleted collections for the given groups, newest first, with total count."""
     if not group_ids:
@@ -64,6 +65,8 @@ def get_collections_for_group_ids_with_total(
         GroupRecitationCollection.group_id.in_(group_ids),
         GroupRecitationCollection.deleted_at.is_(None),
     )
+    if exclude_ids:
+        query = query.filter(GroupRecitationCollection.id.not_in(exclude_ids))
     total = query.count()
     collections = query.order_by(
         GroupRecitationCollection.created_at.desc(), GroupRecitationCollection.id.desc()

--- a/pecha_api/group_recitation_collection/repository.py
+++ b/pecha_api/group_recitation_collection/repository.py
@@ -65,7 +65,9 @@ def get_collections_for_group_ids_with_total(
         GroupRecitationCollection.deleted_at.is_(None),
     )
     total = query.count()
-    collections = query.order_by(GroupRecitationCollection.created_at.desc()).limit(limit).all()
+    collections = query.order_by(
+        GroupRecitationCollection.created_at.desc(), GroupRecitationCollection.id.desc()
+    ).limit(limit).all()
     return collections, total
 
 

--- a/pecha_api/group_recitation_collection/repository.py
+++ b/pecha_api/group_recitation_collection/repository.py
@@ -51,6 +51,24 @@ def get_collections_by_group_ids(
     )
 
 
+def get_collections_for_group_ids_with_total(
+    db: Session,
+    group_ids: List[UUID],
+    limit: int,
+) -> Tuple[List[GroupRecitationCollection], int]:
+    """Get non-deleted collections for the given groups, newest first, with total count."""
+    if not group_ids:
+        return [], 0
+
+    query = db.query(GroupRecitationCollection).filter(
+        GroupRecitationCollection.group_id.in_(group_ids),
+        GroupRecitationCollection.deleted_at.is_(None),
+    )
+    total = query.count()
+    collections = query.order_by(GroupRecitationCollection.created_at.desc()).limit(limit).all()
+    return collections, total
+
+
 def get_collection_by_id(
     db: Session,
     collection_id: UUID,

--- a/pecha_api/notification/notification_repository.py
+++ b/pecha_api/notification/notification_repository.py
@@ -47,6 +47,25 @@ def get_notifications_paginated(
     return rows, total
 
 
+def notification_exists_for_reference(
+    db: Session,
+    *,
+    recipient_author_id: UUID,
+    category: str,
+    reference_id: UUID,
+) -> bool:
+    return (
+        db.query(Notification.id)
+        .filter(
+            Notification.recipient_author_id == recipient_author_id,
+            Notification.category == category,
+            Notification.reference_id == reference_id,
+        )
+        .first()
+        is not None
+    )
+
+
 def mark_notification_read(db: Session, notification: Notification) -> Notification:
     if notification.is_read:
         return notification

--- a/pecha_api/plans/auth/plan_auth_services.py
+++ b/pecha_api/plans/auth/plan_auth_services.py
@@ -25,6 +25,7 @@ from pecha_api.plans.authors.plan_authors_repository import (
 from pecha_api.auth.auth_repository import get_hashed_password, verify_password, create_access_token, create_refresh_token
 from pecha_api.auth.password_reset_repository import save_password_reset, get_password_reset_by_token_for_author
 from pecha_api.auth.auth_service import send_reset_email
+from pecha_api.plans.groups.groups_service import notify_pending_group_invites
 from fastapi import HTTPException
 from starlette import status
 from datetime import datetime, timedelta, timezone
@@ -142,6 +143,7 @@ def verify_author_email(token: str) -> AuthorVerificationResponse:
             if not author.is_verified:
                 author.is_verified = True
                 update_author(db=db_session, author=author)
+                notify_pending_group_invites(author)
                 message = EMAIL_VERIFIED_SUCCESS
             else:
                 message = EMAIL_ALREADY_VERIFIED
@@ -360,6 +362,7 @@ def exchange_phone_token(request: PhoneExchangeRequest) -> PhoneExchangeResponse
             created_by=f"{AUTH0_SMS_PROVIDER}:{sms_identity.subject}",
         )
         author = save_phone_author(db=db, author=author)
+        notify_pending_group_invites(author)
         return _phone_exchange_response(author, sms_identity.phone_number)
 
 
@@ -427,6 +430,7 @@ def exchange_google_token(request: GoogleExchangeRequest) -> GoogleExchangeRespo
             if not author.is_verified:
                 author.is_verified = True
                 author = update_author(db=db, author=author)
+                notify_pending_group_invites(author)
             return _google_exchange_response(author, google_identity.email)
 
         first_name = (request.first_name or google_identity.first_name or "").strip()
@@ -448,5 +452,6 @@ def exchange_google_token(request: GoogleExchangeRequest) -> GoogleExchangeRespo
             created_by=f"{AUTH0_GOOGLE_PROVIDER}:{google_identity.subject}",
         )
         author = save_google_author(db=db, author=author)
+        notify_pending_group_invites(author)
         return _google_exchange_response(author, google_identity.email)
 

--- a/pecha_api/plans/groups/group_invite_email.py
+++ b/pecha_api/plans/groups/group_invite_email.py
@@ -24,6 +24,7 @@ def _build_invitation_html(
     group_title: str,
     invite_role: str,
     invitations_url: str,
+    login_url: str,
     logo_url: str,
 ) -> str:
     expiry_label = _invite_expiry_label()
@@ -80,6 +81,11 @@ def _build_invitation_html(
               <p style="margin:0 0 24px;font-size:14px;word-break:break-all;">
                 <a href="{invitations_url}" style="color:{BRAND_PRIMARY};">{invitations_url}</a>
               </p>
+              <p style="margin:0;font-size:14px;line-height:1.5;color:#333333;">
+                Already have a WeBuddhist account?
+                <a href="{login_url}" style="color:{BRAND_PRIMARY};font-weight:600;text-decoration:none;">Log in to WeBuddhist Studio</a>
+                to view and respond to this invitation. New to WeBuddhist? The login page has a link to sign up.
+              </p>
             </td>
           </tr>
           <tr>
@@ -110,6 +116,7 @@ def send_group_invitation_email(
 ) -> None:
     base_url = get("WEBUDDHIST_STUDIO_BASE_URL").rstrip("/")
     invitations_url = f"{base_url}/groups"
+    login_url = f"{base_url}/login"
     logo_url = get("WEBUDDHIST_EMAIL_LOGO_URL")
     subject = f"You have been invited to join {group_title}"
     html = _build_invitation_html(
@@ -118,6 +125,7 @@ def send_group_invitation_email(
         group_title=group_title,
         invite_role=invite_role,
         invitations_url=invitations_url,
+        login_url=login_url,
         logo_url=logo_url,
     )
     try:

--- a/pecha_api/plans/groups/groups_repository.py
+++ b/pecha_api/plans/groups/groups_repository.py
@@ -101,7 +101,7 @@ def get_standalone_plans_for_group_ids(
         Plan.status == PlanStatus.PUBLISHED,
     )
     total = query.count()
-    plans = query.order_by(Plan.created_at.desc()).limit(limit).all()
+    plans = query.order_by(Plan.created_at.desc(), Plan.id.desc()).limit(limit).all()
     return plans, total
 
 
@@ -241,7 +241,7 @@ def get_series_for_group_ids(
         Series.status == PlanStatus.PUBLISHED,
     )
     total = query.count()
-    series_list = query.order_by(Series.created_at.desc()).limit(limit).all()
+    series_list = query.order_by(Series.created_at.desc(), Series.id.desc()).limit(limit).all()
     return series_list, total
 
 

--- a/pecha_api/plans/groups/groups_repository.py
+++ b/pecha_api/plans/groups/groups_repository.py
@@ -90,6 +90,7 @@ def get_standalone_plans_for_group_ids(
     db: Session,
     group_ids: Sequence[UUID],
     limit: int,
+    exclude_ids: Optional[Sequence[UUID]] = None,
 ) -> Tuple[List[Plan], int]:
     """Published plans that are not part of a series, across the given groups."""
     if not group_ids:
@@ -100,6 +101,8 @@ def get_standalone_plans_for_group_ids(
         Plan.series_id.is_(None),
         Plan.status == PlanStatus.PUBLISHED,
     )
+    if exclude_ids:
+        query = query.filter(Plan.id.not_in(exclude_ids))
     total = query.count()
     plans = query.order_by(Plan.created_at.desc(), Plan.id.desc()).limit(limit).all()
     return plans, total
@@ -231,6 +234,7 @@ def get_series_for_group_ids(
     db: Session,
     group_ids: Sequence[UUID],
     limit: int,
+    exclude_ids: Optional[Sequence[UUID]] = None,
 ) -> Tuple[List[Series], int]:
     """Published series owned by the given groups, newest first."""
     if not group_ids:
@@ -240,6 +244,8 @@ def get_series_for_group_ids(
         Series.deleted_at.is_(None),
         Series.status == PlanStatus.PUBLISHED,
     )
+    if exclude_ids:
+        query = query.filter(Series.id.not_in(exclude_ids))
     total = query.count()
     series_list = query.order_by(Series.created_at.desc(), Series.id.desc()).limit(limit).all()
     return series_list, total

--- a/pecha_api/plans/groups/groups_repository.py
+++ b/pecha_api/plans/groups/groups_repository.py
@@ -16,6 +16,7 @@ from pecha_api.plans.groups.groups_models import (
     author_group_joins,
     author_group_tags,
 )
+from pecha_api.plans.plans_enums import PlanStatus
 from pecha_api.plans.plans_models import Plan
 from pecha_api.plans.series.series_model import Series
 from pecha_api.plans.tags.tag_model import Tag
@@ -83,6 +84,25 @@ def get_plans_by_group_id(db: Session, group_id: UUID) -> List[Plan]:
         )
         .all()
     )
+
+
+def get_standalone_plans_for_group_ids(
+    db: Session,
+    group_ids: Sequence[UUID],
+    limit: int,
+) -> Tuple[List[Plan], int]:
+    """Published plans that are not part of a series, across the given groups."""
+    if not group_ids:
+        return [], 0
+    query = db.query(Plan).filter(
+        Plan.group_id.in_(group_ids),
+        Plan.deleted_at.is_(None),
+        Plan.series_id.is_(None),
+        Plan.status == PlanStatus.PUBLISHED,
+    )
+    total = query.count()
+    plans = query.order_by(Plan.created_at.desc()).limit(limit).all()
+    return plans, total
 
 
 def get_series_partner_id_map_for_group(
@@ -205,6 +225,24 @@ def get_series_by_group_id(db: Session, group_id: UUID) -> List[Series]:
         .distinct()
         .all()
     )
+
+
+def get_series_for_group_ids(
+    db: Session,
+    group_ids: Sequence[UUID],
+    limit: int,
+) -> Tuple[List[Series], int]:
+    """Published series owned by the given groups, newest first."""
+    if not group_ids:
+        return [], 0
+    query = db.query(Series).filter(
+        Series.group_id.in_(group_ids),
+        Series.deleted_at.is_(None),
+        Series.status == PlanStatus.PUBLISHED,
+    )
+    total = query.count()
+    series_list = query.order_by(Series.created_at.desc()).limit(limit).all()
+    return series_list, total
 
 
 def get_group_by_id(db: Session, group_id: UUID) -> Optional[AuthorGroup]:

--- a/pecha_api/plans/groups/groups_response_models.py
+++ b/pecha_api/plans/groups/groups_response_models.py
@@ -314,6 +314,7 @@ class GroupPracticeFeedItemDTO(BaseModel):
     series: Optional[GroupSeriesListItemDTO] = None
     accumulator: Optional[GroupAccumulatorDTO] = None
     plan: Optional[PlanDTO] = None
+    collection: Optional[GroupRecitationCollectionDTO] = None
 
 
 class GroupPracticesFeedResponse(BaseModel):

--- a/pecha_api/plans/groups/groups_response_models.py
+++ b/pecha_api/plans/groups/groups_response_models.py
@@ -54,6 +54,8 @@ __all__ = [
     "GroupPracticeType",
     "GroupPracticeCardDTO",
     "GroupPracticesResponse",
+    "GroupPracticeFeedItemDTO",
+    "GroupPracticesFeedResponse",
 ]
 
 
@@ -284,6 +286,7 @@ class GroupPracticeType(str, Enum):
     SERIES = "series"
     ACCUMULATOR = "accumulator"
     COLLECTION = "collection"
+    PLAN = "plan"
 
 
 class GroupPracticeCardDTO(BaseModel):
@@ -298,3 +301,24 @@ class GroupPracticesResponse(BaseModel):
     skip: int
     limit: int
     total: int
+
+
+class GroupPracticeFeedItemDTO(BaseModel):
+    type: GroupPracticeType
+    practice_at: datetime
+    is_joined: bool
+    group_id: UUID
+    group_name: Optional[str] = None
+    group_slug: Optional[str] = None
+    group_avatar_url: Optional[str] = None
+    series: Optional[GroupSeriesListItemDTO] = None
+    accumulator: Optional[GroupAccumulatorDTO] = None
+    plan: Optional[PlanDTO] = None
+
+
+class GroupPracticesFeedResponse(BaseModel):
+    practices: List[GroupPracticeFeedItemDTO]
+    skip: int
+    limit: int
+    total: int
+    include_unfollowed: bool

--- a/pecha_api/plans/groups/groups_service.py
+++ b/pecha_api/plans/groups/groups_service.py
@@ -10,7 +10,7 @@ from starlette import status
 from pecha_api.config import get, get_int
 from pecha_api.db.database import SessionLocal
 from pecha_api.uploads.S3_utils import generate_presigned_access_url
-from pecha_api.plans.authors.plan_authors_repository import get_author_by_email
+from pecha_api.plans.authors.plan_authors_repository import find_author_by_email
 from pecha_api.plans.authors.plan_authors_service import validate_and_extract_author_details, validate_cms_author_details
 from pecha_api.plans.shared.permissions import is_reviewer, is_super_admin, require_cms_write_access
 from pecha_api.notification.notification_repository import (
@@ -1526,7 +1526,7 @@ def _invite_to_dto(
     inviter_email = invite.created_by
     inviter_name = inviter_email
     if db is not None:
-        inviter = get_author_by_email(db=db, email=inviter_email)
+        inviter = find_author_by_email(db=db, email=inviter_email)
         if inviter:
             display_name = _inviter_display_name(inviter)
             if display_name:
@@ -1618,7 +1618,7 @@ def notify_pending_group_invites(author) -> None:
                 ):
                     continue
                 group_title = _group_name_from_invite(invite)
-                inviter = get_author_by_email(db=db, email=invite.created_by)
+                inviter = find_author_by_email(db=db, email=invite.created_by)
                 inviter_name = _inviter_display_name(inviter) if inviter else invite.created_by
                 create_notification_record(
                     recipient_author_id=author.id,
@@ -1655,7 +1655,7 @@ def create_group_member_invite(
             invite_role=_to_role_value(request.role),
         )
 
-        target_author = get_author_by_email(db=db, email=target_email)
+        target_author = find_author_by_email(db=db, email=target_email)
         if target_author and get_group_member(db=db, group_id=group_id, author_id=target_author.id):
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
@@ -1820,7 +1820,7 @@ def revoke_group_invite(token: str, group_id: UUID, invite_id: UUID) -> None:
                 detail="Only pending invites can be revoked",
             )
         revoke_invite(db=db, invite=invite, revoked_by=author.email)
-        target_author = get_author_by_email(db=db, email=invite.target_email)
+        target_author = find_author_by_email(db=db, email=invite.target_email)
         if target_author:
             _mark_invite_notification_read(
                 db=db,

--- a/pecha_api/plans/groups/groups_service.py
+++ b/pecha_api/plans/groups/groups_service.py
@@ -152,8 +152,12 @@ from pecha_api.plans.tags.tag_helpers import tags_to_summary_dtos
 from pecha_api.users.users_service import validate_and_extract_user_details
 from pecha_api.users.users_repository import get_users_by_ids
 from pecha_api.users.users_models import Users
+from pecha_api.region_restrictions.china_timezone import is_china_timezone
 from pecha_api.region_restrictions.region_restriction_enums import RestrictedItemType
-from pecha_api.region_restrictions.region_restriction_service import filter_items_for_timezone
+from pecha_api.region_restrictions.region_restriction_service import (
+    filter_items_for_timezone,
+    get_restricted_item_ids,
+)
 
 GROUP_NOT_FOUND = "Group not found"
 INVITE_NOT_FOUND = "Invite not found"
@@ -829,6 +833,18 @@ def _as_aware_utc(value: datetime) -> datetime:
     return value
 
 
+def _restricted_ids_for_timezone(
+    item_type: RestrictedItemType,
+    timezone_name: Optional[str],
+) -> Optional[List[UUID]]:
+    """IDs to exclude at the query layer so restricted items never occupy a
+    fetch-window slot ahead of eligible ones. None means no exclusion needed."""
+    if not is_china_timezone(timezone_name):
+        return None
+    restricted_ids = get_restricted_item_ids(item_type)
+    return list(restricted_ids) if restricted_ids else None
+
+
 async def get_group_practices(
     group_id: UUID,
     skip: int = 0,
@@ -967,52 +983,40 @@ def get_group_practices_feed(
                 include_unfollowed=should_include_unfollowed,
             )
 
-        # Over-fetch relative to the requested page so that timezone filtering
-        # (applied after the DB query) doesn't leave the page short of eligible
-        # items that were truncated by a skip+limit-sized query.
-        series_list, _ = get_series_for_group_ids(
-            db=db, group_ids=scope_group_ids, limit=_PRACTICES_FETCH_LIMIT
-        )
-        series_list = filter_items_for_timezone(
-            series_list,
-            timezone_name=timezone_name,
-            item_type=RestrictedItemType.SERIES,
-            id_of=lambda series: series.id,
-        )
-        series_total = len(series_list)
+        # Restricted items are excluded at the query layer (not after fetching)
+        # so a skip+limit-sized fetch window never omits eligible older items,
+        # and the reported total reflects only eligible rows, at any depth.
+        fetch_limit = skip + limit
 
-        plans_list, _ = get_standalone_plans_for_group_ids(
-            db=db, group_ids=scope_group_ids, limit=_PRACTICES_FETCH_LIMIT
+        series_list, series_total = get_series_for_group_ids(
+            db=db,
+            group_ids=scope_group_ids,
+            limit=fetch_limit,
+            exclude_ids=_restricted_ids_for_timezone(RestrictedItemType.SERIES, timezone_name),
         )
-        plans_list = filter_items_for_timezone(
-            plans_list,
-            timezone_name=timezone_name,
-            item_type=RestrictedItemType.PLAN,
-            id_of=lambda plan: plan.id,
-        )
-        plans_total = len(plans_list)
 
-        accumulators, _ = get_group_accumulators_for_group_ids(
-            db=db, group_ids=scope_group_ids, limit=_PRACTICES_FETCH_LIMIT
+        plans_list, plans_total = get_standalone_plans_for_group_ids(
+            db=db,
+            group_ids=scope_group_ids,
+            limit=fetch_limit,
+            exclude_ids=_restricted_ids_for_timezone(RestrictedItemType.PLAN, timezone_name),
         )
-        accumulators = filter_items_for_timezone(
-            accumulators,
-            timezone_name=timezone_name,
-            item_type=RestrictedItemType.GROUP_ACCUMULATOR,
-            id_of=lambda accumulator: accumulator.id,
-        )
-        accumulators_total = len(accumulators)
 
-        collections, _ = get_collections_for_group_ids_with_total(
-            db=db, group_ids=scope_group_ids, limit=_PRACTICES_FETCH_LIMIT
+        accumulators, accumulators_total = get_group_accumulators_for_group_ids(
+            db=db,
+            group_ids=scope_group_ids,
+            limit=fetch_limit,
+            exclude_ids=_restricted_ids_for_timezone(RestrictedItemType.GROUP_ACCUMULATOR, timezone_name),
         )
-        collections = filter_items_for_timezone(
-            collections,
-            timezone_name=timezone_name,
-            item_type=RestrictedItemType.GROUP_RECITATION_COLLECTION,
-            id_of=lambda collection: collection.id,
+
+        collections, collections_total = get_collections_for_group_ids_with_total(
+            db=db,
+            group_ids=scope_group_ids,
+            limit=fetch_limit,
+            exclude_ids=_restricted_ids_for_timezone(
+                RestrictedItemType.GROUP_RECITATION_COLLECTION, timezone_name
+            ),
         )
-        collections_total = len(collections)
         collection_item_counts = get_collection_item_counts(
             db=db, collection_ids=[collection.id for collection in collections]
         )

--- a/pecha_api/plans/groups/groups_service.py
+++ b/pecha_api/plans/groups/groups_service.py
@@ -29,8 +29,12 @@ from pecha_api.plans.cms.cms_plans_repository import get_plans_with_aggregates_b
 from pecha_api.plans.plans_response_models import AuthorDTO, PlanDTO, PlanWithAggregates
 from pecha_api.plans.series.series_model import Series
 from pecha_api.group_accumulator.group_accumulator_repository import (
+    get_group_accumulator_joiners_counts,
+    get_group_accumulators_for_group_ids,
+    get_joined_group_accumulator_ids_by_user,
     remove_group_accumulator_joins_for_group,
 )
+from pecha_api.plans.groups.follow_scope import resolve_public_group_scope
 from pecha_api.plans.groups.groups_repository import (
     add_group_member,
     create_group,
@@ -52,6 +56,8 @@ from pecha_api.plans.groups.groups_repository import (
     get_plans_by_group_id,
     get_plans_by_ids,
     get_series_by_group_id,
+    get_series_for_group_ids,
+    get_standalone_plans_for_group_ids,
     get_series_partner_id_map_for_group,
     get_user_series_enrollment_partner_map,
     has_pending_invite,
@@ -112,6 +118,8 @@ from pecha_api.plans.groups.groups_response_models import (
     GroupMemberAccumulationsResponse,
     GroupMetadataDTO,
     GroupPracticeCardDTO,
+    GroupPracticeFeedItemDTO,
+    GroupPracticesFeedResponse,
     GroupPracticesResponse,
     GroupPracticeType,
     GroupSocialLinkDTO,
@@ -129,7 +137,10 @@ from pecha_api.plans.groups.groups_response_models import (
     UpdateAuthorGroupRequest,
     UpdateGroupMemberRoleRequest,
 )
-from pecha_api.group_accumulator.group_accumulator_service import get_group_accumulators_service
+from pecha_api.group_accumulator.group_accumulator_service import (
+    _convert_to_dto as _group_accumulator_to_dto,
+    get_group_accumulators_service,
+)
 from pecha_api.group_recitation_collection.service import list_group_collections_service
 from pecha_api.plans.groups.groups_models import author_group_tags
 from pecha_api.plans.tags.tag_helpers import tags_to_summary_dtos
@@ -884,6 +895,202 @@ async def get_group_practices(
         skip=skip,
         limit=limit,
         total=total,
+    )
+
+
+def _group_card_title(group: AuthorGroup, language: Optional[str] = None) -> Optional[str]:
+    entries = list(group.metadata_entries or [])
+    if not entries:
+        return group.slug
+    preferred = filter_by_language_with_fallback(
+        entries=entries,
+        language=language,
+        language_of=lambda item: _language_value(item.language),
+    )
+    if preferred:
+        return preferred[0].title
+    for entry in entries:
+        if _language_value(entry.language).upper() == "EN":
+            return entry.title
+    return entries[0].title
+
+
+def get_group_practices_feed(
+    token: str,
+    group_id: Optional[UUID] = None,
+    should_include_unfollowed: bool = False,
+    skip: int = 0,
+    limit: int = 20,
+    language: Optional[str] = None,
+    timezone_name: Optional[str] = None,
+) -> GroupPracticesFeedResponse:
+    """Merged feed of practices (series, group accumulators, and plans that are
+    not part of a series) across the user's joined public groups; with
+    should_include_unfollowed=True, across all public groups."""
+    current_user = validate_and_extract_user_details(token=token)
+
+    with SessionLocal() as db:
+        scope_group_ids, joined_group_id_set = resolve_public_group_scope(
+            db=db,
+            user_id=current_user.id,
+            should_include_unfollowed=should_include_unfollowed,
+        )
+        if group_id is not None:
+            scope_group_ids = [item for item in scope_group_ids if item == group_id]
+        scope_group_ids = filter_items_for_timezone(
+            scope_group_ids,
+            timezone_name=timezone_name,
+            item_type=RestrictedItemType.GROUP,
+            id_of=lambda item: item,
+        )
+        if not scope_group_ids:
+            return GroupPracticesFeedResponse(
+                practices=[],
+                skip=skip,
+                limit=limit,
+                total=0,
+                include_unfollowed=should_include_unfollowed,
+            )
+
+        # Fetch enough of each type to fill the requested page after merge.
+        fetch_limit = skip + limit
+
+        series_list, series_total = get_series_for_group_ids(
+            db=db, group_ids=scope_group_ids, limit=fetch_limit
+        )
+        series_list = filter_items_for_timezone(
+            series_list,
+            timezone_name=timezone_name,
+            item_type=RestrictedItemType.SERIES,
+            id_of=lambda series: series.id,
+        )
+
+        plans_list, plans_total = get_standalone_plans_for_group_ids(
+            db=db, group_ids=scope_group_ids, limit=fetch_limit
+        )
+        plans_list = filter_items_for_timezone(
+            plans_list,
+            timezone_name=timezone_name,
+            item_type=RestrictedItemType.PLAN,
+            id_of=lambda plan: plan.id,
+        )
+
+        accumulators, accumulators_total = get_group_accumulators_for_group_ids(
+            db=db, group_ids=scope_group_ids, limit=fetch_limit
+        )
+        accumulators = filter_items_for_timezone(
+            accumulators,
+            timezone_name=timezone_name,
+            item_type=RestrictedItemType.GROUP_ACCUMULATOR,
+            id_of=lambda accumulator: accumulator.id,
+        )
+
+        # Series DTOs are built per owning group because enrollment and partner
+        # lookups are scoped to a group.
+        series_by_group: Dict[UUID, List[Series]] = {}
+        for series in series_list:
+            series_by_group.setdefault(series.group_id, []).append(series)
+        series_pairs = []
+        for owning_group_id, group_series in series_by_group.items():
+            dtos = _series_to_dtos(
+                db=db,
+                series_list=group_series,
+                group_id=owning_group_id,
+                language=language,
+                published_only=True,
+                user_id=current_user.id,
+            )
+            series_pairs.extend(zip(group_series, dtos))
+
+        plan_aggregate_by_id = {
+            item.plan.id: item
+            for item in get_plans_with_aggregates_by_ids(
+                db=db, plan_ids=[plan.id for plan in plans_list]
+            )
+        }
+
+        accumulator_ids = [accumulator.id for accumulator in accumulators]
+        joined_accumulator_ids = set(
+            get_joined_group_accumulator_ids_by_user(
+                db=db,
+                user_id=current_user.id,
+                group_accumulator_ids=accumulator_ids,
+            )
+        )
+        accumulator_member_counts = get_group_accumulator_joiners_counts(
+            db=db, group_accumulator_ids=accumulator_ids
+        )
+
+        card_group_ids = list({
+            *[series.group_id for series, _ in series_pairs],
+            *[plan.group_id for plan in plans_list],
+            *[accumulator.group_id for accumulator in accumulators],
+        })
+        group_by_id = {
+            group.id: group
+            for group in get_groups_by_ids(db=db, group_ids=card_group_ids)
+        }
+
+        def _feed_item(
+            item_group_id: UUID,
+            created_at: datetime,
+            practice_type: GroupPracticeType,
+            **payload,
+        ):
+            group = group_by_id.get(item_group_id)
+            practice_at = _as_aware_utc(created_at)
+            return (
+                practice_at,
+                GroupPracticeFeedItemDTO(
+                    type=practice_type,
+                    practice_at=practice_at,
+                    is_joined=item_group_id in joined_group_id_set,
+                    group_id=item_group_id,
+                    group_name=_group_card_title(group, language=language) if group else None,
+                    group_slug=group.slug if group else None,
+                    group_avatar_url=_generate_group_asset_url(group.avatar_key) if group else None,
+                    **payload,
+                ),
+            )
+
+        cards = [
+            _feed_item(series.group_id, series.created_at, GroupPracticeType.SERIES, series=dto)
+            for series, dto in series_pairs
+        ]
+        cards.extend(
+            _feed_item(
+                plan.group_id,
+                plan.created_at,
+                GroupPracticeType.PLAN,
+                plan=_plan_aggregate_to_dto(plan_aggregate_by_id[plan.id], group_id=plan.group_id),
+            )
+            for plan in plans_list
+            if plan.id in plan_aggregate_by_id
+        )
+        cards.extend(
+            _feed_item(
+                accumulator.group_id,
+                accumulator.created_at,
+                GroupPracticeType.ACCUMULATOR,
+                accumulator=_group_accumulator_to_dto(
+                    accumulator,
+                    is_joined=accumulator.id in joined_accumulator_ids,
+                    member_count=accumulator_member_counts.get(accumulator.id, 0),
+                ),
+            )
+            for accumulator in accumulators
+        )
+
+        cards.sort(key=lambda entry: entry[0], reverse=True)
+        total = series_total + plans_total + accumulators_total
+        page_cards = [card for _, card in cards[skip:skip + limit]]
+
+    return GroupPracticesFeedResponse(
+        practices=page_cards,
+        skip=skip,
+        limit=limit,
+        total=total,
+        include_unfollowed=should_include_unfollowed,
     )
 
 

--- a/pecha_api/plans/groups/groups_service.py
+++ b/pecha_api/plans/groups/groups_service.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime, timedelta, timezone
 from typing import Dict, List, Literal, Optional, Sequence
 from uuid import UUID
@@ -12,7 +13,10 @@ from pecha_api.uploads.S3_utils import generate_presigned_access_url
 from pecha_api.plans.authors.plan_authors_repository import get_author_by_email
 from pecha_api.plans.authors.plan_authors_service import validate_and_extract_author_details, validate_cms_author_details
 from pecha_api.plans.shared.permissions import is_reviewer, is_super_admin, require_cms_write_access
-from pecha_api.notification.notification_repository import mark_notifications_read_by_reference
+from pecha_api.notification.notification_repository import (
+    mark_notifications_read_by_reference,
+    notification_exists_for_reference,
+)
 from pecha_api.notification.notification_service import create_notification_record
 from pecha_api.plans.groups.group_invite_email import send_group_invitation_email
 from pecha_api.plans.groups.groups_enums import AuthorGroupInviteStatus, AuthorGroupMemberRole, AuthorGroupType
@@ -1597,6 +1601,36 @@ def _mark_invite_notification_read(db, *, recipient_author_id: UUID, invite_id: 
     )
 
 
+def notify_pending_group_invites(author) -> None:
+    """Backfill in-app notifications for any group invites addressed to this
+    author's email that were sent before they had a Studio account. Called
+    once an author becomes verified so the invite is already waiting for them
+    the first time they can see the Studio."""
+    try:
+        with SessionLocal() as db:
+            pending = list_pending_invites_by_email(db=db, target_email=author.email)
+            for invite in pending:
+                if notification_exists_for_reference(
+                    db=db,
+                    recipient_author_id=author.id,
+                    category=NOTIFICATION_CATEGORY_GROUP_INVITE,
+                    reference_id=invite.id,
+                ):
+                    continue
+                group_title = _group_name_from_invite(invite)
+                inviter = get_author_by_email(db=db, email=invite.created_by)
+                inviter_name = _inviter_display_name(inviter) if inviter else invite.created_by
+                create_notification_record(
+                    recipient_author_id=author.id,
+                    title=f"Invitation to join {group_title}",
+                    description=f"{inviter_name} invited you to join {group_title}.",
+                    category=NOTIFICATION_CATEGORY_GROUP_INVITE,
+                    reference_id=invite.id,
+                )
+    except Exception:
+        logging.exception("Failed to backfill group invite notifications for %s", author.email)
+
+
 def create_group_member_invite(
     token: str,
     group_id: UUID,
@@ -1622,12 +1656,7 @@ def create_group_member_invite(
         )
 
         target_author = get_author_by_email(db=db, email=target_email)
-        if not target_author:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="No registered author exists with this email address",
-            )
-        if get_group_member(db=db, group_id=group_id, author_id=target_author.id):
+        if target_author and get_group_member(db=db, group_id=group_id, author_id=target_author.id):
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="This author is already a member of this group",
@@ -1650,17 +1679,19 @@ def create_group_member_invite(
         loaded_group = get_group_by_id(db=db, group_id=group_id)
         group_title = _group_title_from_metadata(loaded_group.metadata_entries)
         inviter_name = _inviter_display_name(author)
-        target_author_id = target_author.id
+        target_author_id = target_author.id if target_author else None
         created_invite_id = created.id
         invite_dto = _invite_to_dto(created, group_name=group_title, db=db)
 
-    notification = create_notification_record(
-        recipient_author_id=target_author_id,
-        title=f"Invitation to join {group_title}",
-        description=f"{inviter_name} invited you to join {group_title}.",
-        category=NOTIFICATION_CATEGORY_GROUP_INVITE,
-        reference_id=created_invite_id,
-    )
+    notification = None
+    if target_author_id is not None:
+        notification = create_notification_record(
+            recipient_author_id=target_author_id,
+            title=f"Invitation to join {group_title}",
+            description=f"{inviter_name} invited you to join {group_title}.",
+            category=NOTIFICATION_CATEGORY_GROUP_INVITE,
+            reference_id=created_invite_id,
+        )
 
     send_group_invitation_email(
         target_email=target_email,
@@ -1672,7 +1703,7 @@ def create_group_member_invite(
 
     return GroupInviteCreatedResponse(
         invite=invite_dto,
-        notification_id=notification.id,
+        notification_id=notification.id if notification else None,
     )
 
 

--- a/pecha_api/plans/groups/groups_service.py
+++ b/pecha_api/plans/groups/groups_service.py
@@ -860,7 +860,11 @@ async def get_group_practices(
             user_id=user_id,
         )
         series_cards = [
-            (_as_aware_utc(series.created_at), GroupPracticeCardDTO(type=GroupPracticeType.SERIES, series=dto))
+            (
+                _as_aware_utc(series.created_at),
+                str(series.id),
+                GroupPracticeCardDTO(type=GroupPracticeType.SERIES, series=dto),
+            )
             for series, dto in zip(group_series, series_dtos)
         ]
 
@@ -872,7 +876,11 @@ async def get_group_practices(
         timezone_name=timezone_name,
     )
     accumulator_cards = [
-        (_as_aware_utc(acc.created_at), GroupPracticeCardDTO(type=GroupPracticeType.ACCUMULATOR, accumulator=acc))
+        (
+            _as_aware_utc(acc.created_at),
+            str(acc.id),
+            GroupPracticeCardDTO(type=GroupPracticeType.ACCUMULATOR, accumulator=acc),
+        )
         for acc in accumulators_response.accumulators
     ]
 
@@ -885,15 +893,16 @@ async def get_group_practices(
     collection_cards = [
         (
             _as_aware_utc(datetime.fromisoformat(collection.created_at)),
+            str(collection.id),
             GroupPracticeCardDTO(type=GroupPracticeType.COLLECTION, collection=collection),
         )
         for collection in collections_response.collections
     ]
 
     all_cards = series_cards + accumulator_cards + collection_cards
-    all_cards.sort(key=lambda entry: entry[0], reverse=True)
+    all_cards.sort(key=lambda entry: (entry[0], entry[1]), reverse=True)
     total = len(all_cards)
-    page_cards = [card for _, card in all_cards[skip:skip + limit]]
+    page_cards = [card for _, _, card in all_cards[skip:skip + limit]]
 
     return GroupPracticesResponse(
         practices=page_cards,
@@ -958,11 +967,11 @@ def get_group_practices_feed(
                 include_unfollowed=should_include_unfollowed,
             )
 
-        # Fetch enough of each type to fill the requested page after merge.
-        fetch_limit = skip + limit
-
-        series_list, series_total = get_series_for_group_ids(
-            db=db, group_ids=scope_group_ids, limit=fetch_limit
+        # Over-fetch relative to the requested page so that timezone filtering
+        # (applied after the DB query) doesn't leave the page short of eligible
+        # items that were truncated by a skip+limit-sized query.
+        series_list, _ = get_series_for_group_ids(
+            db=db, group_ids=scope_group_ids, limit=_PRACTICES_FETCH_LIMIT
         )
         series_list = filter_items_for_timezone(
             series_list,
@@ -970,9 +979,10 @@ def get_group_practices_feed(
             item_type=RestrictedItemType.SERIES,
             id_of=lambda series: series.id,
         )
+        series_total = len(series_list)
 
-        plans_list, plans_total = get_standalone_plans_for_group_ids(
-            db=db, group_ids=scope_group_ids, limit=fetch_limit
+        plans_list, _ = get_standalone_plans_for_group_ids(
+            db=db, group_ids=scope_group_ids, limit=_PRACTICES_FETCH_LIMIT
         )
         plans_list = filter_items_for_timezone(
             plans_list,
@@ -980,9 +990,10 @@ def get_group_practices_feed(
             item_type=RestrictedItemType.PLAN,
             id_of=lambda plan: plan.id,
         )
+        plans_total = len(plans_list)
 
-        accumulators, accumulators_total = get_group_accumulators_for_group_ids(
-            db=db, group_ids=scope_group_ids, limit=fetch_limit
+        accumulators, _ = get_group_accumulators_for_group_ids(
+            db=db, group_ids=scope_group_ids, limit=_PRACTICES_FETCH_LIMIT
         )
         accumulators = filter_items_for_timezone(
             accumulators,
@@ -990,9 +1001,10 @@ def get_group_practices_feed(
             item_type=RestrictedItemType.GROUP_ACCUMULATOR,
             id_of=lambda accumulator: accumulator.id,
         )
+        accumulators_total = len(accumulators)
 
-        collections, collections_total = get_collections_for_group_ids_with_total(
-            db=db, group_ids=scope_group_ids, limit=fetch_limit
+        collections, _ = get_collections_for_group_ids_with_total(
+            db=db, group_ids=scope_group_ids, limit=_PRACTICES_FETCH_LIMIT
         )
         collections = filter_items_for_timezone(
             collections,
@@ -1000,6 +1012,7 @@ def get_group_practices_feed(
             item_type=RestrictedItemType.GROUP_RECITATION_COLLECTION,
             id_of=lambda collection: collection.id,
         )
+        collections_total = len(collections)
         collection_item_counts = get_collection_item_counts(
             db=db, collection_ids=[collection.id for collection in collections]
         )
@@ -1065,6 +1078,7 @@ def get_group_practices_feed(
         }
 
         def _feed_item(
+            item_id,
             item_group_id: UUID,
             created_at: datetime,
             practice_type: GroupPracticeType,
@@ -1074,6 +1088,7 @@ def get_group_practices_feed(
             practice_at = _as_aware_utc(created_at)
             return (
                 practice_at,
+                str(item_id),
                 GroupPracticeFeedItemDTO(
                     type=practice_type,
                     practice_at=practice_at,
@@ -1087,11 +1102,12 @@ def get_group_practices_feed(
             )
 
         cards = [
-            _feed_item(series.group_id, series.created_at, GroupPracticeType.SERIES, series=dto)
+            _feed_item(series.id, series.group_id, series.created_at, GroupPracticeType.SERIES, series=dto)
             for series, dto in series_pairs
         ]
         cards.extend(
             _feed_item(
+                plan.id,
                 plan.group_id,
                 plan.created_at,
                 GroupPracticeType.PLAN,
@@ -1102,6 +1118,7 @@ def get_group_practices_feed(
         )
         cards.extend(
             _feed_item(
+                accumulator.id,
                 accumulator.group_id,
                 accumulator.created_at,
                 GroupPracticeType.ACCUMULATOR,
@@ -1115,6 +1132,7 @@ def get_group_practices_feed(
         )
         cards.extend(
             _feed_item(
+                collection.id,
                 collection.group_id,
                 collection.created_at,
                 GroupPracticeType.COLLECTION,
@@ -1123,9 +1141,9 @@ def get_group_practices_feed(
             for collection, dto in zip(collections, collection_dtos)
         )
 
-        cards.sort(key=lambda entry: entry[0], reverse=True)
+        cards.sort(key=lambda entry: (entry[0], entry[1]), reverse=True)
         total = series_total + plans_total + accumulators_total + collections_total
-        page_cards = [card for _, card in cards[skip:skip + limit]]
+        page_cards = [card for _, _, card in cards[skip:skip + limit]]
 
     return GroupPracticesFeedResponse(
         practices=page_cards,

--- a/pecha_api/plans/groups/groups_service.py
+++ b/pecha_api/plans/groups/groups_service.py
@@ -142,6 +142,11 @@ from pecha_api.group_accumulator.group_accumulator_service import (
     get_group_accumulators_service,
 )
 from pecha_api.group_recitation_collection.service import list_group_collections_service
+from pecha_api.group_recitation_collection.repository import (
+    get_collections_for_group_ids_with_total,
+    get_collection_item_counts,
+)
+from pecha_api.group_recitation_collection.response_models import GroupRecitationCollectionDTO
 from pecha_api.plans.groups.groups_models import author_group_tags
 from pecha_api.plans.tags.tag_helpers import tags_to_summary_dtos
 from pecha_api.users.users_service import validate_and_extract_user_details
@@ -924,9 +929,10 @@ def get_group_practices_feed(
     language: Optional[str] = None,
     timezone_name: Optional[str] = None,
 ) -> GroupPracticesFeedResponse:
-    """Merged feed of practices (series, group accumulators, and plans that are
-    not part of a series) across the user's joined public groups; with
-    should_include_unfollowed=True, across all public groups."""
+    """Merged feed of practices (series, group accumulators, plans that are
+    not part of a series, and recitation collections) across the user's
+    joined public groups; with should_include_unfollowed=True, across all
+    public groups."""
     current_user = validate_and_extract_user_details(token=token)
 
     with SessionLocal() as db:
@@ -985,6 +991,32 @@ def get_group_practices_feed(
             id_of=lambda accumulator: accumulator.id,
         )
 
+        collections, collections_total = get_collections_for_group_ids_with_total(
+            db=db, group_ids=scope_group_ids, limit=fetch_limit
+        )
+        collections = filter_items_for_timezone(
+            collections,
+            timezone_name=timezone_name,
+            item_type=RestrictedItemType.GROUP_RECITATION_COLLECTION,
+            id_of=lambda collection: collection.id,
+        )
+        collection_item_counts = get_collection_item_counts(
+            db=db, collection_ids=[collection.id for collection in collections]
+        )
+        collection_dtos = [
+            GroupRecitationCollectionDTO(
+                id=collection.id,
+                group_id=collection.group_id,
+                name=collection.name,
+                img_url=_generate_group_asset_url(collection.img_url),
+                item_count=collection_item_counts.get(collection.id, 0),
+                created_at=collection.created_at.isoformat()
+                if hasattr(collection.created_at, "isoformat")
+                else str(collection.created_at),
+            )
+            for collection in collections
+        ]
+
         # Series DTOs are built per owning group because enrollment and partner
         # lookups are scoped to a group.
         series_by_group: Dict[UUID, List[Series]] = {}
@@ -1025,6 +1057,7 @@ def get_group_practices_feed(
             *[series.group_id for series, _ in series_pairs],
             *[plan.group_id for plan in plans_list],
             *[accumulator.group_id for accumulator in accumulators],
+            *[collection.group_id for collection in collections],
         })
         group_by_id = {
             group.id: group
@@ -1080,9 +1113,18 @@ def get_group_practices_feed(
             )
             for accumulator in accumulators
         )
+        cards.extend(
+            _feed_item(
+                collection.group_id,
+                collection.created_at,
+                GroupPracticeType.COLLECTION,
+                collection=dto,
+            )
+            for collection, dto in zip(collections, collection_dtos)
+        )
 
         cards.sort(key=lambda entry: entry[0], reverse=True)
-        total = series_total + plans_total + accumulators_total
+        total = series_total + plans_total + accumulators_total + collections_total
         page_cards = [card for _, card in cards[skip:skip + limit]]
 
     return GroupPracticesFeedResponse(

--- a/pecha_api/plans/groups/groups_views.py
+++ b/pecha_api/plans/groups/groups_views.py
@@ -370,8 +370,9 @@ def get_group_practices_feed_endpoint(
         Header(alias="X-Timezone", description="IANA timezone (e.g. Asia/Shanghai). Restricted practices are hidden for Chinese timezones."),
     ] = None,
 ):
-    """Merged feed of practices (series, group accumulators, and plans not in a
-    series) across author groups, sorted newest first.
+    """Merged feed of practices (series, group accumulators, plans not in a
+    series, and recitation collections) across author groups, sorted newest
+    first.
 
     Requires auth. Defaults to groups the user joined. Pass
     ``include_unfollowed=true`` to include all public groups.

--- a/pecha_api/plans/groups/groups_views.py
+++ b/pecha_api/plans/groups/groups_views.py
@@ -17,6 +17,7 @@ from pecha_api.plans.groups.groups_response_models import (
     GroupInviteDTO,
     GroupInviteListResponse,
     GroupMemberAccumulationsResponse,
+    GroupPracticesFeedResponse,
     GroupPracticesResponse,
     PublicAuthorGroupDetailDTO,
     PublicAuthorGroupListResponse,
@@ -45,6 +46,7 @@ from pecha_api.plans.groups.groups_service import (
     get_group_accumulations,
     get_group_member_accumulations,
     get_group_practices,
+    get_group_practices_feed,
     get_joined_group,
     join_group,
     leave_group,
@@ -338,6 +340,51 @@ def delete_group_member_by_id(
         author_id=author_id,
     )
     return None
+
+
+# NOTE: must be registered before the "/{group_id}" routes so the literal
+# "practices" path segment is not captured as a group_id.
+@public_groups_router.get(
+    "/practices",
+    status_code=status.HTTP_200_OK,
+    response_model=GroupPracticesFeedResponse,
+)
+def get_group_practices_feed_endpoint(
+    authentication_credential: Annotated[HTTPAuthorizationCredentials, Depends(oauth2_scheme)],
+    group_id: Annotated[Optional[UUID], Query(description="Filter practices to a single group")] = None,
+    should_include_unfollowed: Annotated[
+        bool,
+        Query(
+            alias="include_unfollowed",
+            description=(
+                "false = practices from joined groups only; "
+                "true = practices from all public groups"
+            ),
+        ),
+    ] = False,
+    language: Annotated[Optional[str], Query(description=_LANGUAGE_QUERY_DESCRIPTION)] = None,
+    skip: Annotated[int, Query(ge=0)] = 0,
+    limit: Annotated[int, Query(ge=1, le=100)] = 20,
+    x_timezone: Annotated[
+        Optional[str],
+        Header(alias="X-Timezone", description="IANA timezone (e.g. Asia/Shanghai). Restricted practices are hidden for Chinese timezones."),
+    ] = None,
+):
+    """Merged feed of practices (series, group accumulators, and plans not in a
+    series) across author groups, sorted newest first.
+
+    Requires auth. Defaults to groups the user joined. Pass
+    ``include_unfollowed=true`` to include all public groups.
+    """
+    return get_group_practices_feed(
+        token=authentication_credential.credentials,
+        group_id=group_id,
+        should_include_unfollowed=should_include_unfollowed,
+        skip=skip,
+        limit=limit,
+        language=language,
+        timezone_name=x_timezone,
+    )
 
 
 @public_groups_router.get("/{group_id}", status_code=status.HTTP_200_OK, response_model=PublicAuthorGroupDetailDTO)

--- a/tests/group_accumulator/test_group_accumulator_repository.py
+++ b/tests/group_accumulator/test_group_accumulator_repository.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock
 from uuid import uuid4
 
 from pecha_api.group_accumulator.group_accumulator_repository import (
+    get_group_accumulators_for_group_ids,
     get_joined_group_accumulator_ids_by_user,
     is_user_joined_group_accumulator,
     remove_group_accumulator_joins_for_group,
@@ -63,3 +64,54 @@ def test_remove_group_accumulator_joins_for_group_deletes_join_rows_only():
 
     db.execute.assert_called_once()
     db.commit.assert_not_called()
+
+
+def test_get_group_accumulators_for_group_ids_empty_group_ids_returns_early():
+    db = MagicMock()
+
+    result = get_group_accumulators_for_group_ids(db=db, group_ids=[], limit=20)
+
+    assert result == ([], 0)
+    db.query.assert_not_called()
+
+
+def test_get_group_accumulators_for_group_ids_without_exclude_ids():
+    db = MagicMock()
+    group_id = uuid4()
+    accumulator = MagicMock()
+    query = MagicMock()
+    db.query.return_value = query
+    query.options.return_value = query
+    query.filter.return_value = query
+    query.count.return_value = 1
+    query.order_by.return_value = query
+    query.limit.return_value = query
+    query.limit.return_value.all.return_value = [accumulator]
+
+    accumulators, total = get_group_accumulators_for_group_ids(
+        db=db, group_ids=[group_id], limit=20
+    )
+
+    assert accumulators == [accumulator]
+    assert total == 1
+    query.filter.assert_called_once()
+
+
+def test_get_group_accumulators_for_group_ids_with_exclude_ids_applies_extra_filter():
+    db = MagicMock()
+    group_id = uuid4()
+    excluded_id = uuid4()
+    query = MagicMock()
+    db.query.return_value = query
+    query.options.return_value = query
+    query.filter.return_value = query
+    query.count.return_value = 0
+    query.order_by.return_value = query
+    query.limit.return_value = query
+    query.limit.return_value.all.return_value = []
+
+    get_group_accumulators_for_group_ids(
+        db=db, group_ids=[group_id], limit=20, exclude_ids=[excluded_id]
+    )
+
+    assert query.filter.call_count == 2

--- a/tests/group_posts/test_comment_like_service.py
+++ b/tests/group_posts/test_comment_like_service.py
@@ -43,7 +43,6 @@ class TestLikeCommentService:
 
     @patch('pecha_api.group_posts.comment_like_service.count_comment_likes')
     @patch('pecha_api.group_posts.comment_like_service.create_like')
-    @patch('pecha_api.group_posts.comment_like_service.resolve_user_id')
     @patch('pecha_api.group_posts.comment_like_service.validate_group_is_public')
     @patch('pecha_api.group_posts.comment_like_service._get_and_validate_comment')
     @patch('pecha_api.group_posts.comment_like_service.SessionLocal')
@@ -52,7 +51,6 @@ class TestLikeCommentService:
         mock_session,
         mock_get_comment,
         mock_validate_group,
-        mock_resolve_user,
         mock_create_like,
         mock_count_likes,
     ):
@@ -61,21 +59,20 @@ class TestLikeCommentService:
         post_id = uuid4()
         group_id = uuid4()
         user_id = uuid4()
-        
+
         mock_db = MagicMock()
         mock_session.return_value.__enter__.return_value = mock_db
         mock_comment = MockComment(comment_id, post_id)
         mock_post = MockPost(post_id, group_id)
         mock_get_comment.return_value = (mock_comment, mock_post, group_id)
-        mock_resolve_user.return_value = user_id
-        
+
         mock_like = MockCommentLike(comment_id, user_id)
         mock_create_like.return_value = (mock_like, True)  # is_new=True
         mock_count_likes.return_value = 1
 
         result = like_comment_service(
             comment_id=comment_id,
-            author_email="user@example.com",
+            user_id=user_id,
         )
 
         assert result.comment_id == comment_id
@@ -87,7 +84,6 @@ class TestLikeCommentService:
 
     @patch('pecha_api.group_posts.comment_like_service.count_comment_likes')
     @patch('pecha_api.group_posts.comment_like_service.create_like')
-    @patch('pecha_api.group_posts.comment_like_service.resolve_user_id')
     @patch('pecha_api.group_posts.comment_like_service.validate_group_is_public')
     @patch('pecha_api.group_posts.comment_like_service._get_and_validate_comment')
     @patch('pecha_api.group_posts.comment_like_service.SessionLocal')
@@ -96,7 +92,6 @@ class TestLikeCommentService:
         mock_session,
         mock_get_comment,
         mock_validate_group,
-        mock_resolve_user,
         mock_create_like,
         mock_count_likes,
     ):
@@ -105,21 +100,20 @@ class TestLikeCommentService:
         post_id = uuid4()
         group_id = uuid4()
         user_id = uuid4()
-        
+
         mock_db = MagicMock()
         mock_session.return_value.__enter__.return_value = mock_db
         mock_comment = MockComment(comment_id, post_id)
         mock_post = MockPost(post_id, group_id)
         mock_get_comment.return_value = (mock_comment, mock_post, group_id)
-        mock_resolve_user.return_value = user_id
-        
+
         mock_like = MockCommentLike(comment_id, user_id)
         mock_create_like.return_value = (mock_like, False)  # is_new=False (already existed)
         mock_count_likes.return_value = 3
 
         result = like_comment_service(
             comment_id=comment_id,
-            author_email="user@example.com",
+            user_id=user_id,
         )
 
         assert result.comment_id == comment_id
@@ -142,7 +136,7 @@ class TestLikeCommentService:
         with pytest.raises(HTTPException) as exc_info:
             like_comment_service(
                 comment_id=uuid4(),
-                author_email="user@example.com",
+                user_id=uuid4(),
             )
 
         assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
@@ -151,7 +145,6 @@ class TestLikeCommentService:
 class TestUnlikeCommentService:
 
     @patch('pecha_api.group_posts.comment_like_service.delete_like')
-    @patch('pecha_api.group_posts.comment_like_service.resolve_user_id')
     @patch('pecha_api.group_posts.comment_like_service.validate_group_is_public')
     @patch('pecha_api.group_posts.comment_like_service._get_and_validate_comment')
     @patch('pecha_api.group_posts.comment_like_service.SessionLocal')
@@ -160,7 +153,6 @@ class TestUnlikeCommentService:
         mock_session,
         mock_get_comment,
         mock_validate_group,
-        mock_resolve_user,
         mock_delete_like,
     ):
         """Test unliking a comment succeeds."""
@@ -168,17 +160,16 @@ class TestUnlikeCommentService:
         post_id = uuid4()
         group_id = uuid4()
         user_id = uuid4()
-        
+
         mock_db = MagicMock()
         mock_session.return_value.__enter__.return_value = mock_db
         mock_comment = MockComment(comment_id, post_id)
         mock_post = MockPost(post_id, group_id)
         mock_get_comment.return_value = (mock_comment, mock_post, group_id)
-        mock_resolve_user.return_value = user_id
 
         unlike_comment_service(
             comment_id=comment_id,
-            author_email="user@example.com",
+            user_id=user_id,
         )
 
         mock_delete_like.assert_called_once_with(db=mock_db, comment_id=comment_id, user_id=user_id)

--- a/tests/group_posts/test_group_post_comments_service.py
+++ b/tests/group_posts/test_group_post_comments_service.py
@@ -225,14 +225,13 @@ class TestCreatePostCommentService:
         mock_get_post.return_value = MockPost(id=post_id, group_id=group_id)
 
         user = MockUser(email="commenter@example.com")
-        mock_db.query.return_value.filter.return_value.first.return_value = user
         mock_create.return_value = MockComment(
             user=user, user_id=user.id, post_id=post_id, text="Hello"
         )
 
         result = create_post_comment_service(
             post_id=post_id,
-            author_email="commenter@example.com",
+            user_id=user.id,
             text="Hello",
         )
 
@@ -268,7 +267,6 @@ class TestCreatePostCommentService:
         mock_get_comment.return_value = MockComment(post_id=post_id)
 
         user = MockUser(email="commenter@example.com")
-        mock_db.query.return_value.filter.return_value.first.return_value = user
         mock_create.return_value = MockComment(
             user=user,
             user_id=user.id,
@@ -279,7 +277,7 @@ class TestCreatePostCommentService:
 
         result = create_post_comment_service(
             post_id=post_id,
-            author_email=user.email,
+            user_id=user.id,
             text="Nested reply",
             parent_comment_id=parent_comment_id,
         )
@@ -315,41 +313,13 @@ class TestCreatePostCommentService:
         with pytest.raises(HTTPException) as exc_info:
             create_post_comment_service(
                 post_id=post_id,
-                author_email="commenter@example.com",
+                user_id=uuid4(),
                 text="Reply",
                 parent_comment_id=parent_comment_id,
             )
 
         assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
         assert exc_info.value.detail == "Parent comment not found"
-
-    @patch('pecha_api.group_posts.comment_service.get_post_by_id_only')
-    @patch('pecha_api.group_posts.comment_service.get_group_by_id')
-    @patch('pecha_api.group_posts.comment_service.SessionLocal')
-    def test_create_comment_user_not_found(
-        self, mock_session, mock_get_group, mock_get_post
-    ):
-        group_id = uuid4()
-        mock_db = MagicMock()
-        mock_session.return_value.__enter__.return_value = mock_db
-        mock_get_group.return_value = MockGroup()
-        mock_get_post.return_value = MockPost(group_id=group_id)
-
-        # Mock the db.query().filter().first() chain to return None
-        mock_query = MagicMock()
-        mock_filter = MagicMock()
-        mock_db.query.return_value = mock_query
-        mock_query.filter.return_value = mock_filter
-        mock_filter.first.return_value = None
-
-        with pytest.raises(HTTPException) as exc_info:
-            create_post_comment_service(
-                post_id=uuid4(),
-                author_email="test@example.com",
-                text="Hello",
-            )
-
-        assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
 
 
 class TestDeletePostCommentService:

--- a/tests/group_posts/test_group_post_comments_views.py
+++ b/tests/group_posts/test_group_post_comments_views.py
@@ -86,14 +86,14 @@ class TestPublicGroupPostCommentsViews:
 class TestCreatePostCommentView:
 
     @patch('pecha_api.group_posts.comment_views.create_post_comment_service')
-    @patch('pecha_api.group_posts.comment_views.validate_and_extract_author_details')
+    @patch('pecha_api.group_posts.comment_views.validate_and_extract_user_details')
     def test_create_comment(self, mock_validate, mock_service):
         client = get_client()
         group_id = uuid4()
         post_id = uuid4()
-        author = MagicMock()
-        author.email = "author@example.com"
-        mock_validate.return_value = author
+        user = MagicMock()
+        user.id = uuid4()
+        mock_validate.return_value = user
         mock_service.return_value = _comment_dto(post_id=post_id)
 
         response = client.post(
@@ -107,19 +107,20 @@ class TestCreatePostCommentView:
         mock_validate.assert_called_once_with(token="test-token")
         mock_service.assert_called_once_with(
             post_id=post_id,
-            author_email="author@example.com",
+            user_id=user.id,
             text="Great post!",
             parent_comment_id=None,
         )
 
     @patch('pecha_api.group_posts.comment_views.create_post_comment_service')
-    @patch('pecha_api.group_posts.comment_views.validate_and_extract_author_details')
+    @patch('pecha_api.group_posts.comment_views.validate_and_extract_user_details')
     def test_create_reply_to_comment(self, mock_validate, mock_service):
         client = get_client()
         group_id = uuid4()
         post_id = uuid4()
         parent_comment_id = uuid4()
-        mock_validate.return_value = MagicMock(email="author@example.com")
+        user = MagicMock(id=uuid4())
+        mock_validate.return_value = user
         mock_service.return_value = _comment_dto(
             post_id=post_id,
             parent_comment_id=parent_comment_id,
@@ -138,7 +139,7 @@ class TestCreatePostCommentView:
         assert response.json()["parent_comment_id"] == str(parent_comment_id)
         mock_service.assert_called_once_with(
             post_id=post_id,
-            author_email="author@example.com",
+            user_id=user.id,
             text="Nested reply",
             parent_comment_id=parent_comment_id,
         )
@@ -154,7 +155,7 @@ class TestCreatePostCommentView:
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     @patch('pecha_api.group_posts.comment_views.create_post_comment_service')
-    @patch('pecha_api.group_posts.comment_views.validate_and_extract_author_details')
+    @patch('pecha_api.group_posts.comment_views.validate_and_extract_user_details')
     def test_create_comment_rejects_blank_text(self, mock_validate, mock_service):
         client = get_client()
 
@@ -168,10 +169,10 @@ class TestCreatePostCommentView:
         mock_service.assert_not_called()
 
     @patch('pecha_api.group_posts.comment_views.create_post_comment_service')
-    @patch('pecha_api.group_posts.comment_views.validate_and_extract_author_details')
+    @patch('pecha_api.group_posts.comment_views.validate_and_extract_user_details')
     def test_create_comment_propagates_service_error(self, mock_validate, mock_service):
         client = get_client()
-        mock_validate.return_value = MagicMock(email="author@example.com")
+        mock_validate.return_value = MagicMock(id=uuid4())
         mock_service.side_effect = HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Not found"
         )
@@ -188,19 +189,16 @@ class TestCreatePostCommentView:
 class TestDeletePostCommentView:
 
     @patch('pecha_api.group_posts.comment_views.delete_post_comment_service')
-    @patch('pecha_api.group_posts.comment_views.resolve_user_id')
-    @patch('pecha_api.group_posts.comment_views.validate_and_extract_author_details')
-    def test_delete_comment(self, mock_validate, mock_resolve_user_id, mock_service):
+    @patch('pecha_api.group_posts.comment_views.validate_and_extract_user_details')
+    def test_delete_comment(self, mock_validate, mock_service):
         client = get_client()
         group_id = uuid4()
         post_id = uuid4()
         comment_id = uuid4()
-        author = MagicMock()
-        author.id = uuid4()
-        author.email = "author@example.com"
         user_id = uuid4()
-        mock_validate.return_value = author
-        mock_resolve_user_id.return_value = user_id
+        user = MagicMock()
+        user.id = user_id
+        mock_validate.return_value = user
         mock_service.return_value = None
 
         response = client.delete(
@@ -224,20 +222,14 @@ class TestDeletePostCommentView:
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     @patch('pecha_api.group_posts.comment_views.delete_post_comment_service')
-    @patch('pecha_api.group_posts.comment_views.resolve_user_id')
-    @patch('pecha_api.group_posts.comment_views.validate_and_extract_author_details')
+    @patch('pecha_api.group_posts.comment_views.validate_and_extract_user_details')
     def test_delete_comment_of_another_user_is_forbidden(
         self,
         mock_validate,
-        mock_resolve_user_id,
         mock_service,
     ):
         client = get_client()
-        mock_validate.return_value = MagicMock(
-            id=uuid4(),
-            email="author@example.com",
-        )
-        mock_resolve_user_id.return_value = uuid4()
+        mock_validate.return_value = MagicMock(id=uuid4())
         mock_service.side_effect = HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="You can only delete your own comments",

--- a/tests/group_posts/test_group_post_comments_websocket_views.py
+++ b/tests/group_posts/test_group_post_comments_websocket_views.py
@@ -96,7 +96,7 @@ def _websocket_env(
 
     with ExitStack() as stack:
         mock_validate = stack.enter_context(
-            patch("pecha_api.group_posts.comment_views.validate_and_extract_author_details")
+            patch("pecha_api.group_posts.comment_views.validate_and_extract_user_details")
         )
         if auth_error is not None:
             mock_validate.side_effect = auth_error
@@ -267,7 +267,7 @@ class TestWebSocketPostCommentsMessages:
 
         mock_create.assert_called_once_with(
             post_id=post_id,
-            author_email=author.email,
+            user_id=author.id,
             text="Great post!",
             parent_comment_id=None,
         )
@@ -295,7 +295,7 @@ class TestWebSocketPostCommentsMessages:
 
         mock_create.assert_called_once_with(
             post_id=post_id,
-            author_email=author.email,
+            user_id=author.id,
             text="Nested reply",
             parent_comment_id=parent_comment_id,
         )

--- a/tests/group_posts/test_like_service.py
+++ b/tests/group_posts/test_like_service.py
@@ -43,7 +43,6 @@ class TestLikePostService:
 
     @patch('pecha_api.group_posts.like_service.count_post_likes')
     @patch('pecha_api.group_posts.like_service.create_like')
-    @patch('pecha_api.group_posts.like_service.resolve_user_id')
     @patch('pecha_api.group_posts.like_service.validate_group_is_public')
     @patch('pecha_api.group_posts.like_service._get_and_validate_post')
     @patch('pecha_api.group_posts.like_service.SessionLocal')
@@ -52,7 +51,6 @@ class TestLikePostService:
         mock_session,
         mock_get_post,
         mock_validate_group,
-        mock_resolve_user,
         mock_create_like,
         mock_count_likes,
     ):
@@ -60,19 +58,18 @@ class TestLikePostService:
         post_id = uuid4()
         group_id = uuid4()
         user_id = uuid4()
-        
+
         mock_db = MagicMock()
         mock_session.return_value.__enter__.return_value = mock_db
         mock_get_post.return_value = (MockPost(post_id, group_id), group_id)
-        mock_resolve_user.return_value = user_id
-        
+
         mock_like = MockLike(post_id, user_id)
         mock_create_like.return_value = (mock_like, True)  # is_new=True
         mock_count_likes.return_value = 1
 
         result = like_post_service(
             post_id=post_id,
-            author_email="user@example.com",
+            user_id=user_id,
         )
 
         assert result.post_id == post_id
@@ -84,7 +81,6 @@ class TestLikePostService:
 
     @patch('pecha_api.group_posts.like_service.count_post_likes')
     @patch('pecha_api.group_posts.like_service.create_like')
-    @patch('pecha_api.group_posts.like_service.resolve_user_id')
     @patch('pecha_api.group_posts.like_service.validate_group_is_public')
     @patch('pecha_api.group_posts.like_service._get_and_validate_post')
     @patch('pecha_api.group_posts.like_service.SessionLocal')
@@ -93,7 +89,6 @@ class TestLikePostService:
         mock_session,
         mock_get_post,
         mock_validate_group,
-        mock_resolve_user,
         mock_create_like,
         mock_count_likes,
     ):
@@ -101,19 +96,18 @@ class TestLikePostService:
         post_id = uuid4()
         group_id = uuid4()
         user_id = uuid4()
-        
+
         mock_db = MagicMock()
         mock_session.return_value.__enter__.return_value = mock_db
         mock_get_post.return_value = (MockPost(post_id, group_id), group_id)
-        mock_resolve_user.return_value = user_id
-        
+
         mock_like = MockLike(post_id, user_id)
         mock_create_like.return_value = (mock_like, False)  # is_new=False (already existed)
         mock_count_likes.return_value = 5
 
         result = like_post_service(
             post_id=post_id,
-            author_email="user@example.com",
+            user_id=user_id,
         )
 
         assert result.post_id == post_id
@@ -136,7 +130,7 @@ class TestLikePostService:
         with pytest.raises(HTTPException) as exc_info:
             like_post_service(
                 post_id=uuid4(),
-                author_email="user@example.com",
+                user_id=uuid4(),
             )
 
         assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
@@ -145,7 +139,6 @@ class TestLikePostService:
 class TestUnlikePostService:
 
     @patch('pecha_api.group_posts.like_service.delete_like')
-    @patch('pecha_api.group_posts.like_service.resolve_user_id')
     @patch('pecha_api.group_posts.like_service.validate_group_is_public')
     @patch('pecha_api.group_posts.like_service._get_and_validate_post')
     @patch('pecha_api.group_posts.like_service.SessionLocal')
@@ -154,22 +147,20 @@ class TestUnlikePostService:
         mock_session,
         mock_get_post,
         mock_validate_group,
-        mock_resolve_user,
         mock_delete_like,
     ):
         """Test unliking a post succeeds."""
         post_id = uuid4()
         group_id = uuid4()
         user_id = uuid4()
-        
+
         mock_db = MagicMock()
         mock_session.return_value.__enter__.return_value = mock_db
         mock_get_post.return_value = (MockPost(post_id, group_id), group_id)
-        mock_resolve_user.return_value = user_id
 
         unlike_post_service(
             post_id=post_id,
-            author_email="user@example.com",
+            user_id=user_id,
         )
 
         mock_delete_like.assert_called_once_with(db=mock_db, post_id=post_id, user_id=user_id)

--- a/tests/group_recitation_collection/test_group_recitation_collection_repository.py
+++ b/tests/group_recitation_collection/test_group_recitation_collection_repository.py
@@ -1,0 +1,55 @@
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from pecha_api.group_recitation_collection.repository import (
+    get_collections_for_group_ids_with_total,
+)
+
+
+def test_get_collections_for_group_ids_with_total_empty_group_ids_returns_early():
+    db = MagicMock()
+
+    result = get_collections_for_group_ids_with_total(db=db, group_ids=[], limit=20)
+
+    assert result == ([], 0)
+    db.query.assert_not_called()
+
+
+def test_get_collections_for_group_ids_with_total_without_exclude_ids():
+    db = MagicMock()
+    group_id = uuid4()
+    collection = MagicMock()
+    query = MagicMock()
+    db.query.return_value = query
+    query.filter.return_value = query
+    query.count.return_value = 1
+    query.order_by.return_value = query
+    query.limit.return_value = query
+    query.limit.return_value.all.return_value = [collection]
+
+    collections, total = get_collections_for_group_ids_with_total(
+        db=db, group_ids=[group_id], limit=20
+    )
+
+    assert collections == [collection]
+    assert total == 1
+    query.filter.assert_called_once()
+
+
+def test_get_collections_for_group_ids_with_total_with_exclude_ids_applies_extra_filter():
+    db = MagicMock()
+    group_id = uuid4()
+    excluded_id = uuid4()
+    query = MagicMock()
+    db.query.return_value = query
+    query.filter.return_value = query
+    query.count.return_value = 0
+    query.order_by.return_value = query
+    query.limit.return_value = query
+    query.limit.return_value.all.return_value = []
+
+    get_collections_for_group_ids_with_total(
+        db=db, group_ids=[group_id], limit=20, exclude_ids=[excluded_id]
+    )
+
+    assert query.filter.call_count == 2

--- a/tests/plans/groups/test_group_invite_email.py
+++ b/tests/plans/groups/test_group_invite_email.py
@@ -24,11 +24,26 @@ def test_build_invitation_html_contains_group_and_role():
         group_title="Dharma Group",
         invite_role="AUTHOR",
         invitations_url="https://studio.webuddhist.com/groups",
+        login_url="https://studio.webuddhist.com/login",
         logo_url="https://example.com/logo.png",
     )
     assert "Dharma Group" in html
     assert "Author" in html
     assert "alice@example.org" in html
+
+
+def test_build_invitation_html_contains_login_link():
+    html = _build_invitation_html(
+        inviter_name="Alice",
+        inviter_email="alice@example.org",
+        group_title="Dharma Group",
+        invite_role="AUTHOR",
+        invitations_url="https://studio.webuddhist.com/groups",
+        login_url="https://studio.webuddhist.com/login",
+        logo_url="https://example.com/logo.png",
+    )
+    assert 'href="https://studio.webuddhist.com/login"' in html
+    assert "Log in to WeBuddhist Studio" in html
 
 
 def test_send_group_invitation_email_success():
@@ -49,7 +64,9 @@ def test_send_group_invitation_email_success():
             invite_role="AUTHOR",
         )
     mock_send.assert_called_once()
-    assert "Dharma Group" in mock_send.call_args.kwargs["message"]
+    message = mock_send.call_args.kwargs["message"]
+    assert "Dharma Group" in message
+    assert 'href="https://studio.webuddhist.com/login"' in message
 
 
 def test_send_group_invitation_email_logs_failure():

--- a/tests/plans/groups/test_groups_repository.py
+++ b/tests/plans/groups/test_groups_repository.py
@@ -13,7 +13,9 @@ from pecha_api.plans.groups.groups_repository import (
     get_groups_paginated,
     get_plans_by_group_id,
     get_series_by_group_id,
+    get_series_for_group_ids,
     get_series_partner_id_map_for_group,
+    get_standalone_plans_for_group_ids,
     get_user_series_enrollment_partner_map,
     leave_group_membership,
     update_group,
@@ -292,3 +294,97 @@ def test_leave_group_membership_does_not_commit_when_partner_cleanup_fails():
         leave_group_membership(db=db, user_id=user_id, group_id=group_id)
 
     db.commit.assert_not_called()
+
+
+def test_get_series_for_group_ids_empty_group_ids_returns_early():
+    db = _make_session_mock()
+
+    result = get_series_for_group_ids(db=db, group_ids=[], limit=20)
+
+    assert result == ([], 0)
+    db.query.assert_not_called()
+
+
+def test_get_series_for_group_ids_without_exclude_ids():
+    db = _make_session_mock()
+    group_id = uuid.uuid4()
+    series = MagicMock()
+    query = MagicMock()
+    db.query.return_value = query
+    query.filter.return_value = query
+    query.count.return_value = 1
+    query.order_by.return_value = query
+    query.limit.return_value = query
+    query.limit.return_value.all.return_value = [series]
+
+    series_list, total = get_series_for_group_ids(db=db, group_ids=[group_id], limit=20)
+
+    assert series_list == [series]
+    assert total == 1
+    query.filter.assert_called_once()
+
+
+def test_get_series_for_group_ids_with_exclude_ids_applies_extra_filter():
+    db = _make_session_mock()
+    group_id = uuid.uuid4()
+    excluded_id = uuid.uuid4()
+    query = MagicMock()
+    db.query.return_value = query
+    query.filter.return_value = query
+    query.count.return_value = 0
+    query.order_by.return_value = query
+    query.limit.return_value = query
+    query.limit.return_value.all.return_value = []
+
+    get_series_for_group_ids(
+        db=db, group_ids=[group_id], limit=20, exclude_ids=[excluded_id]
+    )
+
+    assert query.filter.call_count == 2
+
+
+def test_get_standalone_plans_for_group_ids_empty_group_ids_returns_early():
+    db = _make_session_mock()
+
+    result = get_standalone_plans_for_group_ids(db=db, group_ids=[], limit=20)
+
+    assert result == ([], 0)
+    db.query.assert_not_called()
+
+
+def test_get_standalone_plans_for_group_ids_without_exclude_ids():
+    db = _make_session_mock()
+    group_id = uuid.uuid4()
+    plan = MagicMock()
+    query = MagicMock()
+    db.query.return_value = query
+    query.filter.return_value = query
+    query.count.return_value = 1
+    query.order_by.return_value = query
+    query.limit.return_value = query
+    query.limit.return_value.all.return_value = [plan]
+
+    plans, total = get_standalone_plans_for_group_ids(db=db, group_ids=[group_id], limit=20)
+
+    assert plans == [plan]
+    assert total == 1
+    query.filter.assert_called_once()
+
+
+def test_get_standalone_plans_for_group_ids_with_exclude_ids_applies_extra_filter():
+    db = _make_session_mock()
+    group_id = uuid.uuid4()
+    excluded_id = uuid.uuid4()
+    query = MagicMock()
+    db.query.return_value = query
+    query.filter.return_value = query
+    query.count.return_value = 0
+    query.order_by.return_value = query
+    query.limit.return_value = query
+    query.limit.return_value.all.return_value = []
+
+    get_standalone_plans_for_group_ids(
+        db=db, group_ids=[group_id], limit=20, exclude_ids=[excluded_id]
+    )
+
+    assert query.filter.call_count == 2

--- a/tests/plans/groups/test_groups_service.py
+++ b/tests/plans/groups/test_groups_service.py
@@ -3307,12 +3307,23 @@ def _plan_aggregate(plan):
     return aggregate
 
 
+def _make_feed_collection(group_id, created_at):
+    collection = MagicMock()
+    collection.id = uuid4()
+    collection.group_id = group_id
+    collection.created_at = created_at
+    collection.name = "Collection"
+    collection.img_url = None
+    return collection
+
+
 def test_get_group_practices_feed_merges_and_sorts_by_created_at():
     group = _make_group()
     user = _make_feed_user()
-    series = _make_feed_series(group.id, datetime(2026, 1, 3, tzinfo=timezone.utc))
-    plan = _make_feed_plan(group.id, datetime(2026, 1, 2, tzinfo=timezone.utc))
-    accumulator = _make_feed_accumulator(group.id, datetime(2026, 1, 1, tzinfo=timezone.utc))
+    series = _make_feed_series(group.id, datetime(2026, 1, 4, tzinfo=timezone.utc))
+    plan = _make_feed_plan(group.id, datetime(2026, 1, 3, tzinfo=timezone.utc))
+    accumulator = _make_feed_accumulator(group.id, datetime(2026, 1, 2, tzinfo=timezone.utc))
+    collection = _make_feed_collection(group.id, datetime(2026, 1, 1, tzinfo=timezone.utc))
 
     with patch("pecha_api.plans.groups.groups_service.SessionLocal") as mock_session, patch(
         "pecha_api.plans.groups.groups_service.validate_and_extract_user_details",
@@ -3348,24 +3359,33 @@ def test_get_group_practices_feed_merges_and_sorts_by_created_at():
         "pecha_api.plans.groups.groups_service._group_accumulator_to_dto",
         side_effect=_feed_accumulator_dto,
     ), patch(
+        "pecha_api.plans.groups.groups_service.get_collections_for_group_ids_with_total",
+        return_value=([collection], 1),
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_collection_item_counts",
+        return_value={collection.id: 4},
+    ), patch(
         "pecha_api.plans.groups.groups_service.get_groups_by_ids",
         return_value=[group],
     ):
         _session_local_context(mock_session)
         result = get_group_practices_feed(token="valid-token", skip=0, limit=20)
 
-    assert result.total == 3
+    assert result.total == 4
     assert result.include_unfollowed is False
     assert [card.type for card in result.practices] == [
         GroupPracticeType.SERIES,
         GroupPracticeType.PLAN,
         GroupPracticeType.ACCUMULATOR,
+        GroupPracticeType.COLLECTION,
     ]
     assert result.practices[0].series.id == series.id
     assert result.practices[1].plan.id == plan.id
     assert result.practices[2].accumulator.id == accumulator.id
     assert result.practices[2].accumulator.is_joined is True
     assert result.practices[2].accumulator.member_count == 5
+    assert result.practices[3].collection.id == collection.id
+    assert result.practices[3].collection.item_count == 4
     assert all(card.is_joined for card in result.practices)
     assert all(card.group_id == group.id for card in result.practices)
     assert result.practices[0].group_slug == group.slug
@@ -3408,6 +3428,12 @@ def test_get_group_practices_feed_marks_unfollowed_groups():
     ), patch(
         "pecha_api.plans.groups.groups_service._group_accumulator_to_dto",
         side_effect=_feed_accumulator_dto,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_collections_for_group_ids_with_total",
+        return_value=([], 0),
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_collection_item_counts",
+        return_value={},
     ), patch(
         "pecha_api.plans.groups.groups_service.get_groups_by_ids",
         return_value=[other_group],
@@ -3455,6 +3481,12 @@ def test_get_group_practices_feed_group_filter_restricts_scope():
         "pecha_api.plans.groups.groups_service.get_group_accumulator_joiners_counts",
         return_value={},
     ), patch(
+        "pecha_api.plans.groups.groups_service.get_collections_for_group_ids_with_total",
+        return_value=([], 0),
+    ) as mock_collections, patch(
+        "pecha_api.plans.groups.groups_service.get_collection_item_counts",
+        return_value={},
+    ), patch(
         "pecha_api.plans.groups.groups_service.get_groups_by_ids",
         return_value=[],
     ):
@@ -3464,6 +3496,7 @@ def test_get_group_practices_feed_group_filter_restricts_scope():
     assert mock_series.call_args.kwargs["group_ids"] == [group_b.id]
     assert mock_plans.call_args.kwargs["group_ids"] == [group_b.id]
     assert mock_accumulators.call_args.kwargs["group_ids"] == [group_b.id]
+    assert mock_collections.call_args.kwargs["group_ids"] == [group_b.id]
     assert result.total == 0
 
 
@@ -3521,6 +3554,12 @@ def test_get_group_practices_feed_pagination():
     ), patch(
         "pecha_api.plans.groups.groups_service._group_accumulator_to_dto",
         side_effect=_feed_accumulator_dto,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_collections_for_group_ids_with_total",
+        return_value=([], 0),
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_collection_item_counts",
+        return_value={},
     ), patch(
         "pecha_api.plans.groups.groups_service.get_groups_by_ids",
         return_value=[group],

--- a/tests/plans/groups/test_groups_service.py
+++ b/tests/plans/groups/test_groups_service.py
@@ -1475,7 +1475,7 @@ def test_create_group_member_invite_creates_notification():
             MagicMock(role=AuthorGroupMemberRole.OWNER) if author_id == author.id else None
         ),
     ), patch(
-        "pecha_api.plans.groups.groups_service.get_author_by_email",
+        "pecha_api.plans.groups.groups_service.find_author_by_email",
         return_value=target_author,
     ), patch(
         "pecha_api.plans.groups.groups_service.has_pending_invite",
@@ -1525,7 +1525,7 @@ def test_create_group_member_invite_blocks_existing_member():
         "pecha_api.plans.groups.groups_service.get_group_member",
         side_effect=_get_member,
     ), patch(
-        "pecha_api.plans.groups.groups_service.get_author_by_email",
+        "pecha_api.plans.groups.groups_service.find_author_by_email",
         return_value=target_author,
     ):
         _session_local_context(mock_session)
@@ -1651,7 +1651,7 @@ def test_create_group_member_invite_blocks_pending_invite():
             MagicMock(role=AuthorGroupMemberRole.OWNER) if author_id == author.id else None
         ),
     ), patch(
-        "pecha_api.plans.groups.groups_service.get_author_by_email",
+        "pecha_api.plans.groups.groups_service.find_author_by_email",
         return_value=target_author,
     ), patch(
         "pecha_api.plans.groups.groups_service.has_pending_invite",
@@ -2230,7 +2230,7 @@ def test_revoke_group_invite_success():
     ), patch(
         "pecha_api.plans.groups.groups_service.revoke_invite",
     ) as mock_revoke, patch(
-        "pecha_api.plans.groups.groups_service.get_author_by_email",
+        "pecha_api.plans.groups.groups_service.find_author_by_email",
         return_value=target_author,
     ), patch(
         "pecha_api.plans.groups.groups_service._mark_invite_notification_read",
@@ -2281,7 +2281,7 @@ def test_create_group_member_invite_builds_notification_with_group_title():
             else None
         ),
     ), patch(
-        "pecha_api.plans.groups.groups_service.get_author_by_email",
+        "pecha_api.plans.groups.groups_service.find_author_by_email",
         return_value=target_author,
     ), patch(
         "pecha_api.plans.groups.groups_service.has_pending_invite",
@@ -2362,7 +2362,7 @@ def test_create_group_member_invite_unknown_target_email_still_invites():
         "pecha_api.plans.groups.groups_service.get_group_member",
         return_value=MagicMock(role=AuthorGroupMemberRole.OWNER),
     ), patch(
-        "pecha_api.plans.groups.groups_service.get_author_by_email",
+        "pecha_api.plans.groups.groups_service.find_author_by_email",
         return_value=None,
     ), patch(
         "pecha_api.plans.groups.groups_service.has_pending_invite",
@@ -2390,6 +2390,64 @@ def test_create_group_member_invite_unknown_target_email_still_invites():
     mock_send_email.assert_called_once()
 
 
+def test_create_group_member_invite_unknown_target_email_uses_non_raising_lookup():
+    """Regression guard: the author-lookup used for target_email resolution
+    must be find_author_by_email (returns None on no match), not
+    get_author_by_email (raises HTTPException 404 "Author not found" on no
+    match). Exercises the real find_author_by_email against a db mock that
+    returns no row, instead of mocking the lookup function itself, so a
+    future accidental revert to get_author_by_email is caught here rather
+    than surfacing as a raw 404 in production."""
+    author = _make_author()
+    group = _make_group()
+    invite = MagicMock()
+    invite.id = uuid4()
+    invite.group_id = group.id
+    invite.target_email = "missing@example.org"
+    invite.role = AuthorGroupMemberRole.AUTHOR
+    invite.status = AuthorGroupInviteStatus.PENDING.value
+    invite.expires_at = datetime.now(timezone.utc) + timedelta(minutes=30)
+    invite.created_at = datetime.now(timezone.utc)
+    invite.created_by = author.email
+    invite.accepted_at = None
+    invite.rejected_at = None
+    invite.revoked_at = None
+
+    with patch("pecha_api.plans.groups.groups_service.SessionLocal") as mock_session, patch(
+        "pecha_api.plans.groups.groups_service.validate_and_extract_author_details",
+        return_value=author,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_group_by_id",
+        return_value=group,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_group_member",
+        return_value=MagicMock(role=AuthorGroupMemberRole.OWNER),
+    ), patch(
+        "pecha_api.plans.groups.groups_service.has_pending_invite",
+        return_value=False,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.create_group_invite",
+        return_value=invite,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.send_group_invitation_email",
+    ):
+        mock_db = _session_local_context(mock_session)
+        # No mocking of find_author_by_email: the real repository function
+        # runs against this db mock's query chain, which yields no row.
+        mock_db.query.return_value.options.return_value.filter.return_value.first.return_value = None
+
+        result = create_group_member_invite(
+            token="t",
+            group_id=group.id,
+            request=CreateGroupInviteRequest(
+                target_email="missing@example.org",
+                role=AuthorGroupMemberRole.AUTHOR,
+            ),
+        )
+    assert result.invite.target_email == "missing@example.org"
+    assert result.notification_id is None
+
+
 def _make_invite_for_email(email, group_name="Test Group", created_by="owner@example.org"):
     invite = MagicMock()
     invite.id = uuid4()
@@ -2411,7 +2469,7 @@ def test_notify_pending_group_invites_creates_one_notification_per_invite():
         "pecha_api.plans.groups.groups_service.notification_exists_for_reference",
         return_value=False,
     ), patch(
-        "pecha_api.plans.groups.groups_service.get_author_by_email",
+        "pecha_api.plans.groups.groups_service.find_author_by_email",
         return_value=None,
     ), patch(
         "pecha_api.plans.groups.groups_service.create_notification_record",

--- a/tests/plans/groups/test_groups_service.py
+++ b/tests/plans/groups/test_groups_service.py
@@ -51,6 +51,7 @@ from pecha_api.plans.groups.groups_service import (
     get_group_practices_feed,
     list_group_invites,
     list_my_pending_group_invites,
+    notify_pending_group_invites,
     reject_group_invite_by_id,
     follow_group,
     get_followed_group,
@@ -2330,9 +2331,27 @@ def test_create_group_member_invite_requires_target_email():
     assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_create_group_member_invite_unknown_target_email():
+def test_create_group_member_invite_unknown_target_email_still_invites():
+    """An email with no Author account yet must still succeed: the invite is
+    created and the invitation email is sent, but no in-app notification can
+    be created (there's no author id to attach it to) — notification_id is
+    None. See notify_pending_group_invites for the notification backfill
+    that runs once this person registers and verifies."""
     author = _make_author()
     group = _make_group()
+    invite = MagicMock()
+    invite.id = uuid4()
+    invite.group_id = group.id
+    invite.target_email = "missing@example.org"
+    invite.role = AuthorGroupMemberRole.AUTHOR
+    invite.status = AuthorGroupInviteStatus.PENDING.value
+    invite.expires_at = datetime.now(timezone.utc) + timedelta(minutes=30)
+    invite.created_at = datetime.now(timezone.utc)
+    invite.created_by = author.email
+    invite.accepted_at = None
+    invite.rejected_at = None
+    invite.revoked_at = None
+
     with patch("pecha_api.plans.groups.groups_service.SessionLocal") as mock_session, patch(
         "pecha_api.plans.groups.groups_service.validate_and_extract_author_details",
         return_value=author,
@@ -2345,18 +2364,96 @@ def test_create_group_member_invite_unknown_target_email():
     ), patch(
         "pecha_api.plans.groups.groups_service.get_author_by_email",
         return_value=None,
-    ):
+    ), patch(
+        "pecha_api.plans.groups.groups_service.has_pending_invite",
+        return_value=False,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.create_group_invite",
+        return_value=invite,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.create_notification_record",
+    ) as mock_create_notification, patch(
+        "pecha_api.plans.groups.groups_service.send_group_invitation_email",
+    ) as mock_send_email:
         _session_local_context(mock_session)
-        with pytest.raises(HTTPException) as exc:
-            create_group_member_invite(
-                token="t",
-                group_id=group.id,
-                request=CreateGroupInviteRequest(
-                    target_email="missing@example.org",
-                    role=AuthorGroupMemberRole.AUTHOR,
-                ),
-            )
-    assert "No registered author" in exc.value.detail
+        result = create_group_member_invite(
+            token="t",
+            group_id=group.id,
+            request=CreateGroupInviteRequest(
+                target_email="missing@example.org",
+                role=AuthorGroupMemberRole.AUTHOR,
+            ),
+        )
+    assert result.invite.target_email == "missing@example.org"
+    assert result.notification_id is None
+    mock_create_notification.assert_not_called()
+    mock_send_email.assert_called_once()
+
+
+def _make_invite_for_email(email, group_name="Test Group", created_by="owner@example.org"):
+    invite = MagicMock()
+    invite.id = uuid4()
+    invite.target_email = email
+    invite.created_by = created_by
+    invite.group = MagicMock()
+    invite.group.metadata_entries = [MagicMock(language="EN", title=group_name)]
+    return invite
+
+
+def test_notify_pending_group_invites_creates_one_notification_per_invite():
+    author = _make_author(email="invitee@example.org")
+    invites = [_make_invite_for_email(author.email), _make_invite_for_email(author.email)]
+
+    with patch("pecha_api.plans.groups.groups_service.SessionLocal") as mock_session, patch(
+        "pecha_api.plans.groups.groups_service.list_pending_invites_by_email",
+        return_value=invites,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.notification_exists_for_reference",
+        return_value=False,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_author_by_email",
+        return_value=None,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.create_notification_record",
+    ) as mock_create_notification:
+        _session_local_context(mock_session)
+        notify_pending_group_invites(author)
+
+    assert mock_create_notification.call_count == 2
+    called_reference_ids = {
+        call.kwargs["reference_id"] for call in mock_create_notification.call_args_list
+    }
+    assert called_reference_ids == {invite.id for invite in invites}
+
+
+def test_notify_pending_group_invites_is_idempotent():
+    author = _make_author(email="invitee@example.org")
+    invites = [_make_invite_for_email(author.email)]
+
+    with patch("pecha_api.plans.groups.groups_service.SessionLocal") as mock_session, patch(
+        "pecha_api.plans.groups.groups_service.list_pending_invites_by_email",
+        return_value=invites,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.notification_exists_for_reference",
+        return_value=True,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.create_notification_record",
+    ) as mock_create_notification:
+        _session_local_context(mock_session)
+        notify_pending_group_invites(author)
+
+    mock_create_notification.assert_not_called()
+
+
+def test_notify_pending_group_invites_swallows_errors():
+    author = _make_author(email="invitee@example.org")
+
+    with patch(
+        "pecha_api.plans.groups.groups_service.SessionLocal",
+        side_effect=RuntimeError("db down"),
+    ):
+        # Must not raise: a notification-layer failure can never break signup/login.
+        notify_pending_group_invites(author)
 
 
 def test_accept_group_invite_group_missing_after_invite_found():

--- a/tests/plans/groups/test_groups_service.py
+++ b/tests/plans/groups/test_groups_service.py
@@ -28,12 +28,15 @@ from pecha_api.plans.groups.groups_response_models import (
     UpdateGroupMemberRoleRequest,
 )
 from pecha_api.plans.series.series_response_models import SeriesPartnerDTO
+from pecha_api.region_restrictions.region_restriction_enums import RestrictedItemType
 from pecha_api.plans.groups.groups_service import (
     GROUP_NOT_FOUND,
     _as_aware_utc,
     _assert_metadata_valid,
+    _restricted_ids_for_timezone,
     _generate_group_asset_url,
     _get_member_or_403,
+    _group_card_title,
     _group_to_detail,
     _is_series_enrolled_for_group_context,
     _series_to_dtos,
@@ -3570,3 +3573,191 @@ def test_get_group_practices_feed_pagination():
     assert result.total == 2
     assert len(result.practices) == 1
     assert result.practices[0].accumulator.id == older.id
+
+
+def test_restricted_ids_for_timezone_returns_none_outside_china_timezone():
+    with patch(
+        "pecha_api.plans.groups.groups_service.is_china_timezone", return_value=False
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_restricted_item_ids"
+    ) as mock_get_restricted_ids:
+        result = _restricted_ids_for_timezone(RestrictedItemType.SERIES, "America/New_York")
+
+    assert result is None
+    mock_get_restricted_ids.assert_not_called()
+
+
+def test_restricted_ids_for_timezone_returns_none_when_no_restricted_items():
+    with patch(
+        "pecha_api.plans.groups.groups_service.is_china_timezone", return_value=True
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_restricted_item_ids",
+        return_value=frozenset(),
+    ):
+        result = _restricted_ids_for_timezone(RestrictedItemType.SERIES, "Asia/Shanghai")
+
+    assert result is None
+
+
+def test_restricted_ids_for_timezone_returns_list_when_china_timezone_has_restrictions():
+    restricted_id = uuid4()
+    with patch(
+        "pecha_api.plans.groups.groups_service.is_china_timezone", return_value=True
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_restricted_item_ids",
+        return_value=frozenset({restricted_id}),
+    ) as mock_get_restricted_ids:
+        result = _restricted_ids_for_timezone(RestrictedItemType.GROUP_ACCUMULATOR, "Asia/Shanghai")
+
+    assert result == [restricted_id]
+    mock_get_restricted_ids.assert_called_once_with(RestrictedItemType.GROUP_ACCUMULATOR)
+
+
+def test_get_group_practices_feed_passes_restricted_ids_to_source_queries():
+    """When the caller is in a China timezone, each source query must receive
+    the restricted-id set to exclude at the query layer, so a fixed fetch
+    window never omits eligible items that fall past a restricted one."""
+    group = _make_group()
+    user = _make_feed_user()
+    restricted_series_id = uuid4()
+    restricted_plan_id = uuid4()
+    restricted_accumulator_id = uuid4()
+    restricted_collection_id = uuid4()
+
+    def _restricted_ids(item_type):
+        return {
+            RestrictedItemType.SERIES: frozenset({restricted_series_id}),
+            RestrictedItemType.PLAN: frozenset({restricted_plan_id}),
+            RestrictedItemType.GROUP_ACCUMULATOR: frozenset({restricted_accumulator_id}),
+            RestrictedItemType.GROUP_RECITATION_COLLECTION: frozenset({restricted_collection_id}),
+        }[item_type]
+
+    with patch("pecha_api.plans.groups.groups_service.SessionLocal") as mock_session, patch(
+        "pecha_api.plans.groups.groups_service.validate_and_extract_user_details",
+        return_value=user,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.resolve_public_group_scope",
+        return_value=([group.id], {group.id}),
+    ), patch(
+        "pecha_api.plans.groups.groups_service.filter_items_for_timezone",
+        side_effect=lambda items, **_: list(items),
+    ), patch(
+        "pecha_api.plans.groups.groups_service.is_china_timezone", return_value=True
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_restricted_item_ids",
+        side_effect=_restricted_ids,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_series_for_group_ids",
+        return_value=([], 0),
+    ) as mock_series, patch(
+        "pecha_api.plans.groups.groups_service.get_standalone_plans_for_group_ids",
+        return_value=([], 0),
+    ) as mock_plans, patch(
+        "pecha_api.plans.groups.groups_service.get_plans_with_aggregates_by_ids",
+        return_value=[],
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_group_accumulators_for_group_ids",
+        return_value=([], 0),
+    ) as mock_accumulators, patch(
+        "pecha_api.plans.groups.groups_service.get_joined_group_accumulator_ids_by_user",
+        return_value=[],
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_group_accumulator_joiners_counts",
+        return_value={},
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_collections_for_group_ids_with_total",
+        return_value=([], 0),
+    ) as mock_collections, patch(
+        "pecha_api.plans.groups.groups_service.get_collection_item_counts",
+        return_value={},
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_groups_by_ids",
+        return_value=[],
+    ):
+        _session_local_context(mock_session)
+        get_group_practices_feed(
+            token="valid-token", timezone_name="Asia/Shanghai"
+        )
+
+    assert mock_series.call_args.kwargs["exclude_ids"] == [restricted_series_id]
+    assert mock_plans.call_args.kwargs["exclude_ids"] == [restricted_plan_id]
+    assert mock_accumulators.call_args.kwargs["exclude_ids"] == [restricted_accumulator_id]
+    assert mock_collections.call_args.kwargs["exclude_ids"] == [restricted_collection_id]
+
+
+def test_get_group_practices_feed_no_exclude_ids_outside_china_timezone():
+    group = _make_group()
+    user = _make_feed_user()
+
+    with patch("pecha_api.plans.groups.groups_service.SessionLocal") as mock_session, patch(
+        "pecha_api.plans.groups.groups_service.validate_and_extract_user_details",
+        return_value=user,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.resolve_public_group_scope",
+        return_value=([group.id], {group.id}),
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_series_for_group_ids",
+        return_value=([], 0),
+    ) as mock_series, patch(
+        "pecha_api.plans.groups.groups_service.get_standalone_plans_for_group_ids",
+        return_value=([], 0),
+    ) as mock_plans, patch(
+        "pecha_api.plans.groups.groups_service.get_plans_with_aggregates_by_ids",
+        return_value=[],
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_group_accumulators_for_group_ids",
+        return_value=([], 0),
+    ) as mock_accumulators, patch(
+        "pecha_api.plans.groups.groups_service.get_joined_group_accumulator_ids_by_user",
+        return_value=[],
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_group_accumulator_joiners_counts",
+        return_value={},
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_collections_for_group_ids_with_total",
+        return_value=([], 0),
+    ) as mock_collections, patch(
+        "pecha_api.plans.groups.groups_service.get_collection_item_counts",
+        return_value={},
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_groups_by_ids",
+        return_value=[],
+    ):
+        _session_local_context(mock_session)
+        get_group_practices_feed(token="valid-token")
+
+    assert mock_series.call_args.kwargs["exclude_ids"] is None
+    assert mock_plans.call_args.kwargs["exclude_ids"] is None
+    assert mock_accumulators.call_args.kwargs["exclude_ids"] is None
+    assert mock_collections.call_args.kwargs["exclude_ids"] is None
+
+
+def _make_metadata_entry(language, title):
+    entry = MagicMock()
+    entry.language = language
+    entry.title = title
+    return entry
+
+
+def test_group_card_title_falls_back_to_slug_without_metadata():
+    group = _make_group(slug="no-metadata-group")
+    group.metadata_entries = []
+
+    assert _group_card_title(group) == "no-metadata-group"
+
+
+def test_group_card_title_returns_entry_matching_requested_language():
+    group = _make_group()
+    group.metadata_entries = [
+        _make_metadata_entry("EN", "English Title"),
+        _make_metadata_entry("BO", "Tibetan Title"),
+    ]
+
+    assert _group_card_title(group, language="BO") == "Tibetan Title"
+
+
+def test_group_card_title_falls_back_to_first_entry_when_no_language_matches():
+    group = _make_group()
+    group.metadata_entries = [_make_metadata_entry("FR", "French Title")]
+
+    assert _group_card_title(group, language="BO") == "French Title"

--- a/tests/plans/groups/test_groups_service.py
+++ b/tests/plans/groups/test_groups_service.py
@@ -45,6 +45,7 @@ from pecha_api.plans.groups.groups_service import (
     get_group_accumulations,
     get_group_member_accumulations,
     get_group_practices,
+    get_group_practices_feed,
     list_group_invites,
     list_my_pending_group_invites,
     reject_group_invite_by_id,
@@ -72,6 +73,7 @@ from pecha_api.plans.groups.groups_service import (
 )
 from pecha_api.plans.platform_enums import PlatformRole
 from pecha_api.plans.plans_enums import LanguageCode, PlanStatus
+from pecha_api.plans.plans_response_models import PlanDTO
 
 
 def _session_local_context(mock_session_local):
@@ -3234,3 +3236,298 @@ async def test_get_group_practices_with_invalid_token_continues_anonymously():
     assert mock_series_to_dtos.call_args.kwargs["user_id"] is None
     assert result.total == 0
     assert result.practices == []
+
+
+def _make_feed_user():
+    user = MagicMock()
+    user.id = uuid4()
+    return user
+
+
+def _make_feed_series(group_id, created_at):
+    series = MagicMock()
+    series.id = uuid4()
+    series.group_id = group_id
+    series.created_at = created_at
+    return series
+
+
+def _make_feed_plan(group_id, created_at):
+    plan = MagicMock()
+    plan.id = uuid4()
+    plan.group_id = group_id
+    plan.created_at = created_at
+    return plan
+
+
+def _make_feed_accumulator(group_id, created_at):
+    accumulator = MagicMock()
+    accumulator.id = uuid4()
+    accumulator.group_id = group_id
+    accumulator.created_at = created_at
+    return accumulator
+
+
+def _feed_series_dto(series):
+    return GroupSeriesListItemDTO(
+        id=series.id,
+        author_id=uuid4(),
+        featured=False,
+        status=PlanStatus.PUBLISHED,
+    )
+
+
+def _feed_accumulator_dto(accumulator, is_joined, member_count):
+    return GroupAccumulatorDTO(
+        id=accumulator.id,
+        group_id=accumulator.group_id,
+        title="Accumulator",
+        is_joined=is_joined,
+        member_count=member_count,
+        created_at=accumulator.created_at,
+    )
+
+
+def _feed_plan_dto(plan_info, group_id):
+    return PlanDTO(
+        id=plan_info.plan.id,
+        title="Plan",
+        description="Desc",
+        language="EN",
+        total_days=1,
+        status=PlanStatus.PUBLISHED,
+        subscription_count=0,
+        group_id=group_id,
+    )
+
+
+def _plan_aggregate(plan):
+    aggregate = MagicMock()
+    aggregate.plan = plan
+    return aggregate
+
+
+def test_get_group_practices_feed_merges_and_sorts_by_created_at():
+    group = _make_group()
+    user = _make_feed_user()
+    series = _make_feed_series(group.id, datetime(2026, 1, 3, tzinfo=timezone.utc))
+    plan = _make_feed_plan(group.id, datetime(2026, 1, 2, tzinfo=timezone.utc))
+    accumulator = _make_feed_accumulator(group.id, datetime(2026, 1, 1, tzinfo=timezone.utc))
+
+    with patch("pecha_api.plans.groups.groups_service.SessionLocal") as mock_session, patch(
+        "pecha_api.plans.groups.groups_service.validate_and_extract_user_details",
+        return_value=user,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.resolve_public_group_scope",
+        return_value=([group.id], {group.id}),
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_series_for_group_ids",
+        return_value=([series], 1),
+    ), patch(
+        "pecha_api.plans.groups.groups_service._series_to_dtos",
+        return_value=[_feed_series_dto(series)],
+    ) as mock_series_to_dtos, patch(
+        "pecha_api.plans.groups.groups_service.get_standalone_plans_for_group_ids",
+        return_value=([plan], 1),
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_plans_with_aggregates_by_ids",
+        return_value=[_plan_aggregate(plan)],
+    ), patch(
+        "pecha_api.plans.groups.groups_service._plan_aggregate_to_dto",
+        side_effect=_feed_plan_dto,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_group_accumulators_for_group_ids",
+        return_value=([accumulator], 1),
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_joined_group_accumulator_ids_by_user",
+        return_value=[accumulator.id],
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_group_accumulator_joiners_counts",
+        return_value={accumulator.id: 5},
+    ), patch(
+        "pecha_api.plans.groups.groups_service._group_accumulator_to_dto",
+        side_effect=_feed_accumulator_dto,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_groups_by_ids",
+        return_value=[group],
+    ):
+        _session_local_context(mock_session)
+        result = get_group_practices_feed(token="valid-token", skip=0, limit=20)
+
+    assert result.total == 3
+    assert result.include_unfollowed is False
+    assert [card.type for card in result.practices] == [
+        GroupPracticeType.SERIES,
+        GroupPracticeType.PLAN,
+        GroupPracticeType.ACCUMULATOR,
+    ]
+    assert result.practices[0].series.id == series.id
+    assert result.practices[1].plan.id == plan.id
+    assert result.practices[2].accumulator.id == accumulator.id
+    assert result.practices[2].accumulator.is_joined is True
+    assert result.practices[2].accumulator.member_count == 5
+    assert all(card.is_joined for card in result.practices)
+    assert all(card.group_id == group.id for card in result.practices)
+    assert result.practices[0].group_slug == group.slug
+    assert mock_series_to_dtos.call_args.kwargs["user_id"] == user.id
+    assert mock_series_to_dtos.call_args.kwargs["published_only"] is True
+
+
+def test_get_group_practices_feed_marks_unfollowed_groups():
+    joined_group = _make_group(slug="joined-group")
+    other_group = _make_group(slug="other-group")
+    user = _make_feed_user()
+    accumulator = _make_feed_accumulator(
+        other_group.id, datetime(2026, 1, 1, tzinfo=timezone.utc)
+    )
+
+    with patch("pecha_api.plans.groups.groups_service.SessionLocal") as mock_session, patch(
+        "pecha_api.plans.groups.groups_service.validate_and_extract_user_details",
+        return_value=user,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.resolve_public_group_scope",
+        return_value=([joined_group.id, other_group.id], {joined_group.id}),
+    ) as mock_scope, patch(
+        "pecha_api.plans.groups.groups_service.get_series_for_group_ids",
+        return_value=([], 0),
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_standalone_plans_for_group_ids",
+        return_value=([], 0),
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_plans_with_aggregates_by_ids",
+        return_value=[],
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_group_accumulators_for_group_ids",
+        return_value=([accumulator], 1),
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_joined_group_accumulator_ids_by_user",
+        return_value=[],
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_group_accumulator_joiners_counts",
+        return_value={},
+    ), patch(
+        "pecha_api.plans.groups.groups_service._group_accumulator_to_dto",
+        side_effect=_feed_accumulator_dto,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_groups_by_ids",
+        return_value=[other_group],
+    ):
+        _session_local_context(mock_session)
+        result = get_group_practices_feed(
+            token="valid-token", should_include_unfollowed=True
+        )
+
+    assert mock_scope.call_args.kwargs["should_include_unfollowed"] is True
+    assert result.include_unfollowed is True
+    assert result.total == 1
+    assert result.practices[0].is_joined is False
+    assert result.practices[0].group_id == other_group.id
+    assert result.practices[0].group_slug == "other-group"
+
+
+def test_get_group_practices_feed_group_filter_restricts_scope():
+    group_a = _make_group(slug="group-a")
+    group_b = _make_group(slug="group-b")
+    user = _make_feed_user()
+
+    with patch("pecha_api.plans.groups.groups_service.SessionLocal") as mock_session, patch(
+        "pecha_api.plans.groups.groups_service.validate_and_extract_user_details",
+        return_value=user,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.resolve_public_group_scope",
+        return_value=([group_a.id, group_b.id], {group_a.id, group_b.id}),
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_series_for_group_ids",
+        return_value=([], 0),
+    ) as mock_series, patch(
+        "pecha_api.plans.groups.groups_service.get_standalone_plans_for_group_ids",
+        return_value=([], 0),
+    ) as mock_plans, patch(
+        "pecha_api.plans.groups.groups_service.get_plans_with_aggregates_by_ids",
+        return_value=[],
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_group_accumulators_for_group_ids",
+        return_value=([], 0),
+    ) as mock_accumulators, patch(
+        "pecha_api.plans.groups.groups_service.get_joined_group_accumulator_ids_by_user",
+        return_value=[],
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_group_accumulator_joiners_counts",
+        return_value={},
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_groups_by_ids",
+        return_value=[],
+    ):
+        _session_local_context(mock_session)
+        result = get_group_practices_feed(token="valid-token", group_id=group_b.id)
+
+    assert mock_series.call_args.kwargs["group_ids"] == [group_b.id]
+    assert mock_plans.call_args.kwargs["group_ids"] == [group_b.id]
+    assert mock_accumulators.call_args.kwargs["group_ids"] == [group_b.id]
+    assert result.total == 0
+
+
+def test_get_group_practices_feed_group_filter_outside_scope_returns_empty():
+    group = _make_group()
+    user = _make_feed_user()
+
+    with patch("pecha_api.plans.groups.groups_service.SessionLocal") as mock_session, patch(
+        "pecha_api.plans.groups.groups_service.validate_and_extract_user_details",
+        return_value=user,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.resolve_public_group_scope",
+        return_value=([group.id], {group.id}),
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_series_for_group_ids",
+    ) as mock_series:
+        _session_local_context(mock_session)
+        result = get_group_practices_feed(token="valid-token", group_id=uuid4())
+
+    mock_series.assert_not_called()
+    assert result.total == 0
+    assert result.practices == []
+
+
+def test_get_group_practices_feed_pagination():
+    group = _make_group()
+    user = _make_feed_user()
+    older = _make_feed_accumulator(group.id, datetime(2026, 1, 1, tzinfo=timezone.utc))
+    newer = _make_feed_accumulator(group.id, datetime(2026, 1, 2, tzinfo=timezone.utc))
+
+    with patch("pecha_api.plans.groups.groups_service.SessionLocal") as mock_session, patch(
+        "pecha_api.plans.groups.groups_service.validate_and_extract_user_details",
+        return_value=user,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.resolve_public_group_scope",
+        return_value=([group.id], {group.id}),
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_series_for_group_ids",
+        return_value=([], 0),
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_standalone_plans_for_group_ids",
+        return_value=([], 0),
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_plans_with_aggregates_by_ids",
+        return_value=[],
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_group_accumulators_for_group_ids",
+        return_value=([older, newer], 2),
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_joined_group_accumulator_ids_by_user",
+        return_value=[],
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_group_accumulator_joiners_counts",
+        return_value={},
+    ), patch(
+        "pecha_api.plans.groups.groups_service._group_accumulator_to_dto",
+        side_effect=_feed_accumulator_dto,
+    ), patch(
+        "pecha_api.plans.groups.groups_service.get_groups_by_ids",
+        return_value=[group],
+    ):
+        _session_local_context(mock_session)
+        result = get_group_practices_feed(token="valid-token", skip=1, limit=1)
+
+    assert result.total == 2
+    assert len(result.practices) == 1
+    assert result.practices[0].accumulator.id == older.id

--- a/tests/plans/groups/test_groups_views.py
+++ b/tests/plans/groups/test_groups_views.py
@@ -19,6 +19,8 @@ from pecha_api.plans.groups.groups_response_models import (
     GroupMemberAccumulationsResponse,
     GroupMetadataDTO,
     GroupPracticeCardDTO,
+    GroupPracticeFeedItemDTO,
+    GroupPracticesFeedResponse,
     GroupPracticesResponse,
     GroupPracticeType,
     GroupSeriesListItemDTO,
@@ -530,6 +532,87 @@ def test_get_public_group_practices():
     assert body["total"] == 3
     types = {card["type"] for card in body["practices"]}
     assert types == {"series", "accumulator", "collection"}
+
+
+def test_get_group_practices_feed_success():
+    group_id = uuid4()
+    feed_response = GroupPracticesFeedResponse(
+        practices=[
+            GroupPracticeFeedItemDTO(
+                type=GroupPracticeType.ACCUMULATOR,
+                practice_at=datetime(2026, 1, 2, tzinfo=timezone.utc),
+                is_joined=True,
+                group_id=group_id,
+                group_name="Test Group",
+                group_slug="test-group",
+                accumulator=GroupAccumulatorDTO(
+                    id=uuid4(),
+                    group_id=group_id,
+                    title="Om Mani Padme Hum",
+                    member_count=3,
+                    created_at=datetime(2026, 1, 2, tzinfo=timezone.utc),
+                ),
+            ),
+        ],
+        skip=0,
+        limit=20,
+        total=1,
+        include_unfollowed=False,
+    )
+    with patch(
+        "pecha_api.plans.groups.groups_views.get_group_practices_feed",
+        return_value=feed_response,
+    ) as mock_service:
+        response = client.get(
+            "/author/groups/practices",
+            headers={"Authorization": "Bearer dummy"},
+        )
+    assert response.status_code == status.HTTP_200_OK
+    mock_service.assert_called_once_with(
+        token="dummy",
+        group_id=None,
+        should_include_unfollowed=False,
+        skip=0,
+        limit=20,
+        language=None,
+        timezone_name=None,
+    )
+    body = response.json()
+    assert body["total"] == 1
+    assert body["include_unfollowed"] is False
+    assert body["practices"][0]["type"] == "accumulator"
+    assert body["practices"][0]["is_joined"] is True
+    assert body["practices"][0]["group_name"] == "Test Group"
+
+
+def test_get_group_practices_feed_passes_filters():
+    group_id = uuid4()
+    feed_response = GroupPracticesFeedResponse(
+        practices=[], skip=5, limit=10, total=0, include_unfollowed=True
+    )
+    with patch(
+        "pecha_api.plans.groups.groups_views.get_group_practices_feed",
+        return_value=feed_response,
+    ) as mock_service:
+        response = client.get(
+            f"/author/groups/practices?group_id={group_id}&include_unfollowed=true&skip=5&limit=10&language=en",
+            headers={"Authorization": "Bearer dummy", "X-Timezone": "Asia/Kolkata"},
+        )
+    assert response.status_code == status.HTTP_200_OK
+    mock_service.assert_called_once_with(
+        token="dummy",
+        group_id=group_id,
+        should_include_unfollowed=True,
+        skip=5,
+        limit=10,
+        language="en",
+        timezone_name="Asia/Kolkata",
+    )
+
+
+def test_get_group_practices_feed_requires_auth():
+    response = client.get("/author/groups/practices")
+    assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
 def test_follow_and_unfollow_group():

--- a/tests/plans/plan_auth/test_google_auth_services.py
+++ b/tests/plans/plan_auth/test_google_auth_services.py
@@ -51,7 +51,9 @@ def test_exchange_creates_verified_inactive_google_profile(
     ), patch(
         "pecha_api.plans.auth.plan_auth_services.save_google_author",
         return_value=saved_author,
-    ) as save:
+    ) as save, patch(
+        "pecha_api.plans.auth.plan_auth_services.notify_pending_group_invites",
+    ) as mock_notify:
         response = exchange_google_token(
             GoogleExchangeRequest(
                 auth0_token="auth0-token",
@@ -71,6 +73,7 @@ def test_exchange_creates_verified_inactive_google_profile(
     assert response.status == AuthorStatus.INACTIVE
     assert response.auth is None
     assert response.email == "ada@example.com"
+    mock_notify.assert_called_once_with(saved_author)
 
 
 @patch("pecha_api.plans.auth.plan_auth_services.SessionLocal")
@@ -152,7 +155,9 @@ def test_exchange_existing_active_author_returns_tokens(
     with patch(
         "pecha_api.plans.auth.plan_auth_services.find_author_by_email",
         return_value=author,
-    ):
+    ), patch(
+        "pecha_api.plans.auth.plan_auth_services.notify_pending_group_invites",
+    ) as mock_notify:
         response = exchange_google_token(
             GoogleExchangeRequest(auth0_token="auth0-token")
         )
@@ -160,3 +165,33 @@ def test_exchange_existing_active_author_returns_tokens(
     assert response.status == AuthorStatus.ACTIVE
     assert response.auth is not None
     assert response.auth.access_token == "access"
+    mock_notify.assert_not_called()
+
+
+@patch("pecha_api.plans.auth.plan_auth_services.SessionLocal")
+@patch("pecha_api.plans.auth.plan_auth_services.verify_auth0_google_token")
+def test_exchange_first_verification_of_existing_author_notifies_pending_invites(
+    verify_google,
+    session_local,
+):
+    verify_google.return_value = Auth0GoogleIdentity(
+        subject="google-oauth2|123",
+        email="ada@example.com",
+    )
+    _session(session_local)
+    author = _author(is_active=False, is_verified=False)
+
+    with patch(
+        "pecha_api.plans.auth.plan_auth_services.find_author_by_email",
+        return_value=author,
+    ), patch(
+        "pecha_api.plans.auth.plan_auth_services.update_author",
+        return_value=author,
+    ) as mock_update, patch(
+        "pecha_api.plans.auth.plan_auth_services.notify_pending_group_invites",
+    ) as mock_notify:
+        exchange_google_token(GoogleExchangeRequest(auth0_token="auth0-token"))
+
+    assert author.is_verified is True
+    mock_update.assert_called_once()
+    mock_notify.assert_called_once_with(author)

--- a/tests/plans/plan_auth/test_phone_auth_services.py
+++ b/tests/plans/plan_auth/test_phone_auth_services.py
@@ -56,7 +56,9 @@ def test_exchange_creates_verified_inactive_phone_profile(
     ), patch(
         "pecha_api.plans.auth.plan_auth_services.save_phone_author",
         return_value=saved_author,
-    ) as save:
+    ) as save, patch(
+        "pecha_api.plans.auth.plan_auth_services.notify_pending_group_invites",
+    ) as mock_notify:
         response = exchange_phone_token(
             PhoneExchangeRequest(
                 auth0_token="auth0-token",
@@ -76,6 +78,7 @@ def test_exchange_creates_verified_inactive_phone_profile(
     assert author_arg.is_active is False
     assert response.status == AuthorStatus.INACTIVE
     assert response.auth is None
+    mock_notify.assert_called_once_with(saved_author)
 
 
 def test_exchange_new_profile_requires_both_names():

--- a/tests/plans/plan_auth/test_plan_auth_services.py
+++ b/tests/plans/plan_auth/test_plan_auth_services.py
@@ -190,7 +190,8 @@ def test_verify_author_email_success():
         patch("pecha_api.plans.auth.plan_auth_services.jwt.decode", return_value=payload) as mock_decode, \
         patch("pecha_api.plans.auth.plan_auth_services.SessionLocal") as mock_session_local, \
         patch("pecha_api.plans.auth.plan_auth_services.get_author_by_email") as mock_get_author_by_email, \
-        patch("pecha_api.plans.auth.plan_auth_services.update_author") as mock_update_author:
+        patch("pecha_api.plans.auth.plan_auth_services.update_author") as mock_update_author, \
+        patch("pecha_api.plans.auth.plan_auth_services.notify_pending_group_invites") as mock_notify:
         _mock_session_local(mock_session_local)
         mock_get_author_by_email.return_value = author
 
@@ -199,6 +200,7 @@ def test_verify_author_email_success():
         mock_decode.assert_called_once()
         mock_get_author_by_email.assert_called_once_with(db=ANY, email=payload["email"])
         mock_update_author.assert_called_once_with(db=ANY, author=author)
+        mock_notify.assert_called_once_with(author)
         assert response.email == "john.doe@example.com"
         assert response.status == AuthorStatus.INACTIVE
         assert response.message == EMAIL_VERIFIED_SUCCESS
@@ -219,13 +221,15 @@ def test_verify_author_email_already_verified():
         patch("pecha_api.plans.auth.plan_auth_services.jwt.decode", return_value=payload), \
         patch("pecha_api.plans.auth.plan_auth_services.SessionLocal") as mock_session_local, \
         patch("pecha_api.plans.auth.plan_auth_services.get_author_by_email") as mock_get_author_by_email, \
-        patch("pecha_api.plans.auth.plan_auth_services.update_author") as mock_update_author:
+        patch("pecha_api.plans.auth.plan_auth_services.update_author") as mock_update_author, \
+        patch("pecha_api.plans.auth.plan_auth_services.notify_pending_group_invites") as mock_notify:
         _mock_session_local(mock_session_local)
         mock_get_author_by_email.return_value = author
 
         response: AuthorVerificationResponse  = verify_author_email(token)
 
         mock_update_author.assert_not_called()
+        mock_notify.assert_not_called()
         assert response.email == "john.doe@example.com"
         assert response.status == AuthorStatus.INACTIVE
         assert response.message == EMAIL_ALREADY_VERIFIED


### PR DESCRIPTION
- Introduced `get_group_practices_feed` to merge and sort practices (series, group accumulators, and standalone plans) across user-joined public groups.
- Added new response models: `GroupPracticeFeedItemDTO` and `GroupPracticesFeedResponse` to structure the feed data.
- Implemented endpoint `/author/groups/practices` to retrieve the practices feed with optional filters for group ID and unfollowed groups.
- Enhanced tests to validate the new feed functionality and ensure proper merging and sorting of practices.

This update improves the user experience by providing a consolidated view of practices related to groups, enhancing engagement and accessibility of content.